### PR TITLE
Release cogflow v2.0.1b1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - 'release/**'
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build dependencies
+        run: pip install --upgrade pip build pytest pytest-mock
+
+      - name: Install package
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/
+
+      - name: Build package
+        run: python -m build
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(python -c "import cogflow; print(cogflow.__version__)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Built version: $VERSION"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cogflow-${{ steps.version.outputs.version }}
+          path: dist/
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          prerelease: ${{ contains(steps.version.outputs.version, 'b') || contains(steps.version.outputs.version, 'rc') }}
+          generate_release_notes: true

--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.0beta1"
+__version__ = "2.0.1b1"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -29,9 +29,14 @@ from ..utils.exceptions import (
     CogflowServingError,
 )
 from ..utils.logging import get_logger
-from .serving import ServingManager
 
 logger = get_logger(__name__)
+
+
+def _get_serving_manager_class():
+    """Lazy import to avoid circular dependency with serving.py."""
+    from .serving import ServingManager
+    return ServingManager
 
 # ---------------------------------------------------------------------
 # Global cache: Ensure async K8s config is only loaded once
@@ -61,15 +66,25 @@ class AsyncServingManager:
     _validate_canary, etc.) but uses kubernetes_asyncio for all API calls.
     """
 
-    GROUP = ServingManager.GROUP
-    VERSION = ServingManager.VERSION
-    PLURAL = ServingManager.PLURAL
+    GROUP = "serving.kserve.io"
+    VERSION = "v1beta1"
+    PLURAL = "inferenceservices"
 
-    # Reuse static methods from sync version
-    _validate_canary = ServingManager._validate_canary
-    _process_isvc = ServingManager._process_isvc
-    _get_model_helpers = ServingManager._get_model_helpers
-    _get_dataset_manager = ServingManager._get_dataset_manager
+    @staticmethod
+    def _validate_canary(*args, **kwargs):
+        return _get_serving_manager_class()._validate_canary(*args, **kwargs)
+
+    @staticmethod
+    def _process_isvc(*args, **kwargs):
+        return _get_serving_manager_class()._process_isvc(*args, **kwargs)
+
+    @staticmethod
+    def _get_model_helpers():
+        return _get_serving_manager_class()._get_model_helpers()
+
+    @staticmethod
+    def _get_dataset_manager():
+        return _get_serving_manager_class()._get_dataset_manager()
 
     def __init__(self):
         """Initialize async Kubernetes client."""

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -47,7 +47,7 @@ async def _ensure_async_k8s_config_loaded():
 
     try:
         async_config.load_incluster_config()
-    except async_config.ConfigException:
+    except async_config.config_exception.ConfigException:
         await async_config.load_kube_config()
 
     _ASYNC_K8S_CONFIG_LOADED = True

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -238,33 +238,40 @@ class AsyncServingManager:
         api = await self._get_api()
 
         # Build model spec
-        model_spec = {"storageUri": model_uri}
+        model_spec: Dict[str, Any] = {"storageUri": model_uri}
         if model_format:
             model_spec["modelFormat"] = {"name": model_format}
         if protocol_version:
             model_spec["protocolVersion"] = protocol_version
 
-        predictor = {"model": model_spec}
+        predictor_spec = {
+            "serviceAccountName": "kserve-controller-s3",
+            "minReplicas": 1,
+            "model": model_spec,
+        }
 
-        # Add transformer if image provided
-        if transformer_image:
-            transformer_container = {
-                "name": "transformer",
-                "image": transformer_image,
-            }
-            if transformer_env:
-                transformer_container["env"] = [
-                    {"name": k, "value": str(v)} for k, v in transformer_env.items()
+        spec: Dict[str, Any] = {"predictor": predictor_spec}
+
+        # Transformer (top-level spec field, only when env is provided)
+        if transformer_env:
+            env_list = [
+                {"name": k, "value": str(v)} for k, v in transformer_env.items()
+            ]
+            spec["transformer"] = {
+                "containers": [
+                    {
+                        "name": f"{name}-transformer",
+                        "image": transformer_image,
+                        "env": env_list,
+                    }
                 ]
-            predictor["transformer"] = {"containers": [transformer_container]}
+            }
 
         metadata = async_client.V1ObjectMeta(
             name=name,
             namespace=namespace,
             annotations=annot or {},
         )
-
-        spec = {"predictor": predictor}
 
         body = {
             "apiVersion": f"{self.GROUP}/{self.VERSION}",
@@ -391,18 +398,9 @@ class AsyncServingManager:
         namespace = namespace or common.get_namespace()
 
         try:
-            # Fetch existing ISVC
-            try:
-                isvc = await self.get_isvc(isvc_name, namespace)
-            except CogflowConnectionError:
-                raise
-            except ApiException as e:
-                if e.status == 404:
-                    CogflowErrorHandler.log_and_raise(
-                        f"InferenceService '{isvc_name}' not found in namespace '{namespace}'.",
-                        raise_as=CogflowServingError,
-                    )
-                raise
+            # Fetch existing ISVC. get_isvc() already wraps ApiException
+            # (including 404) into CogflowConnectionError, so we re-raise here.
+            isvc = await self.get_isvc(isvc_name, namespace)
 
             # Case 1: Traffic-only update
             if canary_traffic_percent is not None and not (
@@ -468,13 +466,15 @@ class AsyncServingManager:
                 "spec": {"predictor": predictor_patch},
             }
 
-            # Transformer update
+            # Transformer update (top-level spec field, aligned with sync impl)
             if transformer_env:
-                env_list = [{"name": k, "value": str(v)} for k, v in transformer_env.items()]
-                patch_body["spec"]["predictor"]["transformer"] = {
+                env_list = [
+                    {"name": k, "value": str(v)} for k, v in transformer_env.items()
+                ]
+                patch_body["spec"]["transformer"] = {
                     "containers": [
                         {
-                            "name": "transformer",
+                            "name": f"{isvc_name}-transformer",
                             "image": transformer_image or cog_config.TRANSFORMER_BASE_IMAGE,
                             "env": env_list,
                         }
@@ -486,7 +486,13 @@ class AsyncServingManager:
             logger.info("%s", msg)
             return msg
 
-        except (CogflowValidationError, CogflowModelError, CogflowDatasetError, CogflowServingError):
+        except (
+            CogflowValidationError,
+            CogflowModelError,
+            CogflowDatasetError,
+            CogflowServingError,
+            CogflowConnectionError,
+        ):
             raise
         except Exception as e:
             CogflowErrorHandler.handle_exception(

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -1,0 +1,546 @@
+"""
+CogFlow - Async Serving Manager (Kubernetes-native)
+----------------------------------------------------
+
+Async version of ServingManager for use in async frameworks (FastAPI, etc.).
+Uses kubernetes_asyncio instead of kubernetes for non-blocking I/O.
+
+All public methods mirror ServingManager but are async.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime
+from typing import Optional, Dict, Any, List
+
+from kubernetes_asyncio import client as async_client, config as async_config
+from kubernetes_asyncio.client.exceptions import ApiException
+
+from ..utils import common
+from ..config import config as cog_config
+from ..utils.exceptions import (
+    CogflowErrorHandler,
+    CogflowValidationError,
+    CogflowModelError,
+    CogflowDatasetError,
+    CogflowConnectionError,
+    CogflowServingError,
+)
+from ..utils.logging import get_logger
+from .serving import ServingManager
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------
+# Global cache: Ensure async K8s config is only loaded once
+# ---------------------------------------------------------------------
+_ASYNC_K8S_CONFIG_LOADED = False
+
+
+async def _ensure_async_k8s_config_loaded():
+    """Load Kubernetes config for async client only once."""
+    global _ASYNC_K8S_CONFIG_LOADED
+    if _ASYNC_K8S_CONFIG_LOADED:
+        return
+
+    try:
+        async_config.load_incluster_config()
+    except async_config.ConfigException:
+        await async_config.load_kube_config()
+
+    _ASYNC_K8S_CONFIG_LOADED = True
+
+
+class AsyncServingManager:
+    """
+    Async version of ServingManager for non-blocking K8s operations.
+
+    Shares static/pure methods with ServingManager (_process_isvc,
+    _validate_canary, etc.) but uses kubernetes_asyncio for all API calls.
+    """
+
+    GROUP = ServingManager.GROUP
+    VERSION = ServingManager.VERSION
+    PLURAL = ServingManager.PLURAL
+
+    # Reuse static methods from sync version
+    _validate_canary = ServingManager._validate_canary
+    _process_isvc = ServingManager._process_isvc
+    _get_model_helpers = ServingManager._get_model_helpers
+    _get_dataset_manager = ServingManager._get_dataset_manager
+
+    def __init__(self):
+        """Initialize async Kubernetes client."""
+        self._api = None
+
+    async def _get_api(self):
+        """Lazy-initialize the async K8s API client."""
+        if self._api is None:
+            await _ensure_async_k8s_config_loaded()
+            self._api = async_client.CustomObjectsApi()
+        return self._api
+
+    def _get_transformer_env(
+        self,
+        dataset_id: Optional[str],
+        transformer_image: Optional[str],
+        transformer_parameters: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Resolve transformer parameters (sync — no K8s I/O)."""
+        # Reuse sync logic — this method does no K8s I/O
+        if transformer_parameters:
+            return transformer_parameters
+        if not dataset_id:
+            return {}
+        try:
+            dataset_mgr = self._get_dataset_manager()
+            dataset_id_norm = common.normalize_uuid(dataset_id)
+            dataset = dataset_mgr.get_dataset(dataset_id_norm)
+            if dataset.get("data_source_type") == 20:
+                if not transformer_image:
+                    CogflowErrorHandler.log_and_raise(
+                        "Dataset is Prometheus type but no transformer_image was provided.",
+                        raise_as=CogflowValidationError,
+                    )
+                prom = dataset_mgr.get_prometheus_dataset(dataset_id_norm)
+                return {
+                    "PROMETHEUS_URL": prom.get("connection_type", {}).get("prometheus_url"),
+                    "PROMETHEUS_METRICS": prom.get("metric_list", {}).get("METRIC_FEATURES"),
+                }
+            return {}
+        except (CogflowValidationError, CogflowDatasetError):
+            raise
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context="Resolve transformer parameters from dataset",
+                raise_as=CogflowDatasetError,
+                re_raise=True,
+            )
+
+    # -----------------------------------------------------------------
+    # CRUD Operations (async)
+    # -----------------------------------------------------------------
+
+    async def get_isvc(self, name: str, namespace: Optional[str] = None) -> dict:
+        """Retrieve an InferenceService CRD by name (async)."""
+        namespace = namespace or common.get_namespace()
+        api = await self._get_api()
+        try:
+            return await api.get_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                name=name,
+            )
+        except ApiException as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Get InferenceService '{name}' in namespace '{namespace}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+    async def delete_isvc(self, name: str, namespace: Optional[str] = None) -> bool:
+        """Delete an InferenceService CRD (async)."""
+        namespace = namespace or common.get_namespace()
+        api = await self._get_api()
+        try:
+            await api.delete_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                name=name,
+            )
+            logger.info("InferenceService '%s' deleted from namespace '%s'.", name, namespace)
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                logger.warning("InferenceService '%s' not found in '%s'.", name, namespace)
+                return False
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Delete InferenceService '{name}' in namespace '{namespace}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+    async def update_isvc(self, name: str, patch_body: dict, namespace: Optional[str] = None) -> dict:
+        """Patch an existing InferenceService CRD (async)."""
+        namespace = namespace or common.get_namespace()
+        api = await self._get_api()
+        try:
+            return await api.patch_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                name=name,
+                body=patch_body,
+            )
+        except ApiException as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Patch InferenceService '{name}' in namespace '{namespace}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+    async def restart_isvc(self, name: str, namespace: Optional[str] = None) -> bool:
+        """Restart ISVC by scaling to 0 then back to 1 (async)."""
+        namespace = namespace or common.get_namespace()
+        try:
+            await self.update_isvc(name, {"spec": {"predictor": {"minReplicas": 0}}}, namespace)
+            await asyncio.sleep(1)
+            await self.update_isvc(name, {"spec": {"predictor": {"minReplicas": 1}}}, namespace)
+            logger.info("InferenceService '%s' restart patches applied.", name)
+            return True
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Restart InferenceService '{name}' in namespace '{namespace}'",
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
+    async def create_isvc(
+        self,
+        name: str,
+        model_uri: str,
+        namespace: Optional[str] = None,
+        model_format: str = None,
+        protocol_version: str = None,
+        annot: dict = None,
+        transformer_image: str = cog_config.TRANSFORMER_BASE_IMAGE,
+        transformer_env: dict = None,
+    ) -> dict:
+        """Create a new InferenceService CRD (async)."""
+        namespace = namespace or common.get_namespace()
+        api = await self._get_api()
+
+        # Build model spec
+        model_spec = {"storageUri": model_uri}
+        if model_format:
+            model_spec["modelFormat"] = {"name": model_format}
+        if protocol_version:
+            model_spec["protocolVersion"] = protocol_version
+
+        predictor = {"model": model_spec}
+
+        # Add transformer if image provided
+        if transformer_image:
+            transformer_container = {
+                "name": "transformer",
+                "image": transformer_image,
+            }
+            if transformer_env:
+                transformer_container["env"] = [
+                    {"name": k, "value": str(v)} for k, v in transformer_env.items()
+                ]
+            predictor["transformer"] = {"containers": [transformer_container]}
+
+        metadata = async_client.V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            annotations=annot or {},
+        )
+
+        spec = {"predictor": predictor}
+
+        body = {
+            "apiVersion": f"{self.GROUP}/{self.VERSION}",
+            "kind": "InferenceService",
+            "metadata": metadata.to_dict(),
+            "spec": spec,
+        }
+
+        try:
+            created = await api.create_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                body=body,
+            )
+            logger.info("InferenceService '%s' created in namespace '%s'.", name, namespace)
+            return created
+        except ApiException as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Create InferenceService '{name}' in namespace '{namespace}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+    # -----------------------------------------------------------------
+    # HIGH-LEVEL: DEPLOY MODEL (async)
+    # -----------------------------------------------------------------
+
+    async def deploy_model(
+        self,
+        model_id: str = None,
+        isvc_name: Optional[str] = None,
+        artifact_path: str = None,
+        model_name: str = None,
+        model_version: str = None,
+        dataset_id: str = None,
+        transformer_image: str = cog_config.TRANSFORMER_BASE_IMAGE,
+        transformer_parameters: Dict[str, Any] = None,
+        protocol_version: str = None,
+        model_format: str = None,
+        namespace: Optional[str] = None,
+        model_type: Optional[str] = None,
+    ):
+        """Deploy a model as an InferenceService (async)."""
+        namespace = namespace or common.get_namespace()
+
+        try:
+            detect_model_format, get_model_details = self._get_model_helpers()
+            model_details = get_model_details(
+                model_id=model_id,
+                artifact_path=artifact_path,
+                model_name=model_name,
+                model_version=model_version,
+            )
+            model_uri = model_details["model_uri"]
+
+            transformer_env = self._get_transformer_env(
+                dataset_id, transformer_image, transformer_parameters
+            )
+
+            model_format = model_format or detect_model_format(model_uri=model_uri)
+
+            if not isvc_name:
+                isvc_name = f"model-{common.normalize_uuid(model_details['model_id'])}"
+
+            annot = {
+                "model_id": model_details["model_id"],
+                "model_name": model_details["model_name"],
+                "model_version": model_details["model_version"],
+            }
+            if dataset_id:
+                annot["dataset_id"] = common.normalize_uuid(dataset_id)
+            if model_type:
+                annot["model_type"] = model_type
+
+            logger.info(
+                "Creating InferenceService '%s' for model_uri=%s in namespace=%s.",
+                isvc_name, model_uri, namespace,
+            )
+
+            return await self.create_isvc(
+                name=isvc_name,
+                model_uri=model_uri,
+                model_format=model_format,
+                protocol_version=protocol_version,
+                transformer_image=transformer_image,
+                transformer_env=transformer_env,
+                annot=annot,
+                namespace=namespace,
+            )
+        except (CogflowValidationError, CogflowModelError, CogflowDatasetError):
+            raise
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context="Serve model via AsyncServingManager",
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
+    # -----------------------------------------------------------------
+    # HIGH-LEVEL: UPDATE MODEL (async)
+    # -----------------------------------------------------------------
+
+    async def update_model(
+        self,
+        isvc_name: str,
+        model_id: Optional[str] = None,
+        artifact_path: Optional[str] = None,
+        model_name: Optional[str] = None,
+        model_version: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        transformer_image: Optional[str] = cog_config.TRANSFORMER_BASE_IMAGE,
+        transformer_parameters: Optional[dict] = None,
+        protocol_version: Optional[str] = None,
+        namespace: Optional[str] = None,
+        model_format: Optional[str] = None,
+        canary_traffic_percent: Optional[int] = None,
+        model_type: Optional[str] = None,
+    ) -> str:
+        """Update an existing InferenceService (async)."""
+        namespace = namespace or common.get_namespace()
+
+        try:
+            # Fetch existing ISVC
+            try:
+                isvc = await self.get_isvc(isvc_name, namespace)
+            except CogflowConnectionError:
+                raise
+            except ApiException as e:
+                if e.status == 404:
+                    CogflowErrorHandler.log_and_raise(
+                        f"InferenceService '{isvc_name}' not found in namespace '{namespace}'.",
+                        raise_as=CogflowServingError,
+                    )
+                raise
+
+            # Case 1: Traffic-only update
+            if canary_traffic_percent is not None and not (
+                model_id or model_name or model_version or artifact_path
+            ):
+                self._validate_canary(isvc, isvc_name, canary_traffic_percent)
+                patch_body = {
+                    "spec": {"predictor": {"canaryTrafficPercent": canary_traffic_percent}}
+                }
+                await self.update_isvc(isvc_name, patch_body, namespace)
+                msg = f"Updated traffic to {canary_traffic_percent}% for '{isvc_name}'."
+                logger.info("%s", msg)
+                return msg
+
+            # Case 2: Full model rollout/update
+            detect_model_format, get_model_details = self._get_model_helpers()
+            model_details = get_model_details(
+                model_id=model_id,
+                artifact_path=artifact_path,
+                model_name=model_name,
+                model_version=model_version,
+            )
+
+            transformer_env = self._get_transformer_env(
+                dataset_id, transformer_image, transformer_parameters
+            )
+
+            model_uri = model_details["model_uri"]
+            model_format = model_format or detect_model_format(model_uri=model_uri)
+
+            annot = {
+                "model_id": model_details["model_id"],
+                "model_name": model_details["model_name"],
+                "model_version": model_details["model_version"],
+            }
+            if dataset_id:
+                annot["dataset_id"] = common.normalize_uuid(dataset_id)
+            if model_type:
+                annot["model_type"] = model_type
+
+            # Build model patch
+            model_patch: Dict[str, Any] = {}
+            if model_uri:
+                model_patch["storageUri"] = model_uri
+            if model_format:
+                model_patch["modelFormat"] = {"name": model_format}
+            if protocol_version:
+                model_patch["protocolVersion"] = protocol_version
+
+            predictor_patch: Dict[str, Any] = {"model": model_patch}
+
+            if canary_traffic_percent is not None:
+                if not 0 <= canary_traffic_percent <= 100:
+                    CogflowErrorHandler.log_and_raise(
+                        f"Invalid canary_traffic_percent={canary_traffic_percent}.",
+                        raise_as=CogflowValidationError,
+                    )
+                predictor_patch["canary"] = {"model": model_patch}
+                predictor_patch["canaryTrafficPercent"] = canary_traffic_percent
+
+            patch_body: Dict[str, Any] = {
+                "metadata": {"annotations": annot},
+                "spec": {"predictor": predictor_patch},
+            }
+
+            # Transformer update
+            if transformer_env:
+                env_list = [{"name": k, "value": str(v)} for k, v in transformer_env.items()]
+                patch_body["spec"]["predictor"]["transformer"] = {
+                    "containers": [
+                        {
+                            "name": "transformer",
+                            "image": transformer_image or cog_config.TRANSFORMER_BASE_IMAGE,
+                            "env": env_list,
+                        }
+                    ]
+                }
+
+            await self.update_isvc(isvc_name, patch_body, namespace)
+            msg = f"Updated InferenceService '{isvc_name}' in namespace '{namespace}'."
+            logger.info("%s", msg)
+            return msg
+
+        except (CogflowValidationError, CogflowModelError, CogflowDatasetError, CogflowServingError):
+            raise
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Update model in '{isvc_name}'",
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
+    # -----------------------------------------------------------------
+    # LIST / INSPECT (async)
+    # -----------------------------------------------------------------
+
+    async def list_models(
+        self,
+        namespace: Optional[str] = None,
+        isvc_name: Optional[str] = None,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """List served models / get a specific InferenceService (async)."""
+        ns = namespace or common.get_namespace()
+        api = await self._get_api()
+
+        try:
+            if isvc_name:
+                isvc = await self.get_isvc(isvc_name, ns)
+                return [self._process_isvc(isvc)] if isvc else None
+
+            result = await api.list_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=ns,
+                plural=self.PLURAL,
+            )
+
+            items = result.get("items", [])
+            if not items:
+                return []
+
+            return [self._process_isvc(isvc) for isvc in items]
+
+        except CogflowConnectionError:
+            raise
+        except ApiException as e:
+            if e.status == 404:
+                logger.info("No InferenceServices found in namespace '%s'.", ns)
+                return None
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"List InferenceServices in namespace '{ns}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context="list_models via AsyncServingManager",
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
+
+# Create singleton and expose async methods at module level
+_async_serving = AsyncServingManager()
+
+async_deploy_model = _async_serving.deploy_model
+async_update_model = _async_serving.update_model
+async_delete_isvc = _async_serving.delete_isvc
+async_list_models = _async_serving.list_models
+async_get_isvc = _async_serving.get_isvc
+async_update_isvc = _async_serving.update_isvc
+async_restart_isvc = _async_serving.restart_isvc
+async_create_isvc = _async_serving.create_isvc

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -1359,6 +1359,111 @@ class ModelManager:
                 re_raise=True,
             )
 
+    def get_run(self, run_id: str):
+        """
+        Fetch an MLflow run by its ID.
+
+        Args:
+            run_id (str): The run identifier (UUID, with or without hyphens).
+
+        Returns:
+            mlflow.entities.Run: The MLflow Run object containing info, data
+            (params, metrics, tags), and artifact URI.
+
+        Raises:
+            CogflowRunError: If the run cannot be found or retrieval fails.
+
+        Example:
+            >>> from cogflow import models
+            >>> run = models.get_run("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+            >>> print(run.info.artifact_uri)
+            >>> print(run.data.params)
+        """
+        self._warn_if_unhealthy("fetching run")
+
+        try:
+            run_id = common.uuid_to_hex(run_id)
+            run = self.mlflow.get_run(run_id)
+            logger.debug("Fetched run %s", run_id)
+            return run
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Get run {run_id}",
+                raise_as=CogflowRunError,
+                re_raise=True,
+            )
+
+    def get_run_artifact_uri(self, run_id: str) -> str:
+        """
+        Get the S3 artifact URI for a specific run.
+
+        Args:
+            run_id (str): The run identifier (UUID, with or without hyphens).
+
+        Returns:
+            str: The artifact URI (e.g., "s3://mlflow/0/abc123/artifacts").
+
+        Raises:
+            CogflowRunError: If the run cannot be found or retrieval fails.
+
+        Example:
+            >>> from cogflow import models
+            >>> uri = models.get_run_artifact_uri("a1b2c3d4e5f67890abcdef1234567890")
+            >>> print(uri)
+            s3://mlflow/0/a1b2c3d4e5f67890abcdef1234567890/artifacts
+        """
+        run = self.get_run(run_id)
+        return run.info.artifact_uri
+
+    def list_artifacts_grouped(self, run_id: str) -> Dict[str, List[str]]:
+        """
+        List artifacts for a run, grouped by directory.
+
+        Args:
+            run_id (str): The run identifier (UUID, with or without hyphens).
+
+        Returns:
+            Dict[str, List[str]]: A dictionary mapping directory names to lists
+            of filenames. Root-level files use "" as the key.
+
+        Raises:
+            CogflowRunError: If the run cannot be found or retrieval fails.
+
+        Example:
+            >>> from cogflow import models
+            >>> artifacts = models.list_artifacts_grouped("a1b2c3d4e5")
+            >>> print(artifacts)
+            {"": ["README.md"], "model": ["model.pkl", "config.json"]}
+        """
+        self._warn_if_unhealthy("listing artifacts")
+
+        try:
+            run_id = common.uuid_to_hex(run_id)
+            artifacts = self.client.list_artifacts(run_id)
+            grouped: Dict[str, List[str]] = {}
+
+            for artifact in artifacts:
+                if artifact.is_dir:
+                    # List files inside the directory
+                    sub_artifacts = self.client.list_artifacts(run_id, artifact.path)
+                    grouped[artifact.path] = [
+                        a.path.split("/")[-1]
+                        for a in sub_artifacts
+                        if not a.is_dir
+                    ]
+                else:
+                    grouped.setdefault("", []).append(artifact.path)
+
+            return grouped
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"List artifacts for run {run_id}",
+                raise_as=CogflowRunError,
+                re_raise=True,
+            )
+
     def search_runs(
         self,
         experiment_ids: List[str],

--- a/cogflow/core/pipelines/__init__.py
+++ b/cogflow/core/pipelines/__init__.py
@@ -11,6 +11,7 @@ from uuid import UUID
 # Only import submodules — NOT functions
 from . import components
 from . import orchestration
+from . import inspection
 
 # ===========================================================
 # Public API (manually exposed)
@@ -27,6 +28,27 @@ create_fl_pipeline = orchestration.create_fl_pipeline
 create_fl_pipeline_dataspace = orchestration.create_fl_pipeline_dataspace
 create_run_from_pipeline_func = orchestration.create_run_from_pipeline_func
 kfp = orchestration.kfp
+
+# Pipeline inspection (sync)
+list_all_kfp_runs = inspection.list_all_kfp_runs
+list_pipelines_by_name = inspection.list_pipelines_by_name
+get_pipeline_task_sequence = inspection.get_pipeline_task_sequence
+get_pipeline_task_sequence_by_run_id = inspection.get_pipeline_task_sequence_by_run_id
+get_pipeline_task_sequence_by_run_name = inspection.get_pipeline_task_sequence_by_run_name
+get_pipeline_task_sequence_by_pipeline_id = inspection.get_pipeline_task_sequence_by_pipeline_id
+get_task_structure_by_task_id = inspection.get_task_structure_by_task_id
+
+# Pod/K8s inspection (sync)
+get_pod_definition = inspection.get_pod_definition
+get_pod_events = inspection.get_pod_events
+get_pod_logs = inspection.get_pod_logs
+get_inference_service_logs = inspection.get_inference_service_logs
+
+# Pod/K8s inspection (async)
+async_get_pod_definition = inspection.async_get_pod_definition
+async_get_pod_events = inspection.async_get_pod_events
+async_get_pod_logs = inspection.async_get_pod_logs
+async_get_inference_service_logs = inspection.async_get_inference_service_logs
 
 
 # ===========================================================

--- a/cogflow/core/pipelines/inspection.py
+++ b/cogflow/core/pipelines/inspection.py
@@ -1,0 +1,705 @@
+"""
+CogFlow - Pipeline & Pod Inspection
+------------------------------------
+
+Provides pipeline querying (task sequences, runs) and Kubernetes pod
+inspection (logs, events, definitions) functionality.
+
+Replaces the 1.x NotebookPlugin with clean module-level functions.
+Offers both sync and async variants for K8s operations.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from typing import Optional, Any, List, Dict
+
+from ...utils.logging import get_logger
+from ...utils.exceptions import (
+    CogflowErrorHandler,
+    CogflowPipelineError,
+    CogflowConnectionError,
+)
+from ...utils import common
+
+logger = get_logger(__name__)
+
+
+# ================================================================
+# LAZY LOADERS
+# ================================================================
+
+def _load_k8s():
+    """Lazy load sync Kubernetes client."""
+    from kubernetes import client, config
+    common.load_k8s_config()
+    return client
+
+
+def _load_k8s_async():
+    """Lazy load async Kubernetes client."""
+    from kubernetes_asyncio import client, config
+    return client, config
+
+
+def _kfp_client(
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+):
+    """Create a KFP client using the orchestration module."""
+    from . import orchestration
+    return orchestration.client(
+        api_url=api_url,
+        skip_tls_verify=skip_tls_verify,
+        session_cookies=session_cookies,
+        namespace=namespace,
+    )
+
+
+def _convert_datetime(obj):
+    """Recursively convert datetime objects to ISO strings."""
+    if isinstance(obj, dict):
+        return {k: _convert_datetime(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_convert_datetime(i) for i in obj]
+    elif isinstance(obj, datetime):
+        return obj.isoformat()
+    return obj
+
+
+def _parse_run(run) -> dict:
+    """Parse a single KFP run into a dict."""
+    duration = "N/A"
+    if hasattr(run, "finished_at") and hasattr(run, "created_at"):
+        if run.finished_at and run.created_at:
+            try:
+                delta = run.finished_at - run.created_at
+                duration = str(delta).split(".")[0]
+            except Exception:
+                pass
+
+    start_time = None
+    if hasattr(run, "created_at") and run.created_at:
+        try:
+            start_time = run.created_at.isoformat() if isinstance(run.created_at, datetime) else str(run.created_at)
+        except Exception:
+            start_time = "N/A"
+
+    return {
+        "run_name": getattr(run, "name", getattr(run, "display_name", "Unknown")),
+        "run_id": getattr(run, "id", getattr(run, "run_id", "Unknown")),
+        "status": getattr(run, "status", "Unknown"),
+        "duration": duration,
+        "experiment_id": getattr(
+            getattr(run, "resource_references", [None]),
+            "key", {},
+        ).get("id", "") if hasattr(run, "resource_references") else "",
+        "start_time": start_time,
+    }
+
+
+def _traverse_workflow_nodes(nodes: dict, namespace: str) -> tuple:
+    """
+    Parse workflow nodes to extract pipeline name and task structure.
+
+    Returns:
+        tuple: (pipeline_workflow_name, task_structure_dict)
+    """
+    pipeline_workflow_name = None
+    root_node_id = None
+
+    for node_id, node_data in nodes.items():
+        if node_data.get("type") == "DAG":
+            pipeline_workflow_name = node_data.get("displayName")
+            root_node_id = node_id
+            break
+
+    if not root_node_id:
+        raise ValueError("Root DAG node not found in the pipeline run.")
+
+    task_structure = {}
+
+    def traverse(node_id, parent=None):
+        node = nodes[node_id]
+        task_info = {
+            "id": node_id,
+            "namespace": namespace,
+            "podName": node_id,
+            "name": node.get("displayName", ""),
+            "inputs": node.get("inputs", {}).get("parameters", []),
+            "outputs": node.get("outputs", []),
+            "status": node.get("phase", "unknown"),
+            "startedAt": node.get("startedAt", "unknown"),
+            "finishedAt": node.get("finishedAt", "unknown"),
+            "resourcesDuration": node.get("resourcesDuration", {}),
+            "children": [],
+        }
+
+        if parent is None:
+            task_structure[node_id] = task_info
+        else:
+            parent["children"].append(task_info)
+
+        for child_id in node.get("children", []):
+            traverse(child_id, task_info)
+
+    traverse(root_node_id)
+    return pipeline_workflow_name, task_structure
+
+
+# ================================================================
+# PIPELINE QUERY FUNCTIONS (sync)
+# ================================================================
+
+
+def list_all_kfp_runs(
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> List[dict]:
+    """
+    List all KFP pipeline runs, handling pagination.
+
+    Returns:
+        list[dict]: Parsed run entries with run_name, run_id, status, etc.
+    """
+    parsed_runs = []
+    next_page_token = None
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+
+    while True:
+        runs_response = kfp_client_instance.list_runs(page_token=next_page_token)
+        if runs_response and runs_response.runs:
+            for run in runs_response.runs:
+                parsed_runs.append(_parse_run(run))
+        next_page_token = getattr(runs_response, "next_page_token", None)
+        if not next_page_token:
+            break
+
+    return parsed_runs
+
+
+def list_pipelines_by_name(
+    pipeline_name: str,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    List all versions and runs of a pipeline by name.
+
+    Returns:
+        dict: {pipeline_id, versions, runs}
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+
+    # Find pipeline ID by name
+    pipeline_id = _get_pipeline_id_by_name(
+        kfp_client_instance, pipeline_name
+    )
+
+    # Get versions
+    versions_response = kfp_client_instance.list_pipeline_versions(pipeline_id)
+
+    # Get runs for this pipeline
+    run_list = _list_runs_by_pipeline_id(kfp_client_instance, pipeline_id)
+
+    return {
+        "pipeline_id": pipeline_id,
+        "versions": getattr(versions_response, "versions", []),
+        "runs": run_list,
+    }
+
+
+def get_pipeline_task_sequence_by_run_id(
+    run_id: str,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Get pipeline workflow and task sequence for a given run ID.
+
+    Returns:
+        dict: {run_id, pipeline_workflow_name, namespace, task_structure}
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+    run_details = kfp_client_instance.get_run(run_id)
+
+    workflow_graph = json.loads(run_details.pipeline_runtime.workflow_manifest)
+    ns = workflow_graph["metadata"]["namespace"]
+    nodes = workflow_graph["status"]["nodes"]
+
+    pipeline_workflow_name, task_structure = _traverse_workflow_nodes(nodes, ns)
+
+    return {
+        "run_id": run_id,
+        "pipeline_workflow_name": pipeline_workflow_name,
+        "namespace": ns,
+        "task_structure": task_structure,
+    }
+
+
+def get_pipeline_task_sequence_by_run_name(
+    run_name: str,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Get pipeline task sequence by run name (resolves to run_id first).
+
+    Returns:
+        dict: {run_id, pipeline_workflow_name, namespace, task_structure}
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+    run_id = _get_run_id_by_name(kfp_client_instance, run_name)
+    if not run_id:
+        raise ValueError(f"Pipeline run with name '{run_name}' not found.")
+
+    return get_pipeline_task_sequence_by_run_id(
+        run_id, api_url, skip_tls_verify, session_cookies, namespace
+    )
+
+
+def get_pipeline_task_sequence_by_pipeline_id(
+    pipeline_id: str,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Get task sequence for the latest run of a pipeline by pipeline ID.
+
+    Returns:
+        dict: {pipeline_id, pipeline_workflow_name, namespace, task_structure}
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+
+    # Get latest run for this pipeline
+    runs = kfp_client_instance.list_runs(page_size=1)
+    if not runs or not runs.runs:
+        raise ValueError(f"No runs found for pipeline ID '{pipeline_id}'.")
+
+    run_id = runs.runs[0].id
+    result = get_pipeline_task_sequence_by_run_id(
+        run_id, api_url, skip_tls_verify, session_cookies, namespace
+    )
+    result["pipeline_id"] = pipeline_id
+    return result
+
+
+def get_pipeline_task_sequence(
+    pipeline_name: Optional[str] = None,
+    pipeline_workflow_name: Optional[str] = None,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Get pipeline task sequence by pipeline name or workflow name.
+
+    Returns:
+        dict: {pipeline_workflow_name, namespace, task_structure}
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+
+    if pipeline_name:
+        pipeline_id = _get_pipeline_id_by_name(kfp_client_instance, pipeline_name)
+        return get_pipeline_task_sequence_by_pipeline_id(
+            pipeline_id, api_url, skip_tls_verify, session_cookies, namespace
+        )
+
+    if pipeline_workflow_name:
+        # Find run by workflow name
+        run_id = _get_run_id_by_workflow_name(
+            kfp_client_instance, pipeline_workflow_name
+        )
+        if not run_id:
+            raise ValueError(f"No run found for workflow name '{pipeline_workflow_name}'.")
+        return get_pipeline_task_sequence_by_run_id(
+            run_id, api_url, skip_tls_verify, session_cookies, namespace
+        )
+
+    raise ValueError("Either pipeline_name or pipeline_workflow_name must be provided.")
+
+
+def get_task_structure_by_task_id(
+    task_id: str,
+    run_id: str,
+    api_url: Optional[str] = None,
+    skip_tls_verify: bool = False,
+    session_cookies: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> dict:
+    """
+    Get the task structure for a specific task within a run.
+
+    Returns:
+        dict: Task info with id, podName, name, inputs, outputs, status, etc.
+    """
+    kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
+    run_details = kfp_client_instance.get_run(run_id)
+
+    workflow_graph = json.loads(run_details.pipeline_runtime.workflow_manifest)
+    nodes = workflow_graph["status"]["nodes"]
+    ns = workflow_graph["metadata"]["namespace"]
+
+    if task_id not in nodes:
+        raise ValueError(f"Task '{task_id}' not found in run '{run_id}'.")
+
+    node = nodes[task_id]
+    return {
+        "id": task_id,
+        "namespace": ns,
+        "podName": task_id,
+        "name": node.get("displayName", ""),
+        "inputs": node.get("inputs", {}).get("parameters", []),
+        "outputs": node.get("outputs", []),
+        "status": node.get("phase", "unknown"),
+        "startedAt": node.get("startedAt", "unknown"),
+        "finishedAt": node.get("finishedAt", "unknown"),
+        "resourcesDuration": node.get("resourcesDuration", {}),
+    }
+
+
+# ================================================================
+# POD INSPECTION FUNCTIONS (sync)
+# ================================================================
+
+
+def get_pod_definition(podname: str, namespace: Optional[str] = None) -> str:
+    """
+    Fetch pod definition as JSON string.
+
+    Returns:
+        str: JSON-formatted pod definition.
+    """
+    namespace = namespace or common.get_namespace()
+    k8s_client = _load_k8s()
+    v1 = k8s_client.CoreV1Api()
+
+    try:
+        pod = v1.read_namespaced_pod(name=podname, namespace=namespace)
+        pod_dict = _convert_datetime(pod.to_dict())
+        return json.dumps(pod_dict, indent=4)
+    except k8s_client.exceptions.ApiException as e:
+        if e.status == 404:
+            return json.dumps({"error": f"Pod '{podname}' not found in namespace '{namespace}'"})
+        raise
+
+
+def get_pod_events(podname: str, namespace: Optional[str] = None) -> dict:
+    """
+    Fetch Kubernetes events for a specific pod.
+
+    Returns:
+        dict: {podname, namespace, count, events: [...]}
+    """
+    namespace = namespace or common.get_namespace()
+    k8s_client = _load_k8s()
+    v1 = k8s_client.CoreV1Api()
+
+    def to_iso(ts):
+        return ts.isoformat() if ts else None
+
+    try:
+        events_list = v1.list_namespaced_event(namespace=namespace)
+    except k8s_client.exceptions.ApiException as e:
+        return {"podname": podname, "namespace": namespace, "count": 0, "events": [], "error": str(e)}
+
+    filtered = []
+    for ev in events_list.items or []:
+        involved = getattr(ev, "involved_object", None)
+        if not involved or involved.name != podname:
+            continue
+
+        first_ts = (
+            getattr(ev, "first_timestamp", None)
+            or getattr(ev, "event_time", None)
+            or getattr(getattr(ev, "metadata", None), "creation_timestamp", None)
+        )
+
+        filtered.append({
+            "type": getattr(ev, "type", None),
+            "reason": getattr(ev, "reason", None),
+            "message": getattr(ev, "message", None),
+            "count": getattr(ev, "count", 1),
+            "firstTimestamp": to_iso(first_ts),
+            "lastTimestamp": to_iso(getattr(ev, "last_timestamp", None)),
+            "reportingComponent": getattr(ev, "reporting_component", None),
+            "source": getattr(getattr(ev, "source", None), "component", None),
+            "involvedKind": getattr(involved, "kind", None),
+            "involvedName": getattr(involved, "name", None),
+        })
+
+    return {"podname": podname, "namespace": namespace, "count": len(filtered), "events": filtered}
+
+
+def get_pod_logs(
+    pod_name: str,
+    namespace: Optional[str] = None,
+    container_name: Optional[str] = None,
+) -> str:
+    """
+    Fetch pod logs as JSON array of lines.
+
+    Returns:
+        str: JSON-formatted log lines.
+    """
+    namespace = namespace or common.get_namespace()
+    k8s_client = _load_k8s()
+    v1 = k8s_client.CoreV1Api()
+
+    # Auto-detect container name based on pod name patterns
+    if not container_name:
+        if "pipeline" in pod_name:
+            container_name = "main"
+        elif "predictor" in pod_name:
+            container_name = "kserve-container"
+
+    try:
+        kwargs = {"name": pod_name, "namespace": namespace}
+        if container_name:
+            kwargs["container"] = container_name
+
+        raw_logs = v1.read_namespaced_pod_log(**kwargs)
+        parsed = [line.strip() for line in raw_logs.split("\n") if line.strip()]
+        return json.dumps(parsed, indent=4)
+    except k8s_client.exceptions.ApiException as e:
+        raise Exception(f"Failed to fetch pod logs: {e}")
+
+
+def get_inference_service_logs(
+    inference_service_name: str,
+    namespace: Optional[str] = None,
+    container_name: str = "kserve-container",
+) -> str:
+    """
+    Fetch logs for all pods matching an InferenceService name.
+
+    Returns:
+        str: JSON-formatted log entries per pod.
+    """
+    namespace = namespace or common.get_namespace()
+    k8s_client = _load_k8s()
+    v1 = k8s_client.CoreV1Api()
+
+    pods = v1.list_namespaced_pod(namespace=namespace)
+    isvc_pods = [p for p in pods.items if inference_service_name in p.metadata.name]
+
+    log_entries = []
+    for pod in isvc_pods:
+        pod_logs = get_pod_logs(
+            pod_name=pod.metadata.name,
+            namespace=namespace,
+            container_name=container_name,
+        )
+        log_entries.append({
+            "pod_name": pod.metadata.name,
+            "namespace": pod.metadata.namespace,
+            "logs": pod_logs if pod_logs else "No logs available.",
+        })
+
+    return json.dumps(log_entries, indent=4)
+
+
+# ================================================================
+# ASYNC POD INSPECTION FUNCTIONS
+# ================================================================
+
+_async_k8s_loaded = False
+
+
+async def _ensure_async_k8s():
+    global _async_k8s_loaded
+    if not _async_k8s_loaded:
+        from kubernetes_asyncio import config as async_config
+        try:
+            async_config.load_incluster_config()
+        except Exception:
+            await async_config.load_kube_config()
+        _async_k8s_loaded = True
+
+
+async def async_get_pod_definition(podname: str, namespace: Optional[str] = None) -> str:
+    """Fetch pod definition (async)."""
+    namespace = namespace or common.get_namespace()
+    await _ensure_async_k8s()
+    from kubernetes_asyncio import client as async_client
+    v1 = async_client.CoreV1Api()
+    try:
+        pod = await v1.read_namespaced_pod(name=podname, namespace=namespace)
+        pod_dict = _convert_datetime(pod.to_dict())
+        return json.dumps(pod_dict, indent=4)
+    except Exception as e:
+        return json.dumps({"error": f"Failed to fetch pod: {e}"})
+
+
+async def async_get_pod_events(podname: str, namespace: Optional[str] = None) -> dict:
+    """Fetch pod events (async)."""
+    namespace = namespace or common.get_namespace()
+    await _ensure_async_k8s()
+    from kubernetes_asyncio import client as async_client
+    v1 = async_client.CoreV1Api()
+
+    def to_iso(ts):
+        return ts.isoformat() if ts else None
+
+    try:
+        events_list = await v1.list_namespaced_event(namespace=namespace)
+    except Exception as e:
+        return {"podname": podname, "namespace": namespace, "count": 0, "events": [], "error": str(e)}
+
+    filtered = []
+    for ev in events_list.items or []:
+        involved = getattr(ev, "involved_object", None)
+        if not involved or involved.name != podname:
+            continue
+        first_ts = getattr(ev, "first_timestamp", None) or getattr(ev, "event_time", None)
+        filtered.append({
+            "type": getattr(ev, "type", None),
+            "reason": getattr(ev, "reason", None),
+            "message": getattr(ev, "message", None),
+            "count": getattr(ev, "count", 1),
+            "firstTimestamp": to_iso(first_ts),
+            "lastTimestamp": to_iso(getattr(ev, "last_timestamp", None)),
+            "source": getattr(getattr(ev, "source", None), "component", None),
+        })
+
+    return {"podname": podname, "namespace": namespace, "count": len(filtered), "events": filtered}
+
+
+async def async_get_pod_logs(
+    pod_name: str,
+    namespace: Optional[str] = None,
+    container_name: Optional[str] = None,
+) -> str:
+    """Fetch pod logs (async)."""
+    namespace = namespace or common.get_namespace()
+    await _ensure_async_k8s()
+    from kubernetes_asyncio import client as async_client
+    v1 = async_client.CoreV1Api()
+
+    if not container_name:
+        if "pipeline" in pod_name:
+            container_name = "main"
+        elif "predictor" in pod_name:
+            container_name = "kserve-container"
+
+    kwargs = {"name": pod_name, "namespace": namespace}
+    if container_name:
+        kwargs["container"] = container_name
+
+    raw_logs = await v1.read_namespaced_pod_log(**kwargs)
+    parsed = [line.strip() for line in raw_logs.split("\n") if line.strip()]
+    return json.dumps(parsed, indent=4)
+
+
+async def async_get_inference_service_logs(
+    inference_service_name: str,
+    namespace: Optional[str] = None,
+    container_name: str = "kserve-container",
+) -> str:
+    """Fetch ISVC logs (async)."""
+    namespace = namespace or common.get_namespace()
+    await _ensure_async_k8s()
+    from kubernetes_asyncio import client as async_client
+    v1 = async_client.CoreV1Api()
+
+    pods = await v1.list_namespaced_pod(namespace=namespace)
+    isvc_pods = [p for p in pods.items if inference_service_name in p.metadata.name]
+
+    log_entries = []
+    for pod in isvc_pods:
+        pod_logs = await async_get_pod_logs(
+            pod_name=pod.metadata.name,
+            namespace=namespace,
+            container_name=container_name,
+        )
+        log_entries.append({
+            "pod_name": pod.metadata.name,
+            "namespace": pod.metadata.namespace,
+            "logs": pod_logs if pod_logs else "No logs available.",
+        })
+
+    return json.dumps(log_entries, indent=4)
+
+
+# ================================================================
+# INTERNAL HELPERS
+# ================================================================
+
+
+def _get_pipeline_id_by_name(kfp_client_instance, pipeline_name: str) -> str:
+    """Find pipeline ID by name."""
+    next_page_token = None
+    while True:
+        pipelines = kfp_client_instance.list_pipelines(page_size=100, page_token=next_page_token)
+        if pipelines and pipelines.pipelines:
+            for p in pipelines.pipelines:
+                if p.name == pipeline_name:
+                    return p.id
+        next_page_token = getattr(pipelines, "next_page_token", None)
+        if not next_page_token:
+            break
+    raise ValueError(f"Pipeline '{pipeline_name}' not found.")
+
+
+def _list_runs_by_pipeline_id(kfp_client_instance, pipeline_id: str) -> list:
+    """List all runs for a given pipeline ID."""
+    parsed_runs = []
+    next_page_token = None
+    while True:
+        runs = kfp_client_instance.list_runs(page_token=next_page_token)
+        if runs and runs.runs:
+            for run in runs.runs:
+                parsed_runs.append(_parse_run(run))
+        next_page_token = getattr(runs, "next_page_token", None)
+        if not next_page_token:
+            break
+    return parsed_runs
+
+
+def _get_run_id_by_name(kfp_client_instance, run_name: str) -> Optional[str]:
+    """Find run ID by run name."""
+    next_page_token = None
+    while True:
+        runs = kfp_client_instance.list_runs(page_size=100, page_token=next_page_token)
+        if runs and runs.runs:
+            for run in runs.runs:
+                if run.name == run_name:
+                    return run.id
+        next_page_token = getattr(runs, "next_page_token", None)
+        if not next_page_token:
+            break
+    return None
+
+
+def _get_run_id_by_workflow_name(kfp_client_instance, workflow_name: str) -> Optional[str]:
+    """Find run ID by workflow name."""
+    next_page_token = None
+    while True:
+        runs = kfp_client_instance.list_runs(page_size=100, page_token=next_page_token)
+        if runs and runs.runs:
+            for run in runs.runs:
+                run_details = kfp_client_instance.get_run(run.id)
+                try:
+                    manifest = json.loads(run_details.pipeline_runtime.workflow_manifest)
+                    if manifest.get("metadata", {}).get("name") == workflow_name:
+                        return run.id
+                except Exception:
+                    continue
+        next_page_token = getattr(runs, "next_page_token", None)
+        if not next_page_token:
+            break
+    return None

--- a/cogflow/core/pipelines/inspection.py
+++ b/cogflow/core/pipelines/inspection.py
@@ -12,15 +12,11 @@ Offers both sync and async variants for K8s operations.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional, Any, List, Dict
 
 from ...utils.logging import get_logger
-from ...utils.exceptions import (
-    CogflowErrorHandler,
-    CogflowPipelineError,
-    CogflowConnectionError,
-)
+from ...utils.exceptions import CogflowConnectionError
 from ...utils import common
 
 logger = get_logger(__name__)
@@ -449,12 +445,12 @@ def get_pod_logs(
     pod_name: str,
     namespace: Optional[str] = None,
     container_name: Optional[str] = None,
-) -> str:
+) -> List[str]:
     """
-    Fetch pod logs as JSON array of lines.
+    Fetch pod logs as a list of log lines.
 
     Returns:
-        str: JSON-formatted log lines.
+        List[str]: Log lines (empty list if no logs available).
     """
     namespace = namespace or common.get_namespace()
     k8s_client = _load_k8s()
@@ -473,8 +469,7 @@ def get_pod_logs(
             kwargs["container"] = container_name
 
         raw_logs = v1.read_namespaced_pod_log(**kwargs)
-        parsed = [line.strip() for line in raw_logs.split("\n") if line.strip()]
-        return json.dumps(parsed, indent=4)
+        return [line.strip() for line in raw_logs.split("\n") if line.strip()]
     except k8s_client.exceptions.ApiException as e:
         raise CogflowConnectionError(
             f"Failed to fetch pod logs for pod '{pod_name}' in namespace '{namespace}': {e}"
@@ -485,12 +480,12 @@ def get_inference_service_logs(
     inference_service_name: str,
     namespace: Optional[str] = None,
     container_name: str = "kserve-container",
-) -> str:
+) -> List[Dict[str, Any]]:
     """
     Fetch logs for all pods matching an InferenceService name.
 
     Returns:
-        str: JSON-formatted log entries per pod.
+        List[Dict]: One entry per pod with pod_name, namespace, and logs (list of lines).
     """
     namespace = namespace or common.get_namespace()
     k8s_client = _load_k8s()
@@ -509,10 +504,10 @@ def get_inference_service_logs(
         log_entries.append({
             "pod_name": pod.metadata.name,
             "namespace": pod.metadata.namespace,
-            "logs": pod_logs if pod_logs else "No logs available.",
+            "logs": pod_logs,
         })
 
-    return json.dumps(log_entries, indent=4)
+    return log_entries
 
 
 # ================================================================
@@ -585,8 +580,8 @@ async def async_get_pod_logs(
     pod_name: str,
     namespace: Optional[str] = None,
     container_name: Optional[str] = None,
-) -> str:
-    """Fetch pod logs (async)."""
+) -> List[str]:
+    """Fetch pod logs as list of lines (async)."""
     namespace = namespace or common.get_namespace()
     await _ensure_async_k8s()
     from kubernetes_asyncio import client as async_client
@@ -603,16 +598,15 @@ async def async_get_pod_logs(
         kwargs["container"] = container_name
 
     raw_logs = await v1.read_namespaced_pod_log(**kwargs)
-    parsed = [line.strip() for line in raw_logs.split("\n") if line.strip()]
-    return json.dumps(parsed, indent=4)
+    return [line.strip() for line in raw_logs.split("\n") if line.strip()]
 
 
 async def async_get_inference_service_logs(
     inference_service_name: str,
     namespace: Optional[str] = None,
     container_name: str = "kserve-container",
-) -> str:
-    """Fetch ISVC logs (async)."""
+) -> List[Dict[str, Any]]:
+    """Fetch ISVC logs as structured list (async)."""
     namespace = namespace or common.get_namespace()
     await _ensure_async_k8s()
     from kubernetes_asyncio import client as async_client
@@ -631,10 +625,10 @@ async def async_get_inference_service_logs(
         log_entries.append({
             "pod_name": pod.metadata.name,
             "namespace": pod.metadata.namespace,
-            "logs": pod_logs if pod_logs else "No logs available.",
+            "logs": pod_logs,
         })
 
-    return json.dumps(log_entries, indent=4)
+    return log_entries
 
 
 # ================================================================

--- a/cogflow/core/pipelines/inspection.py
+++ b/cogflow/core/pipelines/inspection.py
@@ -93,10 +93,7 @@ def _parse_run(run) -> dict:
         "run_id": getattr(run, "id", getattr(run, "run_id", "Unknown")),
         "status": getattr(run, "status", "Unknown"),
         "duration": duration,
-        "experiment_id": getattr(
-            getattr(run, "resource_references", [None]),
-            "key", {},
-        ).get("id", "") if hasattr(run, "resource_references") else "",
+        "experiment_id": _extract_experiment_id(run),
         "start_time": start_time,
     }
 
@@ -284,8 +281,11 @@ def get_pipeline_task_sequence_by_pipeline_id(
     """
     kfp_client_instance = _kfp_client(api_url, skip_tls_verify, session_cookies, namespace)
 
-    # Get latest run for this pipeline
-    runs = kfp_client_instance.list_runs(page_size=1)
+    # Get latest run for this specific pipeline
+    filter_str = json.dumps({
+        "predicates": [{"key": "pipeline_id", "op": "EQUALS", "string_value": pipeline_id}]
+    })
+    runs = kfp_client_instance.list_runs(page_size=1, filter=filter_str)
     if not runs or not runs.runs:
         raise ValueError(f"No runs found for pipeline ID '{pipeline_id}'.")
 
@@ -476,7 +476,9 @@ def get_pod_logs(
         parsed = [line.strip() for line in raw_logs.split("\n") if line.strip()]
         return json.dumps(parsed, indent=4)
     except k8s_client.exceptions.ApiException as e:
-        raise Exception(f"Failed to fetch pod logs: {e}")
+        raise CogflowConnectionError(
+            f"Failed to fetch pod logs for pod '{pod_name}' in namespace '{namespace}': {e}"
+        ) from e
 
 
 def get_inference_service_logs(
@@ -640,6 +642,17 @@ async def async_get_inference_service_logs(
 # ================================================================
 
 
+def _extract_experiment_id(run) -> str:
+    """Extract experiment_id from a KFP run object."""
+    refs = getattr(run, "resource_references", None)
+    if refs:
+        for ref in refs:
+            key = getattr(ref, "key", None)
+            if key and getattr(key, "type", None) == "EXPERIMENT":
+                return getattr(key, "id", "")
+    return ""
+
+
 def _get_pipeline_id_by_name(kfp_client_instance, pipeline_name: str) -> str:
     """Find pipeline ID by name."""
     next_page_token = None
@@ -659,8 +672,11 @@ def _list_runs_by_pipeline_id(kfp_client_instance, pipeline_id: str) -> list:
     """List all runs for a given pipeline ID."""
     parsed_runs = []
     next_page_token = None
+    filter_str = json.dumps({
+        "predicates": [{"key": "pipeline_id", "op": "EQUALS", "string_value": pipeline_id}]
+    })
     while True:
-        runs = kfp_client_instance.list_runs(page_token=next_page_token)
+        runs = kfp_client_instance.list_runs(page_token=next_page_token, filter=filter_str)
         if runs and runs.runs:
             for run in runs.runs:
                 parsed_runs.append(_parse_run(run))

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -700,6 +700,8 @@ class ServingManager:
             namespace: Namespace where the InferenceService is deployed.
             model_format: Model format (e.g., "tensorflow", "pytorch").
             canary_traffic_percent: Traffic percentage to route to canary model.
+            model_type: Model type annotation (e.g., "llm", "lora"). Stored as
+                an ISVC annotation under the key ``model_type``.
         Returns:
             str: Status message.
         Raises:
@@ -902,6 +904,9 @@ class ServingManager:
             protocol_version: Protocol version for the model server.
             model_format: Model format (e.g., "tensorflow", "pytorch").
             namespace: Namespace where the InferenceService will be deployed.
+            model_type: Model type annotation (e.g., "llm", "lora"). Stored as
+                an ISVC annotation under the key ``model_type`` and returned in
+                ``list_models()`` responses.
         Returns:
             dict: Created InferenceService details.
         Raises:

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -543,6 +543,7 @@ class ServingManager:
         model_id = annotations.get("model_id")
         model_version = annotations.get("model_version")
         dataset_id = annotations.get("dataset_id")
+        model_type = annotations.get("model_type")
         creation_timestamp = metadata.get("creationTimestamp")
 
         # --- Base URLs ---
@@ -643,6 +644,7 @@ class ServingManager:
             "model_name": model_name or None,
             "model_version": model_version or None,
             "dataset_id": dataset_id or None,
+            "model_type": model_type or None,
             "creation_timestamp": creation_timestamp,
             "age": age,
             "latest_ready_revision": predictor.get("latestReadyRevision")
@@ -676,6 +678,7 @@ class ServingManager:
         namespace: Optional[str] = None,
         model_format: Optional[str] = None,
         canary_traffic_percent: Optional[int] = None,
+        model_type: Optional[str] = None,
     ) -> str:
         """
         High-level update for an existing InferenceService.
@@ -796,6 +799,8 @@ class ServingManager:
             }
             if dataset_id:
                 annot["dataset_id"] = common.normalize_uuid(dataset_id)
+            if model_type:
+                annot["model_type"] = model_type
 
             # --- Model patch ---
             model_patch: Dict[str, Any] = {}
@@ -876,6 +881,7 @@ class ServingManager:
         protocol_version: str = None,
         model_format: str = None,
         namespace: Optional[str] = None,
+        model_type: Optional[str] = None,
     ):
         """
         High-level entrypoint to serve a model:
@@ -946,6 +952,8 @@ class ServingManager:
             }
             if dataset_id:
                 annot["dataset_id"] = common.normalize_uuid(dataset_id)
+            if model_type:
+                annot["model_type"] = model_type
 
             logger.info(
                 "Creating InferenceService '%s' for model_uri=%s in namespace=%s.",
@@ -1111,7 +1119,7 @@ class ServingManager:
 # Create a singleton instance for the public interface
 _serving = ServingManager()
 
-# Exposed SDK-level methods (single source of truth)
+# Exposed SDK-level methods (single source of truth) — sync
 for attr_name in dir(ServingManager):
     # Skip private methods and dunder methods
     if attr_name.startswith("_"):
@@ -1119,7 +1127,19 @@ for attr_name in dir(ServingManager):
 
     attr = getattr(ServingManager, attr_name)
 
-    # Only export methods (callables) that belong to ModelManager
+    # Only export methods (callables) that belong to ServingManager
     if callable(attr):
         # Bind the method to the singleton instance
         globals()[attr_name] = getattr(_serving, attr_name)
+
+# Expose async methods from AsyncServingManager
+from .async_serving import (  # noqa: E402
+    async_deploy_model,
+    async_update_model,
+    async_delete_isvc,
+    async_list_models,
+    async_get_isvc,
+    async_update_isvc,
+    async_restart_isvc,
+    async_create_isvc,
+)

--- a/cogflow/utils/storage.py
+++ b/cogflow/utils/storage.py
@@ -3,6 +3,7 @@ Utility functions for MinIO storage interactions.
 """
 
 from urllib.parse import urlparse
+
 from minio import Minio
 
 from ..config import config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "scikit-learn (==1.7.0)",
     "tenacity",
     "kubernetes",
+    "kubernetes_asyncio",
     "minio>=7.2.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
   "pytest>=7.4.0",
   "pytest-cov>=4.1.0",
   "pytest-mock>=3.12.0",
+  "pytest-asyncio>=0.21.0",
   "coverage",
   "build",
   "twine"

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -1,0 +1,257 @@
+"""
+Unit tests for cogflow.core.async_serving.AsyncServingManager.
+
+All Kubernetes I/O is mocked via kubernetes_asyncio so tests
+do not require a real cluster.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cogflow.utils import common
+import cogflow.core.async_serving as async_serving_module
+
+
+# ---------------------------------------------------------------------
+# FIXTURES
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_async_api():
+    """A fake async CustomObjectsApi that records calls and returns canned data."""
+    api = MagicMock()
+    api.calls = []
+
+    async def get_namespaced_custom_object(**kwargs):
+        api.calls.append(("get", kwargs))
+        return {
+            "metadata": {
+                "name": kwargs["name"],
+                "annotations": {"model_name": "m1", "model_type": "llm"},
+                "creationTimestamp": "2024-01-01T00:00:00Z",
+            },
+            "status": {
+                "conditions": [{"type": "Ready", "status": "True"}],
+                "components": {"predictor": {"traffic": []}},
+            },
+            "spec": {"predictor": {}},
+        }
+
+    async def delete_namespaced_custom_object(**kwargs):
+        api.calls.append(("delete", kwargs))
+        return {}
+
+    async def patch_namespaced_custom_object(**kwargs):
+        api.calls.append(("patch", kwargs))
+        return {"metadata": {"name": kwargs["name"]}}
+
+    async def list_namespaced_custom_object(**kwargs):
+        api.calls.append(("list", kwargs))
+        return {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "isvc-a",
+                        "annotations": {"model_name": "m1", "model_type": "llm"},
+                        "creationTimestamp": "2024-01-01T00:00:00Z",
+                    },
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                        "components": {"predictor": {"traffic": []}},
+                    },
+                    "spec": {"predictor": {}},
+                }
+            ]
+        }
+
+    async def create_namespaced_custom_object(**kwargs):
+        api.calls.append(("create", kwargs))
+        return {"metadata": {"name": kwargs["body"]["metadata"]["name"]}}
+
+    api.get_namespaced_custom_object = get_namespaced_custom_object
+    api.delete_namespaced_custom_object = delete_namespaced_custom_object
+    api.patch_namespaced_custom_object = patch_namespaced_custom_object
+    api.list_namespaced_custom_object = list_namespaced_custom_object
+    api.create_namespaced_custom_object = create_namespaced_custom_object
+    return api
+
+
+@pytest.fixture
+def async_serving(monkeypatch, fake_async_api):
+    """Returns a fresh AsyncServingManager instance with the api pre-injected."""
+    monkeypatch.setattr(common, "get_namespace", lambda: "test-ns", raising=True)
+    monkeypatch.setattr(
+        async_serving_module, "_ASYNC_K8S_CONFIG_LOADED", True, raising=True
+    )
+    mgr = async_serving_module.AsyncServingManager()
+    mgr._api = fake_async_api  # Bypass _get_api()
+    return mgr
+
+
+# ---------------------------------------------------------------------
+# CRUD OPERATIONS
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_get_isvc(async_serving, fake_async_api):
+    """async get_isvc should call get_namespaced_custom_object."""
+    result = await async_serving.get_isvc("model-a")
+    assert result["metadata"]["name"] == "model-a"
+    assert fake_async_api.calls[-1][0] == "get"
+
+
+@pytest.mark.asyncio
+async def test_async_delete_isvc(async_serving, fake_async_api):
+    """async delete_isvc should return True on success."""
+    ok = await async_serving.delete_isvc("model-x")
+    assert ok is True
+    assert fake_async_api.calls[-1][0] == "delete"
+
+
+@pytest.mark.asyncio
+async def test_async_update_isvc(async_serving, fake_async_api):
+    """async update_isvc should patch the InferenceService spec."""
+    patch_body = {"spec": {"predictor": {"minReplicas": 3}}}
+    result = await async_serving.update_isvc("m1", patch_body)
+    assert result["metadata"]["name"] == "m1"
+    assert fake_async_api.calls[-1][0] == "patch"
+
+
+@pytest.mark.asyncio
+async def test_async_restart_isvc(async_serving, fake_async_api):
+    """async restart_isvc should call patch twice (scale to 0 then back)."""
+    await async_serving.restart_isvc("m2")
+    patch_calls = [c for c in fake_async_api.calls if c[0] == "patch"]
+    assert len(patch_calls) == 2
+
+
+# ---------------------------------------------------------------------
+# DEPLOY MODEL with model_type
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_deploy_model_with_model_type(
+    monkeypatch, async_serving, fake_async_api
+):
+    """
+    async deploy_model should set model_type as an ISVC annotation
+    when provided.
+    """
+
+    def fake_detect_model_format(model_uri=None, **_):
+        return "onnx"
+
+    def fake_get_model_details(**_):
+        return {
+            "model_uri": "s3://bucket/model",
+            "model_name": "n1",
+            "model_version": "v1",
+            "model_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+    monkeypatch.setattr(
+        async_serving,
+        "_get_model_helpers",
+        lambda: (fake_detect_model_format, fake_get_model_details),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        async_serving,
+        "_get_transformer_env",
+        lambda *args, **kwargs: {},
+        raising=True,
+    )
+
+    await async_serving.deploy_model(
+        model_id="11111111-1111-1111-1111-111111111111",
+        isvc_name="myisvc",
+        namespace="test-ns",
+        model_type="llm",
+    )
+
+    create_calls = [c for c in fake_async_api.calls if c[0] == "create"]
+    assert len(create_calls) == 1
+    body = create_calls[0][1]["body"]
+
+    assert body["metadata"]["name"] == "myisvc"
+    annotations = body["metadata"]["annotations"]
+    assert annotations["model_type"] == "llm"
+    assert annotations["model_name"] == "n1"
+    assert body["spec"]["predictor"]["model"]["storageUri"] == "s3://bucket/model"
+
+
+@pytest.mark.asyncio
+async def test_async_deploy_model_without_model_type(
+    monkeypatch, async_serving, fake_async_api
+):
+    """
+    async deploy_model should NOT set model_type annotation when not provided.
+    """
+
+    def fake_get_model_details(**_):
+        return {
+            "model_uri": "s3://bucket/model",
+            "model_name": "n1",
+            "model_version": "v1",
+            "model_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+    monkeypatch.setattr(
+        async_serving,
+        "_get_model_helpers",
+        lambda: (lambda **_: "onnx", fake_get_model_details),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        async_serving, "_get_transformer_env", lambda *args, **kwargs: {}, raising=True
+    )
+
+    await async_serving.deploy_model(model_id="11111111-1111-1111-1111-111111111111")
+
+    create_calls = [c for c in fake_async_api.calls if c[0] == "create"]
+    annotations = create_calls[0][1]["body"]["metadata"]["annotations"]
+    assert "model_type" not in annotations
+
+
+# ---------------------------------------------------------------------
+# LIST MODELS
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_list_models_all(async_serving, fake_async_api):
+    """async list_models with no isvc_name should list all in namespace."""
+    models = await async_serving.list_models()
+    assert len(models) == 1
+    assert models[0]["model_name"] == "m1"
+    assert models[0]["model_type"] == "llm"
+    assert fake_async_api.calls[-1][0] == "list"
+
+
+@pytest.mark.asyncio
+async def test_async_list_models_single(async_serving, fake_async_api):
+    """async list_models with isvc_name should return a single wrapped model."""
+    models = await async_serving.list_models(isvc_name="isvc-a")
+    assert len(models) == 1
+    assert models[0]["isvc_name"] == "isvc-a"
+    assert models[0]["model_type"] == "llm"
+
+
+# ---------------------------------------------------------------------
+# MODULE-LEVEL BINDINGS
+# ---------------------------------------------------------------------
+
+
+def test_async_module_exports():
+    """Verify module-level async functions are exposed."""
+    assert callable(async_serving_module.async_deploy_model)
+    assert callable(async_serving_module.async_update_model)
+    assert callable(async_serving_module.async_delete_isvc)
+    assert callable(async_serving_module.async_list_models)
+    assert callable(async_serving_module.async_get_isvc)
+    assert callable(async_serving_module.async_update_isvc)
+    assert callable(async_serving_module.async_restart_isvc)
+    assert callable(async_serving_module.async_create_isvc)

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -80,7 +80,12 @@ def fake_async_api():
 @pytest.fixture
 def async_serving(monkeypatch, fake_async_api):
     """Returns a fresh AsyncServingManager instance with the api pre-injected."""
+    # Prevent real K8s config loading when the sync serving singleton
+    # is instantiated indirectly via _get_serving_manager_class().
+    monkeypatch.setattr(common, "load_k8s_config", lambda: None, raising=True)
     monkeypatch.setattr(common, "get_namespace", lambda: "test-ns", raising=True)
+    # Pre-mark the sync flag so the singleton doesn't try to load config
+    common._k8s_loaded_flag = True
     monkeypatch.setattr(
         async_serving_module, "_ASYNC_K8S_CONFIG_LOADED", True, raising=True
     )

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,0 +1,342 @@
+"""
+Unit tests for cogflow.core.pipelines.inspection.
+
+Mocks KFP client and Kubernetes CoreV1Api to verify:
+- Pagination behavior
+- Pipeline/run filtering
+- Error handling
+- Workflow node parsing
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+import cogflow.core.pipelines.inspection as inspection
+from cogflow.utils.exceptions import CogflowConnectionError
+
+
+# ---------------------------------------------------------------------
+# HELPERS / FAKES
+# ---------------------------------------------------------------------
+
+
+class FakeKey:
+    def __init__(self, type_, id_):
+        self.type = type_
+        self.id = id_
+
+
+class FakeRef:
+    def __init__(self, key):
+        self.key = key
+
+
+class FakeRun:
+    def __init__(self, name, run_id, status="Succeeded", experiment_id="exp-1"):
+        self.name = name
+        self.id = run_id
+        self.status = status
+        self.created_at = None
+        self.finished_at = None
+        self.resource_references = [
+            FakeRef(FakeKey("EXPERIMENT", experiment_id))
+        ]
+
+
+class FakeRunsResponse:
+    def __init__(self, runs, next_token=None):
+        self.runs = runs
+        self.next_page_token = next_token
+
+
+def _make_workflow_manifest(nodes_dict, namespace="ns1"):
+    """Build a workflow manifest JSON string with the given nodes."""
+    return json.dumps(
+        {
+            "metadata": {"namespace": namespace, "name": "wf-name"},
+            "status": {"nodes": nodes_dict},
+        }
+    )
+
+
+# ---------------------------------------------------------------------
+# _parse_run / _extract_experiment_id
+# ---------------------------------------------------------------------
+
+
+def test_extract_experiment_id_from_resource_references():
+    """experiment_id should be picked from resource_references with type=EXPERIMENT."""
+    run = FakeRun("r1", "id-1", experiment_id="exp-42")
+    assert inspection._extract_experiment_id(run) == "exp-42"
+
+
+def test_extract_experiment_id_no_references_returns_empty():
+    """No resource_references → empty string."""
+    run = FakeRun("r1", "id-1")
+    run.resource_references = []
+    assert inspection._extract_experiment_id(run) == ""
+
+
+def test_extract_experiment_id_skips_non_experiment_refs():
+    """Non-EXPERIMENT refs should be ignored."""
+    run = FakeRun("r1", "id-1")
+    run.resource_references = [FakeRef(FakeKey("PIPELINE", "p-1"))]
+    assert inspection._extract_experiment_id(run) == ""
+
+
+def test_parse_run_basic():
+    """_parse_run should extract name, id, status, experiment_id."""
+    run = FakeRun("my-run", "run-123", status="Running", experiment_id="exp-9")
+    parsed = inspection._parse_run(run)
+    assert parsed["run_name"] == "my-run"
+    assert parsed["run_id"] == "run-123"
+    assert parsed["status"] == "Running"
+    assert parsed["experiment_id"] == "exp-9"
+
+
+# ---------------------------------------------------------------------
+# _traverse_workflow_nodes
+# ---------------------------------------------------------------------
+
+
+def test_traverse_workflow_nodes_finds_root_dag():
+    """Should locate the DAG root and traverse children."""
+    nodes = {
+        "root-1": {
+            "type": "DAG",
+            "displayName": "my-pipeline",
+            "phase": "Succeeded",
+            "children": ["task-1"],
+        },
+        "task-1": {
+            "type": "Pod",
+            "displayName": "step-one",
+            "phase": "Succeeded",
+            "children": [],
+        },
+    }
+    name, structure = inspection._traverse_workflow_nodes(nodes, "ns1")
+    assert name == "my-pipeline"
+    assert "root-1" in structure
+    assert structure["root-1"]["name"] == "my-pipeline"
+    assert len(structure["root-1"]["children"]) == 1
+    assert structure["root-1"]["children"][0]["name"] == "step-one"
+
+
+def test_traverse_workflow_nodes_raises_when_no_dag():
+    """Should raise ValueError when no DAG node is present."""
+    nodes = {
+        "task-1": {
+            "type": "Pod",
+            "displayName": "step-one",
+            "phase": "Succeeded",
+            "children": [],
+        }
+    }
+    with pytest.raises(ValueError, match="Root DAG node not found"):
+        inspection._traverse_workflow_nodes(nodes, "ns1")
+
+
+# ---------------------------------------------------------------------
+# list_all_kfp_runs (pagination)
+# ---------------------------------------------------------------------
+
+
+def test_list_all_kfp_runs_paginates(monkeypatch):
+    """Should iterate all pages until next_page_token is None."""
+    page1 = FakeRunsResponse(
+        runs=[FakeRun("r1", "id-1"), FakeRun("r2", "id-2")],
+        next_token="token-2",
+    )
+    page2 = FakeRunsResponse(runs=[FakeRun("r3", "id-3")], next_token=None)
+
+    fake_client = MagicMock()
+    call_log = []
+
+    def fake_list_runs(page_token=None):
+        call_log.append(page_token)
+        if page_token is None:
+            return page1
+        return page2
+
+    fake_client.list_runs = fake_list_runs
+
+    monkeypatch.setattr(inspection, "_kfp_client", lambda *a, **k: fake_client)
+
+    runs = inspection.list_all_kfp_runs()
+    assert len(runs) == 3
+    assert [r["run_id"] for r in runs] == ["id-1", "id-2", "id-3"]
+    assert call_log == [None, "token-2"]
+
+
+# ---------------------------------------------------------------------
+# Pipeline filtering — get_pipeline_task_sequence_by_pipeline_id
+# ---------------------------------------------------------------------
+
+
+def test_get_pipeline_task_sequence_by_pipeline_id_filters_by_pipeline(monkeypatch):
+    """list_runs should be called with a pipeline_id filter."""
+    fake_client = MagicMock()
+
+    def fake_list_runs(page_size=None, filter=None, **_):
+        # Verify filter contains the pipeline_id
+        assert filter is not None
+        parsed = json.loads(filter)
+        assert parsed["predicates"][0]["key"] == "pipeline_id"
+        assert parsed["predicates"][0]["string_value"] == "pid-42"
+        return FakeRunsResponse(runs=[FakeRun("r1", "run-99")])
+
+    fake_client.list_runs = fake_list_runs
+
+    fake_run_details = MagicMock()
+    fake_run_details.pipeline_runtime.workflow_manifest = _make_workflow_manifest(
+        {
+            "root": {
+                "type": "DAG",
+                "displayName": "p1",
+                "phase": "Succeeded",
+                "children": [],
+            }
+        }
+    )
+    fake_client.get_run = MagicMock(return_value=fake_run_details)
+
+    monkeypatch.setattr(inspection, "_kfp_client", lambda *a, **k: fake_client)
+
+    result = inspection.get_pipeline_task_sequence_by_pipeline_id("pid-42")
+    assert result["pipeline_id"] == "pid-42"
+    assert result["pipeline_workflow_name"] == "p1"
+
+
+def test_get_pipeline_task_sequence_by_pipeline_id_raises_when_no_runs(monkeypatch):
+    """Should raise ValueError when no runs found for the pipeline."""
+    fake_client = MagicMock()
+    fake_client.list_runs = MagicMock(return_value=FakeRunsResponse(runs=[]))
+    monkeypatch.setattr(inspection, "_kfp_client", lambda *a, **k: fake_client)
+
+    with pytest.raises(ValueError, match="No runs found"):
+        inspection.get_pipeline_task_sequence_by_pipeline_id("pid-x")
+
+
+# ---------------------------------------------------------------------
+# _list_runs_by_pipeline_id (pipeline filter + pagination)
+# ---------------------------------------------------------------------
+
+
+def test_list_runs_by_pipeline_id_uses_filter():
+    """The internal helper should pass the pipeline_id filter to list_runs."""
+    fake_client = MagicMock()
+    captured_filters = []
+
+    def fake_list_runs(page_token=None, filter=None):
+        captured_filters.append(filter)
+        return FakeRunsResponse(runs=[FakeRun("r1", "id-1")])
+
+    fake_client.list_runs = fake_list_runs
+
+    runs = inspection._list_runs_by_pipeline_id(fake_client, "pid-99")
+    assert len(runs) == 1
+    assert captured_filters[0] is not None
+    parsed = json.loads(captured_filters[0])
+    assert parsed["predicates"][0]["key"] == "pipeline_id"
+    assert parsed["predicates"][0]["string_value"] == "pid-99"
+
+
+# ---------------------------------------------------------------------
+# Pod inspection — error handling
+# ---------------------------------------------------------------------
+
+
+def test_get_pod_logs_raises_cogflow_connection_error_on_api_failure(monkeypatch):
+    """get_pod_logs should wrap ApiException in CogflowConnectionError."""
+    # Build a fake k8s_client that raises ApiException
+    fake_k8s = MagicMock()
+
+    class FakeApiException(Exception):
+        pass
+
+    fake_k8s.exceptions.ApiException = FakeApiException
+
+    fake_v1 = MagicMock()
+    fake_v1.read_namespaced_pod_log = MagicMock(side_effect=FakeApiException("boom"))
+    fake_k8s.CoreV1Api = MagicMock(return_value=fake_v1)
+
+    monkeypatch.setattr(inspection, "_load_k8s", lambda: fake_k8s)
+    monkeypatch.setattr(
+        inspection.common, "get_namespace", lambda: "test-ns", raising=True
+    )
+
+    with pytest.raises(CogflowConnectionError, match="Failed to fetch pod logs"):
+        inspection.get_pod_logs("my-pod")
+
+
+def test_get_pod_definition_returns_json(monkeypatch):
+    """get_pod_definition should return JSON string of the pod spec."""
+    fake_k8s = MagicMock()
+    fake_v1 = MagicMock()
+
+    class FakePod:
+        def to_dict(self):
+            return {"metadata": {"name": "p1"}, "spec": {"containers": []}}
+
+    fake_v1.read_namespaced_pod = MagicMock(return_value=FakePod())
+    fake_k8s.CoreV1Api = MagicMock(return_value=fake_v1)
+
+    monkeypatch.setattr(inspection, "_load_k8s", lambda: fake_k8s)
+    monkeypatch.setattr(
+        inspection.common, "get_namespace", lambda: "test-ns", raising=True
+    )
+
+    result = inspection.get_pod_definition("p1")
+    parsed = json.loads(result)
+    assert parsed["metadata"]["name"] == "p1"
+
+
+def test_get_pod_events_filters_by_pod_name(monkeypatch):
+    """get_pod_events should only return events whose involvedObject matches podname."""
+    fake_k8s = MagicMock()
+    fake_v1 = MagicMock()
+
+    class FakeInvolved:
+        def __init__(self, name, kind="Pod"):
+            self.name = name
+            self.kind = kind
+
+    class FakeEvent:
+        def __init__(self, podname, reason="Started"):
+            self.involved_object = FakeInvolved(podname)
+            self.type = "Normal"
+            self.reason = reason
+            self.message = "msg"
+            self.count = 1
+            self.first_timestamp = None
+            self.last_timestamp = None
+            self.event_time = None
+            self.metadata = MagicMock(creation_timestamp=None)
+            self.reporting_component = None
+            self.reporting_instance = None
+            self.source = MagicMock(component=None)
+
+    fake_events = MagicMock()
+    fake_events.items = [
+        FakeEvent("my-pod", "Started"),
+        FakeEvent("other-pod", "Failed"),
+        FakeEvent("my-pod", "Pulled"),
+    ]
+    fake_v1.list_namespaced_event = MagicMock(return_value=fake_events)
+    fake_k8s.CoreV1Api = MagicMock(return_value=fake_v1)
+    fake_k8s.exceptions.ApiException = Exception
+
+    monkeypatch.setattr(inspection, "_load_k8s", lambda: fake_k8s)
+    monkeypatch.setattr(
+        inspection.common, "get_namespace", lambda: "test-ns", raising=True
+    )
+
+    result = inspection.get_pod_events("my-pod")
+    assert result["count"] == 2
+    assert result["podname"] == "my-pod"
+    reasons = [e["reason"] for e in result["events"]]
+    assert "Started" in reasons
+    assert "Pulled" in reasons
+    assert "Failed" not in reasons

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -879,3 +879,130 @@ def test_create_experiment_failure(manager):
     manager.client.create_experiment.side_effect = RuntimeError("fail")
     with pytest.raises(RuntimeError):
         manager.create_experiment(name="bad")
+
+
+# ---------- get_run ----------
+
+
+def test_get_run_success(manager):
+    """Test get_run returns the MLflow Run object."""
+    fake_run = MagicMock()
+    fake_run.info.run_id = "abc123"
+    manager.mlflow.get_run.return_value = fake_run
+
+    result = manager.get_run("abc123")
+
+    manager.mlflow.get_run.assert_called_once_with("abc123")
+    assert result is fake_run
+
+
+def test_get_run_normalizes_uuid(manager, monkeypatch):
+    """Test that get_run passes run_id through uuid_to_hex."""
+    calls = {}
+
+    def fake_uuid_to_hex(value):
+        calls["got"] = value
+        return "normalized-id"
+
+    monkeypatch.setattr(models_mod.common, "uuid_to_hex", fake_uuid_to_hex)
+    manager.mlflow.get_run.return_value = MagicMock()
+
+    manager.get_run("abc-123-def")
+
+    assert calls["got"] == "abc-123-def"
+    manager.mlflow.get_run.assert_called_once_with("normalized-id")
+
+
+def test_get_run_failure_wraps_exception(manager):
+    """Test get_run wraps errors as CogflowRunError."""
+    manager.mlflow.get_run.side_effect = RuntimeError("boom")
+    with pytest.raises(models_mod.CogflowRunError):
+        manager.get_run("abc123")
+
+
+# ---------- get_run_artifact_uri ----------
+
+
+def test_get_run_artifact_uri_success(manager):
+    """Test get_run_artifact_uri returns the artifact_uri from the run info."""
+    fake_run = MagicMock()
+    fake_run.info.artifact_uri = "s3://mlflow/0/abc123/artifacts"
+    manager.mlflow.get_run.return_value = fake_run
+
+    uri = manager.get_run_artifact_uri("abc123")
+
+    assert uri == "s3://mlflow/0/abc123/artifacts"
+    manager.mlflow.get_run.assert_called_once_with("abc123")
+
+
+def test_get_run_artifact_uri_failure(manager):
+    """Test get_run_artifact_uri propagates errors as CogflowRunError."""
+    manager.mlflow.get_run.side_effect = RuntimeError("boom")
+    with pytest.raises(models_mod.CogflowRunError):
+        manager.get_run_artifact_uri("abc123")
+
+
+# ---------- list_artifacts_grouped ----------
+
+
+def test_list_artifacts_grouped_root_files_only(manager):
+    """Files at root level should be grouped under empty-string key."""
+    file1 = MagicMock()
+    file1.path = "README.md"
+    file1.is_dir = False
+    file2 = MagicMock()
+    file2.path = "config.json"
+    file2.is_dir = False
+
+    manager.client.list_artifacts.return_value = [file1, file2]
+
+    result = manager.list_artifacts_grouped("run-1")
+
+    assert "" in result
+    assert sorted(result[""]) == ["README.md", "config.json"]
+
+
+def test_list_artifacts_grouped_with_directories(manager):
+    """Files inside directories should be grouped by directory name."""
+    root_file = MagicMock()
+    root_file.path = "README.md"
+    root_file.is_dir = False
+
+    model_dir = MagicMock()
+    model_dir.path = "model"
+    model_dir.is_dir = True
+
+    sub_file1 = MagicMock()
+    sub_file1.path = "model/model.pkl"
+    sub_file1.is_dir = False
+    sub_file2 = MagicMock()
+    sub_file2.path = "model/config.yaml"
+    sub_file2.is_dir = False
+
+    def list_artifacts(run_id, path=None):
+        if path == "model":
+            return [sub_file1, sub_file2]
+        return [root_file, model_dir]
+
+    manager.client.list_artifacts.side_effect = list_artifacts
+
+    result = manager.list_artifacts_grouped("run-1")
+
+    assert result[""] == ["README.md"]
+    assert sorted(result["model"]) == ["config.yaml", "model.pkl"]
+
+
+def test_list_artifacts_grouped_empty_run(manager):
+    """Empty run should return empty dict."""
+    manager.client.list_artifacts.return_value = []
+
+    result = manager.list_artifacts_grouped("run-1")
+
+    assert result == {}
+
+
+def test_list_artifacts_grouped_failure(manager):
+    """Errors from MLflow client should be wrapped as CogflowRunError."""
+    manager.client.list_artifacts.side_effect = RuntimeError("boom")
+    with pytest.raises(models_mod.CogflowRunError):
+        manager.list_artifacts_grouped("run-1")

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -148,6 +148,10 @@ def test_init_loads_k8s_config_once(monkeypatch):
     monkeypatch.setattr(common, "load_k8s_config", mock_load, raising=True)
     monkeypatch.setattr(common, "get_namespace", lambda: "ns", raising=True)
 
+    # Reset the loaded flag set by previous serving module imports
+    if hasattr(common, "_k8s_loaded_flag"):
+        monkeypatch.delattr(common, "_k8s_loaded_flag", raising=False)
+
     # Import serving module after patching
     import cogflow.core.serving as serving_module
 
@@ -291,6 +295,73 @@ def test_deploy_model_resolves_model_and_calls_create_isvc(
     transformer = body["spec"]["transformer"]
     env_list = transformer["containers"][0]["env"]
     assert {"name": "A", "value": "1"} in env_list
+
+
+def test_deploy_model_with_model_type(monkeypatch, serving, serving_module):
+    """
+    deploy_model should set model_type as an ISVC annotation when provided.
+    """
+    _, fake_api, _ = serving_module
+
+    def fake_get_model_details(**_):
+        return {
+            "model_uri": "s3://bucket/model",
+            "model_name": "n1",
+            "model_version": "v1",
+            "model_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+    monkeypatch.setattr(
+        serving,
+        "_get_model_helpers",
+        lambda: (lambda **_: "onnx", fake_get_model_details),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        serving, "_get_transformer_env", lambda *args, **kwargs: {}, raising=True
+    )
+
+    serving.deploy_model(
+        model_id="11111111-1111-1111-1111-111111111111",
+        isvc_name="myisvc",
+        namespace="test-namespace",
+        model_type="llm",
+    )
+
+    create_calls = [c for c in fake_api.calls if c[0] == "create"]
+    annotations = create_calls[0][1]["body"]["metadata"]["annotations"]
+    assert annotations["model_type"] == "llm"
+
+
+def test_deploy_model_without_model_type(monkeypatch, serving, serving_module):
+    """
+    deploy_model should NOT set model_type annotation when not provided.
+    """
+    _, fake_api, _ = serving_module
+
+    def fake_get_model_details(**_):
+        return {
+            "model_uri": "s3://bucket/model",
+            "model_name": "n1",
+            "model_version": "v1",
+            "model_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+    monkeypatch.setattr(
+        serving,
+        "_get_model_helpers",
+        lambda: (lambda **_: "onnx", fake_get_model_details),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        serving, "_get_transformer_env", lambda *args, **kwargs: {}, raising=True
+    )
+
+    serving.deploy_model(model_id="11111111-1111-1111-1111-111111111111")
+
+    create_calls = [c for c in fake_api.calls if c[0] == "create"]
+    annotations = create_calls[0][1]["body"]["metadata"]["annotations"]
+    assert "model_type" not in annotations
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add missing APIs needed for Cog-Engine migration from cogflow 1.x to 2.0
- Add GitHub Actions workflow for automated build and release

### Models
- `get_run()`, `get_run_artifact_uri()`, `list_artifacts_grouped()` for MLflow run/artifact access

### Serving
- `model_type` annotation support in `deploy_model()` and `update_model()`
- `AsyncServingManager` using `kubernetes_asyncio` for non-blocking K8s ops
- Async variants: `async_deploy_model`, `async_list_models`, `async_delete_isvc`, etc.

### Pipelines
- Pipeline query functions: `list_pipelines_by_name`, `get_pipeline_task_sequence*`, `get_task_structure_by_task_id`
- Pod inspection: `get_pod_definition`, `get_pod_events`, `get_pod_logs`, `get_inference_service_logs` (sync + async)
- `list_all_kfp_runs` with pagination

### CI/CD
- `release.yml` workflow: builds, tests, uploads artifacts on `release/**` branch push; creates GitHub Release on `v*` tag push

### Dependencies
- Added `kubernetes_asyncio`

## Test plan
- [x] All 171 tests pass (1 skipped)
- [x] GitHub Actions workflow runs successfully
- [x] Build artifacts uploaded