### PR TITLE
bug fixes

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -2582,6 +2582,7 @@ def serve_model(
     transformer_parameters: dict = None,
     protocol_version: str = None,
     model_format: str = None,
+    namespace: str = None,
 ):
     """
     Resolve a model and create a KServe InferenceService.
@@ -2599,6 +2600,7 @@ def serve_model(
         transformer_parameters (dict, optional): Parameters for the transformer.
         protocol_version (str, optional): Protocol version for the model server (e.g., "v1", "v2").
         model_format (str, optional): Model format (e.g., "mlflow", "sklearn").
+        namespace (str, optional): Kubernetes namespace to deploy the InferenceService.
 
     Examples:
         # Serve using run ID (with optional artifact path)
@@ -2683,6 +2685,7 @@ def serve_model(
             transformer_parameters=transformer_parameters,
             protocol_version=protocol_version,
             model_format=model_format,
+            namespace=namespace,
         )
 
     except Exception as e:

--- a/cogflow/plugins/kubeflowplugin.py
+++ b/cogflow/plugins/kubeflowplugin.py
@@ -662,7 +662,7 @@ class KubeflowPlugin:
 
         try:
             if namespace is None:
-                utils.get_default_target_namespace()
+                namespace = utils.get_default_target_namespace()
             KServeClient().delete(isvc_name, namespace)
             print("Inference Service has been deleted successfully.")
         except Exception as exp:

--- a/cogflow/plugins/kubeflowplugin.py
+++ b/cogflow/plugins/kubeflowplugin.py
@@ -646,12 +646,13 @@ class KubeflowPlugin:
         return model_info
 
     @staticmethod
-    def delete_served_model(isvc_name: str):
+    def delete_served_model(isvc_name: str, namespace: str = None):
         """
         Delete a deployed model by its ISVC name.
 
         Args:
             isvc_name (str): Name of the deployed model.
+            namespace (str, optional): Namespace where the model is deployed.
 
         Returns:
             None
@@ -660,7 +661,9 @@ class KubeflowPlugin:
         PluginManager().verify_activation(KubeflowPlugin().section)
 
         try:
-            KServeClient().delete(isvc_name)
+            if namespace is None:
+                utils.get_default_target_namespace()
+            KServeClient().delete(isvc_name, namespace)
             print("Inference Service has been deleted successfully.")
         except Exception as exp:
             raise Exception(f"Failed to delete Inference Service: {exp}")
@@ -1547,6 +1550,7 @@ class KubeflowPlugin:
         transformer_parameters: dict = None,
         protocol_version: str = None,
         model_format: str = None,
+        namespace: str = None,
     ):
         """
         Create a KServe InferenceService with optional transformer.
@@ -1565,10 +1569,12 @@ class KubeflowPlugin:
             Required if transformer_image is provided.
             protocol_version (str, optional): Protocol version for the model server (e.g., "v1", "v2").
             model_format (str, optional): Model format, e.g., "tensorflow", "pytorch", "sklearn", etc.
+            namespace (str, optional): Namespace to deploy the InferenceService.
         """
         PluginManager().verify_activation(KubeflowPlugin().section)
 
-        namespace = utils.get_default_target_namespace()
+        if namespace is None:
+            namespace = utils.get_default_target_namespace()
         if isvc_name is None:
             now = datetime.now()
             date = now.strftime("%d%M")


### PR DESCRIPTION
This pull request adds support for specifying a Kubernetes namespace when serving or deleting models using KServe in the `cogflow` package. The changes ensure that users can deploy or remove inference services in a specific namespace, falling back to a default if not provided.

**Namespace support for serving and deleting models:**

* Added an optional `namespace` parameter to the `serve_model` function in both `cogflow/__init__.py` and `cogflow/plugins/kubeflowplugin.py`, allowing users to specify the Kubernetes namespace for model deployment. 
* Updated function docstrings to document the new `namespace` parameter for clarity and user guidance. 
* Modified the logic in `serve_model` to use the provided namespace, or fall back to a default namespace if none is specified. 

**Namespace support for model deletion:**

* Updated the `delete_served_model` method in `cogflow/plugins/kubeflowplugin.py` to accept an optional `namespace` parameter, and pass it to `KServeClient().delete`. If not specified, the default namespace is used. 