### PR TITLE
1.11.16

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -76,6 +76,7 @@ register_dataset: Register a dataset.
 import inspect
 import json
 import os
+from datetime import datetime
 from typing import Callable, Union, Any, List, Optional, Dict, Mapping
 import time
 from uuid import UUID
@@ -863,7 +864,9 @@ def log_model(
                 or active_run.data.tags.get("mlflow.runName")
             ),
             "model_version": int(model_details.get("model_version") or 0),
-            "register_date": active_run.info.start_time,
+            "register_date": datetime.fromtimestamp(
+                active_run.info.start_time / 1000
+            ).isoformat(),
             "type": model_type,
             "description": str(
                 active_run.data.tags.get("mlflow.note.content") or "log_model"

--- a/docker_image_variants/fl/Dockerfile
+++ b/docker_image_variants/fl/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install specific version of cogflow
 
-RUN pip3 install --ignore-installed cogflow==1.11.14
+RUN pip3 install --ignore-installed cogflow==1.11.16
 
 # Install additional Python packages
 RUN pip3 install \

--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install specific version of cogflow
 
-RUN pip3 install --ignore-installed cogflow==1.11.15
+RUN pip3 install --ignore-installed cogflow==1.11.16
 
 # Install additional Python packages (shap, xgboost)
 RUN pip3 install --ignore-requires-python shap xgboost

--- a/docker_image_variants/lite/Dockerfile
+++ b/docker_image_variants/lite/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10-slim
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install specific version of cogflow
-RUN pip3 install --ignore-installed cogflow==1.11.14
+RUN pip3 install --ignore-installed cogflow==1.11.16
 
 # Verify the installation of cogflow
 RUN python3 -c 'import cogflow'

--- a/docker_image_variants/tensor/Dockerfile
+++ b/docker_image_variants/tensor/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install specific version of cogflow
 
-RUN pip3 install --ignore-installed cogflow==1.11.14
+RUN pip3 install --ignore-installed cogflow==1.11.16
 
 # Install additional Python packages
 RUN pip3 install \

--- a/docker_image_variants/torch/Dockerfile
+++ b/docker_image_variants/torch/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 # Install specific version of cogflow
 
-RUN pip3 install --ignore-installed cogflow==1.11.14
+RUN pip3 install --ignore-installed cogflow==1.11.16
 
 # Install additional Python packages
 RUN pip3 install \

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open("LICENSE.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="cogflow",
-    version="1.11.15",
+    version="1.11.16",
     author="Sai_kireeti",
     author_email="sai.kireeti@hiro-microdatacenters.nl",
     description="COG modules",


### PR DESCRIPTION
This pull request updates the `cogflow` package to version `1.11.16` across the codebase and Docker image variants, and improves the formatting of the `register_date` field in the model logging function for better readability and consistency.

**Version upgrades:**

* Updated the `cogflow` package version to `1.11.16` in `setup.py` and all Dockerfiles (`fl`, `lite`, `tensor`, `torch`, `latest`) to ensure consistency and access to the latest features and fixes. 

**Model logging improvements:**

* Changed the `register_date` field in the `log_model` function (`cogflow/__init__.py`) to use ISO 8601 formatted datetime instead of a raw timestamp, improving clarity and interoperability.
* Added import of `datetime` in `cogflow/__init__.py` to support the new date formatting.