### PR TITLE
2.0.0b1

### DIFF
--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -547,9 +547,9 @@ class ServingManager:
 
         # --- Base URLs ---
         served_model_url = (
-            status_dict.get("url")
-            or status_dict.get("address", {}).get("url")
+            status_dict.get("address", {}).get("url")
             or status_dict.get("components", {}).get("predictor", {}).get("url")
+            or status_dict.get("url")
             or status_dict.get("components", {}).get("transformer", {}).get("url")
         )
 


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for determining the `served_model_url` in the `_process_isvc` function. The order in which the code checks for possible URLs in the `status_dict` has been changed to prioritize the `address.url` over the top-level `url`.

- Changed the priority order for selecting `served_model_url` in `_process_isvc` to check `address.url` before the top-level `url`, improving consistency with expected data structures.