### PR TITLE
Vendor kfp 1.8.24 to support pydantic 2 downstreams

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,36 @@
+cogflow
+=======
+
+Copyright (c) HIRO Microdatacenters BV.
+Distributed under the MIT License (see LICENSE.md).
+
+This product vendors third-party software:
+
+----------------------------------------------------------------------
+Kubeflow Pipelines SDK (kfp)
+----------------------------------------------------------------------
+Source:    https://github.com/kubeflow/pipelines
+Version:   1.8.24
+Location:  ./kfp/
+License:   Apache License, Version 2.0
+           See ./kfp/LICENSE for the full text.
+
+cogflow vendors a copy of the kfp 1.8.24 SDK in the top-level `kfp/`
+directory so that it ships under the same `kfp` import name without
+forcing kfp's transitive `pydantic<2` dependency on cogflow consumers.
+The vendored source is unmodified except for this NOTICE.
+
+Original copyright:
+    Copyright 2018-2024 The Kubeflow Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b1"
+__version__ = "2.0.1b2"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/config.py
+++ b/cogflow/config.py
@@ -6,14 +6,20 @@ Centralized configuration for CogFlow — environment-driven via Pydantic.
 Environment variables always take precedence; defaults are used otherwise.
 
 Compatible with:
-  • Pydantic 1.x  ✅  (required by KFP 1.8.22)
-  • Python 3.11
+  • Pydantic 1.x and 2.x  ✅
+  • Python 3.10+
 """
 
 import logging
 from functools import lru_cache
 from typing import Optional
-from pydantic import BaseSettings, Field
+
+from pydantic import Field
+
+try:
+    from pydantic_settings import BaseSettings  # pydantic 2
+except ImportError:  # pydantic 1
+    from pydantic import BaseSettings  # type: ignore[no-redef,assignment]
 
 
 # ----------------------------------------------------------------------
@@ -98,7 +104,7 @@ class CogFlowSettings(BaseSettings):
     RETRY_BACKOFF_MAX: int = 10
 
     # ---------- Component Storage ----------
-    COMPONENTS_BUCKET_NAME = "components"
+    COMPONENTS_BUCKET_NAME: str = "components"
 
     # ---------- Config behavior ----------
     class Config:

--- a/kfp/LICENSE
+++ b/kfp/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kfp/__init__.py
+++ b/kfp/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `kfp` is a namespace package.
+# https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+__version__ = '1.8.24'
+
+from . import components
+from . import containers
+from . import dsl
+from . import auth
+from ._client import Client
+from ._config import *
+from ._local_client import LocalClient
+from ._runners import *

--- a/kfp/__main__.py
+++ b/kfp/__main__.py
@@ -1,0 +1,22 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cli.cli import main
+
+# TODO(hongyes): add more commands:
+# kfp compile (migrate from dsl-compile)
+# kfp experiment (manage experiments)
+
+if __name__ == '__main__':
+    main()

--- a/kfp/_auth.py
+++ b/kfp/_auth.py
@@ -1,0 +1,517 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+import json
+import logging
+import os
+from typing import Any, Callable, Dict, Generator, Iterable, Tuple, Union
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+from webbrowser import open_new_tab
+import wsgiref.simple_server
+import wsgiref.util
+
+import google.auth
+import google.auth.app_engine
+import google.auth.compute_engine.credentials
+import google.auth.iam
+from google.auth.transport.requests import Request
+import google.oauth2.credentials
+import google.oauth2.service_account
+import requests
+
+IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
+OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
+LOCAL_KFP_CREDENTIAL = os.path.expanduser('~/.config/kfp/credentials.json')
+
+
+def get_gcp_access_token() -> Union[str, None]:
+    """Gets GCP access token for the current Application Default Credentials.
+
+    Returns:
+        GCP access token or None, if it is not set. For more information, see
+    https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token.
+    """
+    token = None
+    try:
+        creds, _ = google.auth.default(
+            scopes=['https://www.googleapis.com/auth/cloud-platform'])
+        if not creds.valid:
+            auth_req = Request()
+            creds.refresh(auth_req)
+        if creds.valid:
+            token = creds.token
+    except Exception as err:
+        logging.warning('Failed to get GCP access token: %s', err)
+    return token
+
+
+def get_auth_token(client_id: str, other_client_id: str,
+                   other_client_secret: str) -> Tuple[Union[str, None], bool]:
+    """Gets auth token from default service account or user account.
+
+    Returns:
+        Tuple of (ID token or None, if not found, and a boolean
+        indicating whether a refresh token has been saved locally)
+    """
+    is_refresh_token = True
+    if os.path.exists(LOCAL_KFP_CREDENTIAL):
+        # fetch IAP auth token using the locally stored credentials.
+        with open(LOCAL_KFP_CREDENTIAL, 'r') as f:
+            credentials = json.load(f)
+        if client_id in credentials:
+            saved_refresh_token = credentials[client_id].get('refresh_token')
+            saved_other_client_id = credentials[client_id].get(
+                'other_client_id')
+            saved_other_client_secret = credentials[client_id].get(
+                'other_client_secret')
+            if None not in {
+                    saved_refresh_token, saved_other_client_id,
+                    saved_other_client_secret
+            }:
+                return id_token_from_refresh_token(saved_other_client_id,
+                                                   saved_other_client_secret,
+                                                   saved_refresh_token,
+                                                   client_id), is_refresh_token
+    if other_client_id is None or other_client_secret is None:
+        # fetch IAP auth token: service accounts
+        token = get_auth_token_from_sa(client_id)
+        is_refresh_token = False
+    else:
+        # fetch IAP auth token: user account
+        # Obtain the ID token for provided Client ID with user accounts.
+        # Flow: get authorization code -> exchange for refresh token -> obtain
+        # and return ID token
+        refresh_token, is_refresh_token = get_refresh_token_from_client_id(
+            other_client_id, other_client_secret)
+        credentials = {}
+        if os.path.exists(LOCAL_KFP_CREDENTIAL):
+            with open(LOCAL_KFP_CREDENTIAL, 'r') as f:
+                credentials = json.load(f)
+        credentials[client_id] = {}
+        credentials[client_id]['other_client_id'] = other_client_id
+        credentials[client_id]['other_client_secret'] = other_client_secret
+        if is_refresh_token:
+            credentials[client_id]['refresh_token'] = refresh_token
+        else:
+            credentials[client_id]['access_token'] = refresh_token
+        # TODO: handle the case when the refresh_token expires, which only
+        # happens if the refresh_token is not used once for six months.
+        if not os.path.exists(os.path.dirname(LOCAL_KFP_CREDENTIAL)):
+            os.makedirs(os.path.dirname(LOCAL_KFP_CREDENTIAL))
+        with open(LOCAL_KFP_CREDENTIAL, 'w') as f:
+            json.dump(credentials, f)
+        token = id_token_from_refresh_token(other_client_id,
+                                            other_client_secret, refresh_token,
+                                            client_id)
+    return token, is_refresh_token
+
+
+def get_auth_token_from_sa(client_id: str) -> Union[str, None]:
+    """Gets auth token from default service account.
+
+    Returns:
+        Authorization token or None, if not found.
+    """
+    service_account_credentials = get_service_account_credentials(client_id)
+    if service_account_credentials:
+        return get_google_open_id_connect_token(service_account_credentials)
+    return None
+
+
+def get_service_account_credentials(
+        client_id: str
+) -> Union[google.oauth2.service_account.Credentials, None]:
+    """Figure out what environment we're running in and get some preliminary
+    information about the service account.
+
+    Args:
+        client_id: OAuth client ID.
+
+    Returns:
+        OAuth2 credentials or None.
+    """
+    bootstrap_credentials, _ = google.auth.default(scopes=[IAM_SCOPE])
+    if isinstance(bootstrap_credentials, google.oauth2.credentials.Credentials):
+        logging.info('Found OAuth2 credentials and skip SA auth.')
+        return None
+    if isinstance(bootstrap_credentials, google.auth.app_engine.Credentials):
+        # import requests_toolbelt.adapters.appengine here for those who run KFP
+        # in an environment where urllib3<2.0.0 (https://github.com/kubeflow/pipelines/blob/9f278f3682662b24b46be2d9ef4a783bcc1f9b0c/sdk/python/requirements.in#L25C14-L25C14)
+        # is not available, preventing breaks due to https://github.com/kubeflow/pipelines/issues/9326#issuecomment-1535491761
+        # whenever the user runs `import kfp`.
+        # by putting the import statement here, only those invoking the KFP SDK client
+        # from within App Engine are strictly required to have urllib3<2.0.0.
+        import requests_toolbelt.adapters.appengine
+        requests_toolbelt.adapters.appengine.monkeypatch()
+    # For service account's using the Compute Engine metadata service,
+    # service_account_email isn't available until refresh is called.
+    bootstrap_credentials.refresh(Request())
+    signer_email = bootstrap_credentials.service_account_email
+    if isinstance(bootstrap_credentials,
+                  google.auth.compute_engine.credentials.Credentials):
+        # Since the Compute Engine metadata service doesn't expose the service
+        # account key, we use the IAM signBlob API to sign instead.
+        # In order for this to work:
+        #
+        # 1. Your VM needs the https://www.googleapis.com/auth/iam scope.
+        #    You can specify this specific scope when creating a VM
+        #    through the API or gcloud. When using Cloud Console,
+        #    you'll need to specify the "full access to all Cloud APIs"
+        #    scope. A VM's scopes can only be specified at creation time.
+        #
+        # 2. The VM's default service account needs the "Service Account Actor"
+        #    role. This can be found under the "Project" category in Cloud
+        #    Console, or roles/iam.serviceAccountActor in gcloud.
+        signer = google.auth.iam.Signer(Request(), bootstrap_credentials,
+                                        signer_email)
+    else:
+        # A Signer object can sign a JWT using the service account's key.
+        signer = bootstrap_credentials.signer
+    # Construct OAuth 2.0 service account credentials using the signer
+    # and email acquired from the bootstrap credentials.
+    return google.oauth2.service_account.Credentials(
+        signer,
+        signer_email,
+        token_uri=OAUTH_TOKEN_URI,
+        additional_claims={'target_audience': client_id})
+
+
+def get_google_open_id_connect_token(
+    service_account_credentials: google.oauth2.service_account.Credentials
+) -> str:
+    """Gets an OpenID Connect token issued by Google for the service account.
+
+    This function:
+      1. Generates a JWT signed with the service account's private key
+         containing a special "target_audience" claim.
+      2. Sends it to the OAUTH_TOKEN_URI endpoint. Because the JWT in #1
+         has a target_audience claim, that endpoint will respond with
+         an OpenID Connect token for the service account -- in other words,
+         a JWT signed by *Google*. The aud claim in this JWT will be
+         set to the value from the target_audience claim in #1.
+    For more information, see
+    https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+    The HTTP/REST example on that page describes the JWT structure and
+    demonstrates how to call the token endpoint. (The example on that page
+    shows how to get an OAuth2 access token; this code is using a
+    modified version of it to get an OpenID Connect token).
+
+    Returns:
+        OAuth ID token.
+    """
+    service_account_jwt = (
+        service_account_credentials._make_authorization_grant_assertion())
+    request = google.auth.transport.requests.Request()
+    body = {
+        'assertion': service_account_jwt,
+        'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
+    }
+    token_response = google.oauth2._client._token_endpoint_request(
+        request, OAUTH_TOKEN_URI, body)
+    return token_response['id_token']
+
+
+def get_refresh_token_from_client_id(client_id: str,
+                                     client_secret: str) -> Tuple[str, bool]:
+    """Obtains the ID token for provided Client ID with user accounts.
+    Flow: get authorization code -> exchange for refresh token -> obtain and
+    return ID token.
+
+    Args:
+        client_id: OAuth client ID.
+        client_secret: OAuth client secret.
+            See https://console.cloud.google.com/apis/credentials.
+
+    Returns:
+        Tuple of (OAuth short-lived access token or long-lived refresh token,
+        and a boolean indicating whether the returned token is refresh_token)
+    """
+    auth_code, redirect_uri = get_auth_code(client_id)
+    token, is_refresh_token = get_refresh_token_from_code(
+        auth_code, client_id, client_secret, redirect_uri)
+    return token, is_refresh_token
+
+
+def get_auth_code(client_id: str) -> Tuple[str, str]:
+    """Retrieves authorization token using Loopback flow.
+
+    Args:
+        client_id: OAuth client ID. To retrieve it, visit
+          https://console.cloud.google.com/apis/credentials.
+
+    Returns:
+        A tuple of (authorization token, redirect_uri parameter).
+
+    Raises:
+        ValueError: If the provided authorization_response is empty.
+    """
+    host = 'localhost'
+    port = 9901
+    redirect_uri = f'http://{host}:{port}'
+    auth_url = ('https://accounts.google.com/o/oauth2/v2/auth?'
+                f'client_id={client_id}&response_type=code&'
+                'scope=openid%20email&access_type=offline&'
+                f'redirect_uri={redirect_uri}')
+    authorization_response = None
+    if ('SSH_CONNECTION' in os.environ) or ('SSH_CLIENT' in os.environ):
+        try:
+            print((
+                'SSH connection detected. Please follow the instructions below.'
+                ' Otherwise, press CTRL+C if you are not connected via SSH.'))
+            authorization_response = get_auth_response_ssh(host, port, auth_url)
+        except KeyboardInterrupt:
+            authorization_response = None
+            logging.warning('User pressed CTRL+C. Trying to open browser...')
+    if authorization_response is None:
+        try:
+            print(('Using a local web-server. Please follow the instructions '
+                   'below. Otherwise, press CTRL+C to cancel and manually '
+                   'copy-paste the response URL.'))
+            authorization_response = get_auth_response_local(
+                host, port, auth_url)
+        except KeyboardInterrupt:
+            logging.warning('User pressed CTRL+C. See instructions below.')
+            authorization_response = get_auth_response_ssh(host, port, auth_url)
+        except OSError as err:
+            logging.warning(
+                ('%s.\n Error occurred while creating a local web-server. '
+                 'Possibly http://%s:%i is allocated to '
+                 'another process. Falling back to manual mode. '
+                 'See instructions below.'), err, host, port)
+            authorization_response = get_auth_response_ssh(host, port, auth_url)
+    if authorization_response is None:
+        raise ValueError(
+            'Authorization response URL is empty. This may be caused by '
+            f'corrupted or expired credentials in {LOCAL_KFP_CREDENTIAL}'
+            '. Try renaming or moving them to another directory before '
+            'running again.')
+    token = fetch_auth_token_from_response(authorization_response)
+    return token, redirect_uri
+
+
+def get_auth_response_ssh(host: str, port: int, auth_url: str) -> str:
+    """Fetches OAuth authorization response URL for remote SSH connection.
+
+    Args:
+        host: Hostname in redirect_uri.
+        port: Port in redirect_uri.
+        auth_url: OAuth request URL.
+
+    Returns:
+        A URL containing authorization code.
+    """
+    print(auth_url)
+    authorization_response = input(
+        'Carefully follow these steps: (1) open the URL above in your'
+        ' browser, (2) authenticate and copy a url of the response page'
+        f' that starts with http://{host}:{port}..., and (3) paste it'
+        ' below:\n')
+    return authorization_response
+
+
+def get_auth_response_local(host: str, port: int,
+                            auth_url: str) -> Union[str, None]:
+    """Fetches OAuth authorization response URL using a local web-server.
+
+    Args:
+        host: Hostname of the server.
+        port: Port of the server.
+        auth_url: OAuth request URL.
+
+    Returns:
+        A URL containing authorization code.
+    """
+    with get_local_server_app(host, port) as (local_server, wsgi_app):
+        open_new_tab(auth_url)
+        print(f'Please visit this URL to authorize Kubeflow SDK: {auth_url}')
+        print((f'Make sure that http://{host}:{port} is added to Authorized'
+               ' redirect URIs for your OAuth 2.0 Client ID. Check it here:'
+               ' https://console.cloud.google.com/apis/credentials'))
+        local_server.handle_request()
+        return wsgi_app.last_request_uri
+
+
+def get_refresh_token_from_code(auth_code: str, client_id: str,
+                                client_secret: str,
+                                redirect_uri: str) -> Tuple[str, bool]:
+    """Returns refresh or access token from authorization code.
+
+    Args:
+        auth_code: OAuth authorization code.
+        client_id: OAuth client ID.
+        client_secret: OAuth client secret.
+        redirect_uri: Redirect uri used to obtain auth_code.
+
+    Returns:
+        Tuple of (OAuth short-lived access token or long-lived refresh token,
+        and a boolean indicating whether the returned token is refresh_token)
+
+    Raises:
+        ValueError: If HTTP request returns
+            a requests.exceptions.HTTPError.
+    """
+    payload = {
+        'code': auth_code,
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'redirect_uri': redirect_uri,
+        'grant_type': 'authorization_code'
+    }
+    res = requests.post(OAUTH_TOKEN_URI, data=payload)
+    try:
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise ValueError(
+            ('Some HTTPErrors are caused by expired credentials in '
+             f'{LOCAL_KFP_CREDENTIAL} Try renaming or moving '
+             'them to another directory before running again.')) from err
+    parsed_res = json.loads(res.text)
+    token = parsed_res.get('refresh_token')
+    is_refresh_token = True
+    if token is None:
+        token = parsed_res.get('access_token')
+        is_refresh_token = False
+    return str(token), is_refresh_token
+
+
+def id_token_from_refresh_token(client_id: str, client_secret: str,
+                                refresh_token: str, audience: str) -> str:
+    """Returns ID token from refresh token.
+
+    Args:
+        client_id: OAuth client ID.
+        client_secret: OAuth client secret.
+        refresh_token: OAuth refresh token.
+        audience: OAuth audience.
+
+    Returns:
+        OAuth ID token.
+
+    Raises:
+        ValueError: If HTTP request returns
+            a requests.exceptions.HTTPError.
+    """
+    payload = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'refresh_token': refresh_token,
+        'grant_type': 'refresh_token',
+        'audience': audience
+    }
+    res = requests.post(OAUTH_TOKEN_URI, data=payload)
+    try:
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise ValueError(
+            ('Some HTTPErrors are caused by expired credentials in '
+             f'{LOCAL_KFP_CREDENTIAL}. Try renaming or moving '
+             'them to another directory before running again.')) from err
+    return str(json.loads(res.text).get('id_token'))
+
+
+class RedirectWSGIApp:
+    """WSGI app to handle the authorization redirect.
+
+    Stores the request URI and displays the given success message.
+    """
+
+    def __init__(self, success_message: str) -> None:
+        """
+        Args:
+            success_message: The message to display in the web browser
+                the authorization flow is complete.
+        """
+        self.last_request_uri = None
+        self._success_message = success_message
+
+    def __call__(
+        self, environ: Dict[str, Any], start_response: Callable[[str, list],
+                                                                Callable[...,
+                                                                         None]]
+    ) -> Iterable[bytes]:
+        """WSGI Callable. Updates environment dictionary with parameters
+        required for WSGI and returns it.
+
+        Args:
+            environ: The WSGI environment.
+            start_response: The WSGI start_response
+                callable.
+
+        Returns:
+            The response body.
+        """
+        wsgiref.util.setup_testing_defaults(environ)
+        start_response('200 OK',
+                       [('Content-type', 'text/plain; charset=utf-8')])
+        self.last_request_uri = wsgiref.util.request_uri(environ)
+        return [self._success_message.encode('utf-8')]
+
+
+@contextmanager
+def get_local_server_app(
+    host: str, port: int
+) -> Generator[Tuple[wsgiref.simple_server.WSGIServer, RedirectWSGIApp], None,
+               None]:
+    """Creates a local web-server for given host and port.
+
+    Args:
+        host: Hostname of the server.
+        port: Port of the server.
+
+    Returns:
+        Tuple of (a local server instance, WSGI app that handles
+            the authorization redirect).
+    """
+    success_message = ('Kubeflow SDK authentication is completed.'
+                       ' You may close this window now.')
+    wsgi_app = RedirectWSGIApp(success_message)
+    wsgiref.simple_server.WSGIServer.allow_reuse_address = False
+    local_server = wsgiref.simple_server.make_server(
+        host,
+        port,
+        wsgi_app,
+        handler_class=wsgiref.simple_server.WSGIRequestHandler)
+    try:
+        yield local_server, wsgi_app
+    finally:
+        local_server.server_close()
+        del wsgi_app
+
+
+def fetch_auth_token_from_response(url: str) -> str:
+    """Fetches authorization code for OAuth2.0 Loopback flow.
+
+    Args:
+        url: A string containing the response URL.
+
+    Returns:
+        An access code.
+
+    Raises:
+        KeyError: If no authorization code is found in the provided url.
+    """
+    parsed_url = urlparse(url)
+    parsed_query = parse_qs(parsed_url.query)
+    access_code = parsed_query.get('code')
+    if access_code is None:
+        raise KeyError((
+            'Authorization code is missing or empty in the response.'
+            ' Please, try again or check '
+            'https://www.kubeflow.org/docs/distributions/gke/deploy/oauth-setup'
+        ))
+    if isinstance(access_code, list):
+        access_code = str(access_code.pop(0))
+    return access_code

--- a/kfp/_client.py
+++ b/kfp/_client.py
@@ -1,0 +1,1444 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import datetime
+import json
+import logging
+import os
+import re
+import tarfile
+import tempfile
+import time
+from typing import Callable, Mapping, Optional
+import warnings
+import zipfile
+
+from kfp import dsl
+from kfp._auth import get_auth_token
+from kfp._auth import get_gcp_access_token
+from kfp.compiler import compiler
+from kfp.compiler._k8s_helper import sanitize_k8s_name
+import kfp_server_api
+from kfp_server_api import ApiException
+import yaml
+
+# Operators on scalar values. Only applies to one of |int_value|,
+# |long_value|, |string_value| or |timestamp_value|.
+_FILTER_OPERATIONS = {
+    'UNKNOWN': 0,
+    'EQUALS': 1,
+    'NOT_EQUALS': 2,
+    'GREATER_THAN': 3,
+    'GREATER_THAN_EQUALS': 5,
+    'LESS_THAN': 6,
+    'LESS_THAN_EQUALS': 7
+}
+
+
+def _add_generated_apis(target_struct, api_module, api_client):
+    """Initializes a hierarchical API object based on the generated API module.
+
+    PipelineServiceApi.create_pipeline becomes
+    target_struct.pipelines.create_pipeline
+    """
+    Struct = type('Struct', (), {})
+
+    def camel_case_to_snake_case(name):
+        import re
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+
+    for api_name in dir(api_module):
+        if not api_name.endswith('ServiceApi'):
+            continue
+
+        short_api_name = camel_case_to_snake_case(
+            api_name[0:-len('ServiceApi')]) + 's'
+        api_struct = Struct()
+        setattr(target_struct, short_api_name, api_struct)
+        service_api = getattr(api_module.api, api_name)
+        initialized_service_api = service_api(api_client)
+        for member_name in dir(initialized_service_api):
+            if member_name.startswith('_') or member_name.endswith(
+                    '_with_http_info'):
+                continue
+
+            bound_member = getattr(initialized_service_api, member_name)
+            setattr(api_struct, member_name, bound_member)
+    models_struct = Struct()
+    for member_name in dir(api_module.models):
+        if not member_name[0].islower():
+            setattr(models_struct, member_name,
+                    getattr(api_module.models, member_name))
+    target_struct.api_models = models_struct
+
+
+KF_PIPELINES_ENDPOINT_ENV = 'KF_PIPELINES_ENDPOINT'
+KF_PIPELINES_UI_ENDPOINT_ENV = 'KF_PIPELINES_UI_ENDPOINT'
+KF_PIPELINES_DEFAULT_EXPERIMENT_NAME = 'KF_PIPELINES_DEFAULT_EXPERIMENT_NAME'
+KF_PIPELINES_OVERRIDE_EXPERIMENT_NAME = 'KF_PIPELINES_OVERRIDE_EXPERIMENT_NAME'
+KF_PIPELINES_IAP_OAUTH2_CLIENT_ID_ENV = 'KF_PIPELINES_IAP_OAUTH2_CLIENT_ID'
+KF_PIPELINES_APP_OAUTH2_CLIENT_ID_ENV = 'KF_PIPELINES_APP_OAUTH2_CLIENT_ID'
+KF_PIPELINES_APP_OAUTH2_CLIENT_SECRET_ENV = 'KF_PIPELINES_APP_OAUTH2_CLIENT_SECRET'
+
+
+class Client(object):
+    """API Client for KubeFlow Pipeline.
+
+    Args:
+      host: The host name to use to talk to Kubeflow Pipelines. If not set, the in-cluster
+          service DNS name will be used, which only works if the current environment is a pod
+          in the same cluster (such as a Jupyter instance spawned by Kubeflow's
+          JupyterHub). If you have a different connection to cluster, such as a kubectl
+          proxy connection, then set it to something like "127.0.0.1:8080/pipeline.
+          If you connect to an IAP enabled cluster, set it to
+          https://<your-deployment>.endpoints.<your-project>.cloud.goog/pipeline".
+      client_id: The client ID used by Identity-Aware Proxy.
+      namespace: The namespace where the kubeflow pipeline system is run.
+      other_client_id: The client ID used to obtain the auth codes and refresh tokens.
+          Reference: https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_desktop_app.
+      other_client_secret: The client secret used to obtain the auth codes and refresh tokens.
+      existing_token: Pass in token directly, it's used for cases better get token outside of SDK, e.x. GCP Cloud Functions
+          or caller already has a token
+      cookies: CookieJar object containing cookies that will be passed to the pipelines API.
+      proxy: HTTP or HTTPS proxy server
+      ssl_ca_cert: Cert for proxy
+      kube_context: String name of context within kubeconfig to use, defaults to the current-context set within kubeconfig.
+      credentials: A TokenCredentialsBase object which provides the logic to
+          populate the requests with credentials to authenticate against the API
+          server.
+      ui_host: Base url to use to open the Kubeflow Pipelines UI. This is used when running the client from a notebook to generate and
+          print links.
+    """
+
+    # in-cluster DNS name of the pipeline service
+    IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
+    KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
+
+    # Auto populated path in pods
+    # https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+    # https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller
+    NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+    LOCAL_KFP_CONTEXT = os.path.expanduser('~/.config/kfp/context.json')
+
+    # TODO: Wrap the configurations for different authentication methods.
+    def __init__(self,
+                 host=None,
+                 client_id=None,
+                 namespace='kubeflow',
+                 other_client_id=None,
+                 other_client_secret=None,
+                 existing_token=None,
+                 cookies=None,
+                 proxy=None,
+                 ssl_ca_cert=None,
+                 kube_context=None,
+                 credentials=None,
+                 ui_host=None):
+        """Create a new instance of kfp client."""
+        host = host or os.environ.get(KF_PIPELINES_ENDPOINT_ENV)
+        self._uihost = os.environ.get(KF_PIPELINES_UI_ENDPOINT_ENV, ui_host or
+                                      host)
+        client_id = client_id or os.environ.get(
+            KF_PIPELINES_IAP_OAUTH2_CLIENT_ID_ENV)
+        other_client_id = other_client_id or os.environ.get(
+            KF_PIPELINES_APP_OAUTH2_CLIENT_ID_ENV)
+        other_client_secret = other_client_secret or os.environ.get(
+            KF_PIPELINES_APP_OAUTH2_CLIENT_SECRET_ENV)
+
+        config = self._load_config(host, client_id, namespace, other_client_id,
+                                   other_client_secret, existing_token, proxy,
+                                   ssl_ca_cert, kube_context, credentials)
+        # Save the loaded API client configuration, as a reference if update is
+        # needed.
+        self._load_context_setting_or_default()
+
+        # If custom namespace provided, overwrite the loaded or default one in
+        # context settings for current client instance
+        if namespace != 'kubeflow':
+            self._context_setting['namespace'] = namespace
+
+        self._existing_config = config
+        if cookies is None:
+            cookies = self._context_setting.get('client_authentication_cookie')
+        api_client = kfp_server_api.api_client.ApiClient(
+            config,
+            cookie=cookies,
+            header_name=self._context_setting.get(
+                'client_authentication_header_name'),
+            header_value=self._context_setting.get(
+                'client_authentication_header_value'))
+        _add_generated_apis(self, kfp_server_api, api_client)
+        self._job_api = kfp_server_api.api.job_service_api.JobServiceApi(
+            api_client)
+        self._run_api = kfp_server_api.api.run_service_api.RunServiceApi(
+            api_client)
+        self._experiment_api = kfp_server_api.api.experiment_service_api.ExperimentServiceApi(
+            api_client)
+        self._pipelines_api = kfp_server_api.api.pipeline_service_api.PipelineServiceApi(
+            api_client)
+        self._upload_api = kfp_server_api.api.PipelineUploadServiceApi(
+            api_client)
+        self._healthz_api = kfp_server_api.api.healthz_service_api.HealthzServiceApi(
+            api_client)
+        if not self._context_setting['namespace'] and self.get_kfp_healthz(
+        ).multi_user is True:
+            try:
+                with open(Client.NAMESPACE_PATH, 'r') as f:
+                    current_namespace = f.read()
+                    self.set_user_namespace(current_namespace)
+            except FileNotFoundError:
+                logging.info(
+                    'Failed to automatically set namespace.', exc_info=False)
+
+    def _load_config(self, host, client_id, namespace, other_client_id,
+                     other_client_secret, existing_token, proxy, ssl_ca_cert,
+                     kube_context, credentials):
+        config = kfp_server_api.configuration.Configuration()
+
+        if proxy:
+            # https://github.com/kubeflow/pipelines/blob/c6ac5e0b1fd991e19e96419f0f508ec0a4217c29/backend/api/python_http_client/kfp_server_api/rest.py#L100
+            config.proxy = proxy
+
+        if ssl_ca_cert:
+            config.ssl_ca_cert = ssl_ca_cert
+
+        host = host or ''
+
+        # Defaults to 'https' if host does not contain 'http' or 'https' protocol.
+        if host and not host.startswith('http'):
+            warnings.warn(
+                'The host %s does not contain the "http" or "https" protocol.'
+                ' Defaults to "https".' % host)
+            host = 'https://' + host
+
+        # Preprocess the host endpoint to prevent some common user mistakes.
+        if not client_id:
+            # always preserving the protocol (http://localhost requires it)
+            host = host.rstrip('/')
+
+        if host:
+            config.host = host
+
+        token = None
+
+        # "existing_token" is designed to accept token generated outside of SDK. Here is an example.
+        #
+        # https://cloud.google.com/functions/docs/securing/function-identity
+        # https://cloud.google.com/endpoints/docs/grpc/service-account-authentication
+        #
+        # import requests
+        # import kfp
+        #
+        # def get_access_token():
+        #     url = 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token'
+        #     r = requests.get(url, headers={'Metadata-Flavor': 'Google'})
+        #     r.raise_for_status()
+        #     access_token = r.json()['access_token']
+        #     return access_token
+        #
+        # client = kfp.Client(host='<KFPHost>', existing_token=get_access_token())
+        #
+        if existing_token:
+            token = existing_token
+            self._is_refresh_token = False
+        elif client_id:
+            token, self._is_refresh_token = get_auth_token(
+                client_id, other_client_id, other_client_secret)
+            self._is_refresh_token = True
+        elif self._is_inverse_proxy_host(host):
+            token = get_gcp_access_token()
+            self._is_refresh_token = False
+        elif credentials:
+            config.api_key['authorization'] = 'placeholder'
+            config.api_key_prefix['authorization'] = 'Bearer'
+            config.refresh_api_key_hook = credentials.refresh_api_key_hook
+
+        if token:
+            config.api_key['authorization'] = token
+            config.api_key_prefix['authorization'] = 'Bearer'
+            return config
+
+        if host:
+            # if host is explicitly set with auth token, it's probably a port forward address.
+            return config
+
+        import kubernetes as k8s
+        in_cluster = True
+        try:
+            k8s.config.load_incluster_config()
+        except:
+            in_cluster = False
+            pass
+
+        if in_cluster:
+            config.host = Client.IN_CLUSTER_DNS_NAME.format(namespace)
+            config = self._get_config_with_default_credentials(config)
+            return config
+
+        try:
+            k8s.config.load_kube_config(
+                client_configuration=config, context=kube_context)
+        except:
+            print('Failed to load kube config.')
+            return config
+
+        if config.host:
+            config.host = config.host + '/' + Client.KUBE_PROXY_PATH.format(
+                namespace)
+        return config
+
+    def _is_inverse_proxy_host(self, host):
+        if host:
+            return re.match(r'\S+.googleusercontent.com/{0,1}$', host)
+        if re.match(r'\w+', host):
+            warnings.warn(
+                'The received host is %s, please include the full endpoint address '
+                '(with ".(pipelines/notebooks).googleusercontent.com")' % host)
+        return False
+
+    def _is_ipython(self):
+        """Returns whether we are running in notebook."""
+        try:
+            import IPython
+            ipy = IPython.get_ipython()
+            if ipy is None:
+                return False
+        except ImportError:
+            return False
+
+        return True
+
+    def _get_url_prefix(self):
+        if self._uihost:
+            # User's own connection.
+            if self._uihost.startswith('http://') or self._uihost.startswith(
+                    'https://'):
+                return self._uihost
+            else:
+                return 'http://' + self._uihost
+
+        # In-cluster pod. We could use relative URL.
+        return '/pipeline'
+
+    def _load_context_setting_or_default(self):
+        if os.path.exists(Client.LOCAL_KFP_CONTEXT):
+            with open(Client.LOCAL_KFP_CONTEXT, 'r') as f:
+                self._context_setting = json.load(f)
+        else:
+            self._context_setting = {
+                'namespace': '',
+            }
+
+    def _refresh_api_client_token(self):
+        """Refreshes the existing token associated with the kfp_api_client."""
+        if getattr(self, '_is_refresh_token', None):
+            return
+
+        new_token = get_gcp_access_token()
+        self._existing_config.api_key['authorization'] = new_token
+
+    def _get_config_with_default_credentials(self, config):
+        """Apply default credentials to the configuration object.
+
+        This method accepts a Configuration object and extends it with
+        some default credentials interface.
+        """
+        # XXX: The default credentials are audience-based service account tokens
+        # projected by the kubelet (ServiceAccountTokenVolumeCredentials). As we
+        # implement more and more credentials, we can have some heuristic and
+        # choose from a number of options.
+        # See https://github.com/kubeflow/pipelines/pull/5287#issuecomment-805654121
+        from kfp import auth
+        credentials = auth.ServiceAccountTokenVolumeCredentials()
+        config_copy = copy.deepcopy(config)
+
+        try:
+            credentials.refresh_api_key_hook(config_copy)
+        except Exception:
+            logging.warning('Failed to set up default credentials. Proceeding'
+                            ' without credentials...')
+            return config
+
+        config.refresh_api_key_hook = credentials.refresh_api_key_hook
+        config.api_key_prefix['authorization'] = 'Bearer'
+        config.refresh_api_key_hook(config)
+        return config
+
+    def set_user_namespace(self, namespace: str):
+        """Set user namespace into local context setting file.
+
+        This function should only be used when Kubeflow Pipelines is in the multi-user mode.
+
+        Args:
+          namespace: kubernetes namespace the user has access to.
+        """
+        self._context_setting['namespace'] = namespace
+        if not os.path.exists(os.path.dirname(Client.LOCAL_KFP_CONTEXT)):
+            os.makedirs(os.path.dirname(Client.LOCAL_KFP_CONTEXT))
+        with open(Client.LOCAL_KFP_CONTEXT, 'w') as f:
+            json.dump(self._context_setting, f)
+
+    def get_kfp_healthz(self) -> kfp_server_api.ApiGetHealthzResponse:
+        """Gets healthz info of KFP deployment.
+
+        Returns:
+          response: json formatted response from the healtz endpoint.
+        """
+        count = 0
+        response = None
+        max_attempts = 5
+        while not response:
+            count += 1
+            if count > max_attempts:
+                raise TimeoutError(
+                    'Failed getting healthz endpoint after {} attempts.'.format(
+                        max_attempts))
+            try:
+                response = self._healthz_api.get_healthz()
+                return response
+            # ApiException, including network errors, is the only type that may
+            # recover after retry.
+            except kfp_server_api.ApiException:
+                # logging.exception also logs detailed info about the ApiException
+                logging.exception(
+                    'Failed to get healthz info attempt {} of 5.'.format(count))
+                time.sleep(5)
+
+    def get_user_namespace(self) -> str:
+        """Get user namespace in context config.
+
+        Returns:
+          namespace: kubernetes namespace from the local context file or empty if it wasn't set.
+        """
+        return self._context_setting['namespace']
+
+    def create_experiment(
+            self,
+            name: str,
+            description: str = None,
+            namespace: str = None) -> kfp_server_api.ApiExperiment:
+        """Create a new experiment.
+
+        Args:
+          name: The name of the experiment.
+          description: Description of the experiment.
+          namespace: Kubernetes namespace where the experiment should be created.
+            For single user deployment, leave it as None;
+            For multi user, input a namespace where the user is authorized.
+
+        Returns:
+          An Experiment object. Most important field is id.
+        """
+        namespace = namespace or self.get_user_namespace()
+        experiment = None
+        try:
+            experiment = self.get_experiment(
+                experiment_name=name, namespace=namespace)
+        except ValueError as error:
+            # Ignore error if the experiment does not exist.
+            if not str(error).startswith('No experiment is found with name'):
+                raise error
+
+        if not experiment:
+            logging.info('Creating experiment {}.'.format(name))
+
+            resource_references = []
+            if namespace:
+                key = kfp_server_api.models.ApiResourceKey(
+                    id=namespace,
+                    type=kfp_server_api.models.ApiResourceType.NAMESPACE)
+                reference = kfp_server_api.models.ApiResourceReference(
+                    key=key,
+                    relationship=kfp_server_api.models.ApiRelationship.OWNER)
+                resource_references.append(reference)
+
+            experiment = kfp_server_api.models.ApiExperiment(
+                name=name,
+                description=description,
+                resource_references=resource_references)
+            experiment = self._experiment_api.create_experiment(body=experiment)
+
+        if self._is_ipython():
+            import IPython
+            html = \
+                ('<a href="%s/#/experiments/details/%s" target="_blank" >Experiment details</a>.'
+                % (self._get_url_prefix(), experiment.id))
+            IPython.display.display(IPython.display.HTML(html))
+        return experiment
+
+    def get_pipeline_id(self, name) -> Optional[str]:
+        """Find the id of a pipeline by name.
+
+        Args:
+          name: Pipeline name.
+
+        Returns:
+          Returns the pipeline id if a pipeline with the name exists.
+        """
+        pipeline_filter = json.dumps({
+            'predicates': [{
+                'op': _FILTER_OPERATIONS['EQUALS'],
+                'key': 'name',
+                'stringValue': name,
+            }]
+        })
+        result = self._pipelines_api.list_pipelines(filter=pipeline_filter)
+        if result.pipelines is None:
+            return None
+        if len(result.pipelines) == 1:
+            return result.pipelines[0].id
+        elif len(result.pipelines) > 1:
+            raise ValueError(
+                'Multiple pipelines with the name: {} found, the name needs to be unique'
+                .format(name))
+        return None
+
+    def list_experiments(
+            self,
+            page_token='',
+            page_size=10,
+            sort_by='',
+            namespace=None,
+            filter=None) -> kfp_server_api.ApiListExperimentsResponse:
+        """List experiments.
+
+        Args:
+          page_token: Token for starting of the page.
+          page_size: Size of the page.
+          sort_by: Can be '[field_name]', '[field_name] desc'. For example, 'name desc'.
+          namespace: Kubernetes namespace where the experiment was created.
+            For single user deployment, leave it as None;
+            For multi user, input a namespace where the user is authorized.
+          filter: A url-encoded, JSON-serialized Filter protocol buffer
+            (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+
+        Returns:
+          A response object including a list of experiments and next page token.
+        """
+        namespace = namespace or self.get_user_namespace()
+        response = self._experiment_api.list_experiment(
+            page_token=page_token,
+            page_size=page_size,
+            sort_by=sort_by,
+            resource_reference_key_type=kfp_server_api.models.api_resource_type
+            .ApiResourceType.NAMESPACE,
+            resource_reference_key_id=namespace,
+            filter=filter)
+        return response
+
+    def get_experiment(self,
+                       experiment_id=None,
+                       experiment_name=None,
+                       namespace=None) -> kfp_server_api.ApiExperiment:
+        """Get details of an experiment.
+
+        Either experiment_id or experiment_name is required
+
+        Args:
+          experiment_id: Id of the experiment. (Optional)
+          experiment_name: Name of the experiment. (Optional)
+          namespace: Kubernetes namespace where the experiment was created.
+            For single user deployment, leave it as None;
+            For multi user, input the namespace where the user is authorized.
+
+        Returns:
+          A response object including details of a experiment.
+
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found or None of the arguments is provided
+        """
+        namespace = namespace or self.get_user_namespace()
+        if experiment_id is None and experiment_name is None:
+            raise ValueError(
+                'Either experiment_id or experiment_name is required')
+        if experiment_id is not None:
+            return self._experiment_api.get_experiment(id=experiment_id)
+        experiment_filter = json.dumps({
+            'predicates': [{
+                'op': _FILTER_OPERATIONS['EQUALS'],
+                'key': 'name',
+                'stringValue': experiment_name,
+            }]
+        })
+        if namespace:
+            result = self._experiment_api.list_experiment(
+                filter=experiment_filter,
+                resource_reference_key_type=kfp_server_api.models
+                .api_resource_type.ApiResourceType.NAMESPACE,
+                resource_reference_key_id=namespace)
+        else:
+            result = self._experiment_api.list_experiment(
+                filter=experiment_filter)
+        if not result.experiments:
+            raise ValueError(
+                'No experiment is found with name {}.'.format(experiment_name))
+        if len(result.experiments) > 1:
+            raise ValueError(
+                'Multiple experiments is found with name {}.'.format(
+                    experiment_name))
+        return result.experiments[0]
+
+    def archive_experiment(self, experiment_id: str):
+        """Archive experiment.
+
+        Args:
+          experiment_id: id of the experiment.
+
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found.
+        """
+        self._experiment_api.archive_experiment(experiment_id)
+
+    def delete_experiment(self, experiment_id):
+        """Delete experiment.
+
+        Args:
+          experiment_id: id of the experiment.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found.
+        """
+        return self._experiment_api.delete_experiment(id=experiment_id)
+
+    def _extract_pipeline_yaml(self, package_file):
+
+        def _choose_pipeline_yaml_file(file_list) -> str:
+            yaml_files = [file for file in file_list if file.endswith('.yaml')]
+            if len(yaml_files) == 0:
+                raise ValueError(
+                    'Invalid package. Missing pipeline yaml file in the package.'
+                )
+
+            if 'pipeline.yaml' in yaml_files:
+                return 'pipeline.yaml'
+            else:
+                if len(yaml_files) == 1:
+                    return yaml_files[0]
+                raise ValueError(
+                    'Invalid package. There is no pipeline.yaml file and there are multiple yaml files.'
+                )
+
+        if package_file.endswith('.tar.gz') or package_file.endswith('.tgz'):
+            with tarfile.open(package_file, 'r:gz') as tar:
+                file_names = [member.name for member in tar if member.isfile()]
+                pipeline_yaml_file = _choose_pipeline_yaml_file(file_names)
+                with tar.extractfile(tar.getmember(pipeline_yaml_file)) as f:
+                    return yaml.safe_load(f)
+        elif package_file.endswith('.zip'):
+            with zipfile.ZipFile(package_file, 'r') as zip:
+                pipeline_yaml_file = _choose_pipeline_yaml_file(zip.namelist())
+                with zip.open(pipeline_yaml_file) as f:
+                    return yaml.safe_load(f)
+        elif package_file.endswith('.yaml') or package_file.endswith('.yml'):
+            with open(package_file, 'r') as f:
+                return yaml.safe_load(f)
+        else:
+            raise ValueError(
+                'The package_file ' + package_file +
+                ' should end with one of the following formats: [.tar.gz, .tgz, .zip, .yaml, .yml]'
+            )
+
+    def _override_caching_options(self, workflow: dict, enable_caching: bool):
+        templates = workflow['spec']['templates']
+        for template in templates:
+            if 'metadata' in template \
+               and 'labels' in template['metadata'] \
+               and 'pipelines.kubeflow.org/enable_caching' in template['metadata']['labels']:
+                template['metadata']['labels'][
+                    'pipelines.kubeflow.org/enable_caching'] = str(
+                        enable_caching).lower()
+
+    def list_pipelines(self,
+                       page_token='',
+                       page_size=10,
+                       sort_by='',
+                       filter=None) -> kfp_server_api.ApiListPipelinesResponse:
+        """List pipelines.
+
+        Args:
+          page_token: Token for starting of the page.
+          page_size: Size of the page.
+          sort_by: one of 'field_name', 'field_name desc'. For example, 'name desc'.
+          filter: A url-encoded, JSON-serialized Filter protocol buffer
+            (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+
+        Returns:
+          A response object including a list of pipelines and next page token.
+        """
+        return self._pipelines_api.list_pipelines(
+            page_token=page_token,
+            page_size=page_size,
+            sort_by=sort_by,
+            filter=filter)
+
+    # TODO: provide default namespace, similar to kubectl default namespaces.
+    def run_pipeline(
+        self,
+        experiment_id: str,
+        job_name: str,
+        pipeline_package_path: Optional[str] = None,
+        params: Optional[dict] = None,
+        pipeline_id: Optional[str] = None,
+        version_id: Optional[str] = None,
+        pipeline_root: Optional[str] = None,
+        enable_caching: Optional[str] = None,
+        service_account: Optional[str] = None,
+    ) -> kfp_server_api.ApiRun:
+        """Run a specified pipeline.
+
+        Args:
+          experiment_id: The id of an experiment.
+          job_name: Name of the job.
+          pipeline_package_path: Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).
+          params: A dictionary with key (string) as param name and value (string) as as param value.
+          pipeline_id: The id of a pipeline.
+          version_id: The id of a pipeline version.
+            If both pipeline_id and version_id are specified, version_id will take precendence.
+            If only pipeline_id is specified, the default version of this pipeline is used to create the run.
+          pipeline_root: The root path of the pipeline outputs. This argument should
+            be used only for pipeline compiled with
+            dsl.PipelineExecutionMode.V2_COMPATIBLE or
+            dsl.PipelineExecutionMode.V2_ENGINGE mode.
+          enable_caching: Optional. Whether or not to enable caching for the run.
+            This setting affects v2 compatible mode and v2 mode only.
+            If not set, defaults to the compile time settings, which are True for all
+            tasks by default, while users may specify different caching options for
+            individual tasks.
+            If set, the setting applies to all tasks in the pipeline -- overrides
+            the compile time settings.
+          service_account: Optional. Specifies which Kubernetes service account this
+            run uses.
+
+        Returns:
+          A run object. Most important field is id.
+        """
+        if params is None:
+            params = {}
+
+        if pipeline_root is not None:
+            params[dsl.ROOT_PARAMETER_NAME] = pipeline_root
+
+        job_config = self._create_job_config(
+            experiment_id=experiment_id,
+            params=params,
+            pipeline_package_path=pipeline_package_path,
+            pipeline_id=pipeline_id,
+            version_id=version_id,
+            enable_caching=enable_caching,
+        )
+        run_body = kfp_server_api.models.ApiRun(
+            pipeline_spec=job_config.spec,
+            resource_references=job_config.resource_references,
+            name=job_name,
+            service_account=service_account)
+
+        response = self._run_api.create_run(body=run_body)
+
+        if self._is_ipython():
+            import IPython
+            html = (
+                '<a href="%s/#/runs/details/%s" target="_blank" >Run details</a>.'
+                % (self._get_url_prefix(), response.run.id))
+            IPython.display.display(IPython.display.HTML(html))
+        return response.run
+
+    def create_recurring_run(
+        self,
+        experiment_id: str,
+        job_name: str,
+        description: Optional[str] = None,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        interval_second: Optional[int] = None,
+        cron_expression: Optional[str] = None,
+        max_concurrency: Optional[int] = 1,
+        no_catchup: Optional[bool] = None,
+        params: Optional[dict] = None,
+        pipeline_package_path: Optional[str] = None,
+        pipeline_id: Optional[str] = None,
+        version_id: Optional[str] = None,
+        enabled: bool = True,
+        enable_caching: Optional[bool] = None,
+        service_account: Optional[str] = None,
+    ) -> kfp_server_api.ApiJob:
+        """Create a recurring run.
+
+        Args:
+          experiment_id: The string id of an experiment.
+          job_name: Name of the job.
+          description: An optional job description.
+          start_time: The RFC3339 time string of the time when to start the job.
+          end_time: The RFC3339 time string of the time when to end the job.
+          interval_second: Integer indicating the seconds between two recurring runs in for a periodic schedule.
+          cron_expression: A cron expression representing a set of times, using 6 space-separated fields, e.g. "0 0 9 ? * 2-6".
+            See `here <https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format>`_ for details of the cron expression format.
+          max_concurrency: Integer indicating how many jobs can be run in parallel.
+          no_catchup: Whether the recurring run should catch up if behind schedule.
+            For example, if the recurring run is paused for a while and re-enabled
+            afterwards. If no_catchup=False, the scheduler will catch up on (backfill) each
+            missed interval. Otherwise, it only schedules the latest interval if more than one interval
+            is ready to be scheduled.
+            Usually, if your pipeline handles backfill internally, you should turn catchup
+            off to avoid duplicate backfill. (default: {False})
+          pipeline_package_path: Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).
+          params: A dictionary with key (string) as param name and value (string) as param value.
+          pipeline_id: The id of a pipeline.
+          version_id: The id of a pipeline version.
+            If both pipeline_id and version_id are specified, version_id will take precendence.
+            If only pipeline_id is specified, the default version of this pipeline is used to create the run.
+          enabled: A bool indicating whether the recurring run is enabled or disabled.
+          enable_caching: Optional. Whether or not to enable caching for the run.
+            This setting affects v2 compatible mode and v2 mode only.
+            If not set, defaults to the compile time settings, which are True for all
+            tasks by default, while users may specify different caching options for
+            individual tasks.
+            If set, the setting applies to all tasks in the pipeline -- overrides
+            the compile time settings.
+          service_account: Optional. Specifies which Kubernetes service account this
+            recurring run uses.
+
+        Returns:
+          A Job object. Most important field is id.
+
+        Raises:
+          ValueError: If required parameters are not supplied.
+        """
+
+        job_config = self._create_job_config(
+            experiment_id=experiment_id,
+            params=params,
+            pipeline_package_path=pipeline_package_path,
+            pipeline_id=pipeline_id,
+            version_id=version_id,
+            enable_caching=enable_caching,
+        )
+
+        if all([interval_second, cron_expression
+               ]) or not any([interval_second, cron_expression]):
+            raise ValueError(
+                'Either interval_second or cron_expression is required')
+        if interval_second is not None:
+            trigger = kfp_server_api.models.ApiTrigger(
+                periodic_schedule=kfp_server_api.models.ApiPeriodicSchedule(
+                    start_time=start_time,
+                    end_time=end_time,
+                    interval_second=interval_second))
+        if cron_expression is not None:
+            trigger = kfp_server_api.models.ApiTrigger(
+                cron_schedule=kfp_server_api.models.ApiCronSchedule(
+                    start_time=start_time,
+                    end_time=end_time,
+                    cron=cron_expression))
+
+        job_body = kfp_server_api.models.ApiJob(
+            enabled=enabled,
+            pipeline_spec=job_config.spec,
+            resource_references=job_config.resource_references,
+            name=job_name,
+            description=description,
+            no_catchup=no_catchup,
+            trigger=trigger,
+            max_concurrency=max_concurrency,
+            service_account=service_account)
+        return self._job_api.create_job(body=job_body)
+
+    def _create_job_config(
+        self,
+        experiment_id: str,
+        params: Optional[dict],
+        pipeline_package_path: Optional[str],
+        pipeline_id: Optional[str],
+        version_id: Optional[str],
+        enable_caching: Optional[bool],
+    ):
+        """Create a JobConfig with spec and resource_references.
+
+        Args:
+          experiment_id: The id of an experiment.
+          pipeline_package_path: Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).
+          params: A dictionary with key (string) as param name and value (string) as param value.
+          pipeline_id: The id of a pipeline.
+          version_id: The id of a pipeline version.
+            If both pipeline_id and version_id are specified, version_id will take precendence.
+            If only pipeline_id is specified, the default version of this pipeline is used to create the run.
+          enable_caching: Whether or not to enable caching for the run.
+            This setting affects v2 compatible mode and v2 mode only.
+            If not set, defaults to the compile time settings, which are True for all
+            tasks by default, while users may specify different caching options for
+            individual tasks.
+            If set, the setting applies to all tasks in the pipeline -- overrides
+            the compile time settings.
+
+        Returns:
+          A JobConfig object with attributes spec and resource_reference.
+        """
+
+        class JobConfig:
+
+            def __init__(self, spec, resource_references):
+                self.spec = spec
+                self.resource_references = resource_references
+
+        params = params or {}
+        pipeline_json_string = None
+        if pipeline_package_path:
+            pipeline_obj = self._extract_pipeline_yaml(pipeline_package_path)
+
+            # Caching option set at submission time overrides the compile time settings.
+            if enable_caching is not None:
+                self._override_caching_options(pipeline_obj, enable_caching)
+
+            pipeline_json_string = json.dumps(pipeline_obj)
+        api_params = [
+            kfp_server_api.ApiParameter(
+                name=sanitize_k8s_name(name=k, allow_capital_underscore=True),
+                value=str(v) if type(v) not in (list, dict) else json.dumps(v))
+            for k, v in params.items()
+        ]
+        resource_references = []
+        key = kfp_server_api.models.ApiResourceKey(
+            id=experiment_id,
+            type=kfp_server_api.models.ApiResourceType.EXPERIMENT)
+        reference = kfp_server_api.models.ApiResourceReference(
+            key=key, relationship=kfp_server_api.models.ApiRelationship.OWNER)
+        resource_references.append(reference)
+
+        if version_id:
+            key = kfp_server_api.models.ApiResourceKey(
+                id=version_id,
+                type=kfp_server_api.models.ApiResourceType.PIPELINE_VERSION)
+            reference = kfp_server_api.models.ApiResourceReference(
+                key=key,
+                relationship=kfp_server_api.models.ApiRelationship.CREATOR)
+            resource_references.append(reference)
+
+        spec = kfp_server_api.models.ApiPipelineSpec(
+            pipeline_id=pipeline_id,
+            workflow_manifest=pipeline_json_string,
+            parameters=api_params)
+        return JobConfig(spec=spec, resource_references=resource_references)
+
+    def create_run_from_pipeline_func(
+        self,
+        pipeline_func: Callable,
+        arguments: Mapping[str, str],
+        run_name: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        pipeline_conf: Optional[dsl.PipelineConf] = None,
+        namespace: Optional[str] = None,
+        mode: dsl.PipelineExecutionMode = dsl.PipelineExecutionMode.V1_LEGACY,
+        launcher_image: Optional[str] = None,
+        pipeline_root: Optional[str] = None,
+        enable_caching: Optional[bool] = None,
+        service_account: Optional[str] = None,
+    ):
+        """Runs pipeline on KFP-enabled Kubernetes cluster.
+
+        This command compiles the pipeline function, creates or gets an experiment and submits the pipeline for execution.
+
+        Args:
+          pipeline_func: A function that describes a pipeline by calling components and composing them into execution graph.
+          arguments: Arguments to the pipeline function provided as a dict.
+          run_name: Optional. Name of the run to be shown in the UI.
+          experiment_name: Optional. Name of the experiment to add the run to.
+          pipeline_conf: Optional. Pipeline configuration ops that will be applied
+            to all the ops in the pipeline func.
+          namespace: Kubernetes namespace where the pipeline runs are created.
+            For single user deployment, leave it as None;
+            For multi user, input a namespace where the user is authorized
+          mode: The PipelineExecutionMode to use when compiling and running
+            pipeline_func.
+          launcher_image: The launcher image to use if the mode is specified as
+            PipelineExecutionMode.V2_COMPATIBLE. Should only be needed for tests
+            or custom deployments right now.
+          pipeline_root: The root path of the pipeline outputs. This argument should
+            be used only for pipeline compiled with
+            dsl.PipelineExecutionMode.V2_COMPATIBLE or
+            dsl.PipelineExecutionMode.V2_ENGINGE mode.
+          enable_caching: Optional. Whether or not to enable caching for the run.
+            This setting affects v2 compatible mode and v2 mode only.
+            If not set, defaults to the compile time settings, which are True for all
+            tasks by default, while users may specify different caching options for
+            individual tasks.
+            If set, the setting applies to all tasks in the pipeline -- overrides
+            the compile time settings.
+          service_account: Optional. Specifies which Kubernetes service account this
+            run uses.
+        """
+        if pipeline_root is not None and mode == dsl.PipelineExecutionMode.V1_LEGACY:
+            raise ValueError('`pipeline_root` should not be used with '
+                             'dsl.PipelineExecutionMode.V1_LEGACY mode.')
+
+        #TODO: Check arguments against the pipeline function
+        pipeline_name = pipeline_func.__name__
+        run_name = run_name or pipeline_name + ' ' + datetime.datetime.now(
+        ).strftime('%Y-%m-%d %H-%M-%S')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pipeline_package_path = os.path.join(tmpdir, 'pipeline.yaml')
+            compiler.Compiler(
+                mode=mode, launcher_image=launcher_image).compile(
+                    pipeline_func=pipeline_func,
+                    package_path=pipeline_package_path,
+                    pipeline_conf=pipeline_conf)
+
+            return self.create_run_from_pipeline_package(
+                pipeline_file=pipeline_package_path,
+                arguments=arguments,
+                run_name=run_name,
+                experiment_name=experiment_name,
+                namespace=namespace,
+                pipeline_root=pipeline_root,
+                enable_caching=enable_caching,
+                service_account=service_account,
+            )
+
+    def create_run_from_pipeline_package(
+        self,
+        pipeline_file: str,
+        arguments: Mapping[str, str],
+        run_name: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        pipeline_root: Optional[str] = None,
+        enable_caching: Optional[bool] = None,
+        service_account: Optional[str] = None,
+    ):
+        """Runs pipeline on KFP-enabled Kubernetes cluster.
+
+        This command takes a local pipeline package, creates or gets an experiment
+        and submits the pipeline for execution.
+
+        Args:
+          pipeline_file: A compiled pipeline package file.
+          arguments: Arguments to the pipeline function provided as a dict.
+          run_name: Optional. Name of the run to be shown in the UI.
+          experiment_name: Optional. Name of the experiment to add the run to.
+          namespace: Kubernetes namespace where the pipeline runs are created.
+            For single user deployment, leave it as None;
+            For multi user, input a namespace where the user is authorized
+          pipeline_root: The root path of the pipeline outputs. This argument should
+            be used only for pipeline compiled with
+            dsl.PipelineExecutionMode.V2_COMPATIBLE or
+            dsl.PipelineExecutionMode.V2_ENGINGE mode.
+          enable_caching: Optional. Whether or not to enable caching for the run.
+            This setting affects v2 compatible mode and v2 mode only.
+            If not set, defaults to the compile time settings, which are True for all
+            tasks by default, while users may specify different caching options for
+            individual tasks.
+            If set, the setting applies to all tasks in the pipeline -- overrides
+            the compile time settings.
+          service_account: Optional. Specifies which Kubernetes service account this
+            run uses.
+        """
+
+        class RunPipelineResult:
+
+            def __init__(self, client, run_info):
+                self._client = client
+                self.run_info = run_info
+                self.run_id = run_info.id
+
+            def wait_for_run_completion(self, timeout=None):
+                timeout = timeout or datetime.timedelta.max
+                return self._client.wait_for_run_completion(
+                    self.run_id, timeout)
+
+            def __repr__(self):
+                return 'RunPipelineResult(run_id={})'.format(self.run_id)
+
+        #TODO: Check arguments against the pipeline function
+        pipeline_name = os.path.basename(pipeline_file)
+        experiment_name = experiment_name or os.environ.get(
+            KF_PIPELINES_DEFAULT_EXPERIMENT_NAME, None)
+        overridden_experiment_name = os.environ.get(
+            KF_PIPELINES_OVERRIDE_EXPERIMENT_NAME, experiment_name)
+        if overridden_experiment_name != experiment_name:
+            import warnings
+            warnings.warn('Changing experiment name from "{}" to "{}".'.format(
+                experiment_name, overridden_experiment_name))
+        experiment_name = overridden_experiment_name or 'Default'
+        run_name = run_name or (
+            pipeline_name + ' ' +
+            datetime.datetime.now().strftime('%Y-%m-%d %H-%M-%S'))
+        experiment = self.create_experiment(
+            name=experiment_name, namespace=namespace)
+        run_info = self.run_pipeline(
+            experiment_id=experiment.id,
+            job_name=run_name,
+            pipeline_package_path=pipeline_file,
+            params=arguments,
+            pipeline_root=pipeline_root,
+            enable_caching=enable_caching,
+            service_account=service_account,
+        )
+        return RunPipelineResult(self, run_info)
+
+    def delete_job(self, job_id: str):
+        """Deletes a job.
+
+        Args:
+          job_id: id of the job.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          kfp_server_api.ApiException: If the job is not found.
+        """
+        return self._job_api.delete_job(id=job_id)
+
+    def disable_job(self, job_id: str):
+        """Disables a job.
+
+        Args:
+          job_id: id of the job.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          ApiException: If the job is not found.
+        """
+        return self._job_api.disable_job(id=job_id)
+
+    def list_runs(self,
+                  page_token='',
+                  page_size=10,
+                  sort_by='',
+                  experiment_id=None,
+                  namespace=None,
+                  filter=None) -> kfp_server_api.ApiListRunsResponse:
+        """List runs, optionally can be filtered by experiment or namespace.
+
+        Args:
+          page_token: Token for starting of the page.
+          page_size: Size of the page.
+          sort_by: One of 'field_name', 'field_name desc'. For example, 'name desc'.
+          experiment_id: Experiment id to filter upon
+          namespace: Kubernetes namespace to filter upon.
+            For single user deployment, leave it as None;
+            For multi user, input a namespace where the user is authorized.
+          filter: A url-encoded, JSON-serialized Filter protocol buffer
+            (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+
+        Returns:
+          A response object including a list of experiments and next page token.
+        """
+        namespace = namespace or self.get_user_namespace()
+        if experiment_id is not None:
+            response = self._run_api.list_runs(
+                page_token=page_token,
+                page_size=page_size,
+                sort_by=sort_by,
+                resource_reference_key_type=kfp_server_api.models
+                .api_resource_type.ApiResourceType.EXPERIMENT,
+                resource_reference_key_id=experiment_id,
+                filter=filter)
+        elif namespace:
+            response = self._run_api.list_runs(
+                page_token=page_token,
+                page_size=page_size,
+                sort_by=sort_by,
+                resource_reference_key_type=kfp_server_api.models
+                .api_resource_type.ApiResourceType.NAMESPACE,
+                resource_reference_key_id=namespace,
+                filter=filter)
+        else:
+            response = self._run_api.list_runs(
+                page_token=page_token,
+                page_size=page_size,
+                sort_by=sort_by,
+                filter=filter)
+        return response
+
+    def list_recurring_runs(self,
+                            page_token='',
+                            page_size=10,
+                            sort_by='',
+                            experiment_id=None,
+                            filter=None) -> kfp_server_api.ApiListJobsResponse:
+        """List recurring runs.
+
+        Args:
+          page_token: Token for starting of the page.
+          page_size: Size of the page.
+          sort_by: One of 'field_name', 'field_name desc'. For example, 'name desc'.
+          experiment_id: Experiment id to filter upon.
+          filter: A url-encoded, JSON-serialized Filter protocol buffer
+            (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+
+        Returns:
+          A response object including a list of recurring_runs and next page token.
+        """
+        if experiment_id is not None:
+            response = self._job_api.list_jobs(
+                page_token=page_token,
+                page_size=page_size,
+                sort_by=sort_by,
+                resource_reference_key_type=kfp_server_api.models
+                .api_resource_type.ApiResourceType.EXPERIMENT,
+                resource_reference_key_id=experiment_id,
+                filter=filter)
+        else:
+            response = self._job_api.list_jobs(
+                page_token=page_token,
+                page_size=page_size,
+                sort_by=sort_by,
+                filter=filter)
+        return response
+
+    def get_recurring_run(self, job_id: str) -> kfp_server_api.ApiJob:
+        """Get recurring_run details.
+
+        Args:
+          job_id: id of the recurring_run.
+
+        Returns:
+          A response object including details of a recurring_run.
+
+        Raises:
+          kfp_server_api.ApiException: If recurring_run is not found.
+        """
+        return self._job_api.get_job(id=job_id)
+
+    def get_run(self, run_id: str) -> kfp_server_api.ApiRun:
+        """Get run details.
+
+        Args:
+          run_id: id of the run.
+
+        Returns:
+          A response object including details of a run.
+
+        Raises:
+          kfp_server_api.ApiException: If run is not found.
+        """
+        return self._run_api.get_run(run_id=run_id)
+
+    def wait_for_run_completion(self, run_id: str, timeout: int):
+        """Waits for a run to complete.
+
+        Args:
+          run_id: Run id, returned from run_pipeline.
+          timeout: Timeout in seconds.
+
+        Returns:
+          A run detail object: Most important fields are run and pipeline_runtime.
+
+        Raises:
+          TimeoutError: if the pipeline run failed to finish before the specified timeout.
+        """
+        status = 'Running:'
+        start_time = datetime.datetime.now()
+        if isinstance(timeout, datetime.timedelta):
+            timeout = timeout.total_seconds()
+        is_valid_token = False
+        while (status is None or status.lower()
+               not in ['succeeded', 'failed', 'skipped', 'error']):
+            try:
+                get_run_response = self._run_api.get_run(run_id=run_id)
+                is_valid_token = True
+            except ApiException as api_ex:
+                # if the token is valid but receiving 401 Unauthorized error
+                # then refresh the token
+                if is_valid_token and api_ex.status == 401:
+                    logging.info('Access token has expired !!! Refreshing ...')
+                    self._refresh_api_client_token()
+                    continue
+                else:
+                    raise api_ex
+            status = get_run_response.run.status
+            elapsed_time = (datetime.datetime.now() -
+                            start_time).total_seconds()
+            logging.info('Waiting for the job to complete...')
+            if elapsed_time > timeout:
+                raise TimeoutError('Run timeout')
+            time.sleep(5)
+        return get_run_response
+
+    def _get_workflow_json(self, run_id):
+        """Get the workflow json.
+
+        Args:
+          run_id: run id, returned from run_pipeline.
+
+        Returns:
+          workflow: Json workflow
+        """
+        get_run_response = self._run_api.get_run(run_id=run_id)
+        workflow = get_run_response.pipeline_runtime.workflow_manifest
+        workflow_json = json.loads(workflow)
+        return workflow_json
+
+    def upload_pipeline(
+        self,
+        pipeline_package_path: str = None,
+        pipeline_name: str = None,
+        description: str = None,
+    ) -> kfp_server_api.ApiPipeline:
+        """Uploads the pipeline to the Kubeflow Pipelines cluster.
+
+        Args:
+          pipeline_package_path: Local path to the pipeline package.
+          pipeline_name: Optional. Name of the pipeline to be shown in the UI.
+          description: Optional. Description of the pipeline to be shown in the UI.
+
+        Returns:
+          Server response object containing pipleine id and other information.
+        """
+
+        response = self._upload_api.upload_pipeline(
+            pipeline_package_path, name=pipeline_name, description=description)
+        if self._is_ipython():
+            import IPython
+            html = '<a href=%s/#/pipelines/details/%s>Pipeline details</a>.' % (
+                self._get_url_prefix(), response.id)
+            IPython.display.display(IPython.display.HTML(html))
+        return response
+
+    def upload_pipeline_version(
+        self,
+        pipeline_package_path,
+        pipeline_version_name: str,
+        pipeline_id: Optional[str] = None,
+        pipeline_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> kfp_server_api.ApiPipelineVersion:
+        """Uploads a new version of the pipeline to the Kubeflow Pipelines
+        cluster.
+
+        Args:
+          pipeline_package_path: Local path to the pipeline package.
+          pipeline_version_name:  Name of the pipeline version to be shown in the UI.
+          pipeline_id: Optional. Id of the pipeline.
+          pipeline_name: Optional. Name of the pipeline.
+          description: Optional. Description of the pipeline version to be shown in the UI.
+
+        Returns:
+          Server response object containing pipleine id and other information.
+
+        Raises:
+          ValueError when none or both of pipeline_id or pipeline_name are specified
+          kfp_server_api.ApiException: If pipeline id is not found.
+        """
+
+        if all([pipeline_id, pipeline_name
+               ]) or not any([pipeline_id, pipeline_name]):
+            raise ValueError('Either pipeline_id or pipeline_name is required')
+
+        if pipeline_name:
+            pipeline_id = self.get_pipeline_id(pipeline_name)
+        kwargs = dict(
+            name=pipeline_version_name,
+            pipelineid=pipeline_id,
+        )
+
+        if description:
+            kwargs['description'] = description
+        try:
+            response = self._upload_api.upload_pipeline_version(
+                pipeline_package_path, **kwargs)
+        except kfp_server_api.exceptions.ApiTypeError as e:
+            # ToDo: Remove this once we drop support for kfp_server_api < 1.7.1
+            if 'description' in e.message and 'unexpected keyword argument' in e.message:
+                raise NotImplementedError(
+                    'Pipeline version description is not supported in current kfp-server-api pypi package. Upgrade to 1.7.1 or above'
+                )
+            else:
+                raise e
+
+        if self._is_ipython():
+            import IPython
+            html = '<a href=%s/#/pipelines/details/%s>Pipeline details</a>.' % (
+                self._get_url_prefix(), response.id)
+            IPython.display.display(IPython.display.HTML(html))
+        return response
+
+    def get_pipeline(self, pipeline_id: str) -> kfp_server_api.ApiPipeline:
+        """Get pipeline details.
+
+        Args:
+          pipeline_id: id of the pipeline.
+
+        Returns:
+          A response object including details of a pipeline.
+
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
+        """
+        return self._pipelines_api.get_pipeline(id=pipeline_id)
+
+    def delete_pipeline(self, pipeline_id):
+        """Delete pipeline.
+
+        Args:
+          pipeline_id: id of the pipeline.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
+        """
+        return self._pipelines_api.delete_pipeline(id=pipeline_id)
+
+    def list_pipeline_versions(
+            self,
+            pipeline_id: str,
+            page_token: str = '',
+            page_size: int = 10,
+            sort_by: str = ''
+    ) -> kfp_server_api.ApiListPipelineVersionsResponse:
+        """Lists pipeline versions.
+
+        Args:
+          pipeline_id: Id of the pipeline to list versions
+          page_token: Token for starting of the page.
+          page_size: Size of the page.
+          sort_by: One of 'field_name', 'field_name desc'. For example, 'name desc'.
+
+        Returns:
+          A response object including a list of versions and next page token.
+
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
+        """
+
+        return self._pipelines_api.list_pipeline_versions(
+            page_token=page_token,
+            page_size=page_size,
+            sort_by=sort_by,
+            resource_key_type=kfp_server_api.models.api_resource_type
+            .ApiResourceType.PIPELINE,
+            resource_key_id=pipeline_id)
+
+    def delete_pipeline_version(self, version_id: str):
+        """Delete pipeline version.
+
+        Args:
+          version_id: id of the pipeline version.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          Exception if pipeline version is not found.
+        """
+        return self._pipelines_api.delete_pipeline_version(
+            version_id=version_id)

--- a/kfp/_config.py
+++ b/kfp/_config.py
@@ -1,0 +1,18 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#TODO: wrap the DSL level configuration into one Config
+TYPE_CHECK = True
+# COMPILING_FOR_V2 is True when using kfp.v2.compiler or use (v1) kfp.compiler
+# with V2_COMPATIBLE or V2_ENGINE mode
+COMPILING_FOR_V2 = False

--- a/kfp/_local_client.py
+++ b/kfp/_local_client.py
@@ -1,0 +1,546 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import warnings
+from collections import deque
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union, cast
+
+from . import dsl
+from .compiler.compiler import sanitize_k8s_name
+
+
+class _Dag:
+    """DAG stands for Direct Acyclic Graph.
+
+    DAG here is used to decide the order to execute pipeline ops.
+
+    For more information on DAG, please refer to `wiki <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`_.
+    """
+
+    def __init__(self, nodes: List[str]) -> None:
+        """
+
+        Args::
+          nodes: List of DAG nodes, each node is identified by an unique name.
+        """
+        self._graph = {node: [] for node in nodes}
+        self._reverse_graph = {node: [] for node in nodes}
+
+    @property
+    def graph(self):
+        return self._graph
+
+    @property
+    def reverse_graph(self):
+        return self._reverse_graph
+
+    def add_edge(self, edge_source: str, edge_target: str) -> None:
+        """Add an edge between DAG nodes.
+
+        Args::
+          edge_source: the source node of the edge
+          edge_target: the target node of the edge
+        """
+        self._graph[edge_source].append(edge_target)
+        self._reverse_graph[edge_target].append(edge_source)
+
+    def get_follows(self, source_node: str) -> List[str]:
+        """Get all target nodes start from the specified source node.
+
+        Args::
+          source_node: the source node
+        """
+        return self._graph.get(source_node, [])
+
+    def get_dependencies(self, target_node: str) -> List[str]:
+        """Get all source nodes end with the specified target node.
+
+        Args::
+          target_node: the target node
+        """
+        return self._reverse_graph.get(target_node, [])
+
+    def topological_sort(self) -> List[str]:
+        """List DAG nodes in topological order."""
+
+        in_degree = {node: 0 for node in self._graph.keys()}
+
+        for i in self._graph:
+            for j in self._graph[i]:
+                in_degree[j] += 1
+
+        queue = deque()
+        for node, degree in in_degree.items():
+            if degree == 0:
+                queue.append(node)
+
+        sorted_nodes = []
+
+        while queue:
+            u = queue.popleft()
+            sorted_nodes.append(u)
+
+            for node in self._graph[u]:
+                in_degree[node] -= 1
+
+                if in_degree[node] == 0:
+                    queue.append(node)
+
+        return sorted_nodes
+
+
+def _extract_pipeline_param(param: str) -> dsl.PipelineParam:
+    """Extract PipelineParam from string."""
+    matches = re.findall(r"{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+)}}",
+                         param)
+    op_dependency_name = matches[0][0]
+    output_file_name = matches[0][1]
+    return dsl.PipelineParam(output_file_name, op_dependency_name)
+
+
+def _get_op(ops: List[dsl.ContainerOp],
+            op_name: str) -> Union[dsl.ContainerOp, None]:
+    """Get the first op with specified op name."""
+    return next(filter(lambda op: op.name == op_name, ops), None)
+
+
+def _get_subgroup(groups: List[dsl.OpsGroup],
+                  group_name: str) -> Union[dsl.OpsGroup, None]:
+    """Get the first OpsGroup with specified group name."""
+    return next(filter(lambda g: g.name == group_name, groups), None)
+
+
+class LocalClient:
+
+    class ExecutionMode:
+        """Configuration to decide whether the client executes a component in
+        docker or in local process."""
+
+        DOCKER = "docker"
+        LOCAL = "local"
+
+        def __init__(
+            self,
+            mode: str = DOCKER,
+            images_to_exclude: List[str] = [],
+            ops_to_exclude: List[str] = [],
+            docker_options: List[str] = [],
+        ) -> None:
+            """Constructor.
+
+            Args:
+                mode: Default execution mode, default 'docker'
+                images_to_exclude: If the image of op is in images_to_exclude, the op is
+                    executed in the mode different from default_mode.
+                ops_to_exclude: If the name of op is in ops_to_exclude, the op is
+                    executed in the mode different from default_mode.
+                docker_options: Docker options used in docker mode,
+                    e.g. docker_options=["-e", "foo=bar"].
+            """
+            if mode not in [self.DOCKER, self.LOCAL]:
+                raise Exception(
+                    "Invalid execution mode, must be docker of local")
+            self._mode = mode
+            self._images_to_exclude = images_to_exclude
+            self._ops_to_exclude = ops_to_exclude
+            self._docker_options = docker_options
+
+        @property
+        def mode(self) -> str:
+            return self._mode
+
+        @property
+        def images_to_exclude(self) -> List[str]:
+            return self._images_to_exclude
+
+        @property
+        def ops_to_exclude(self) -> List[str]:
+            return self._ops_to_exclude
+
+        @property
+        def docker_options(self) -> List[str]:
+            return self._docker_options
+
+    def __init__(self, pipeline_root: Optional[str] = None) -> None:
+        """Construct the instance of LocalClient.
+
+        Args：
+            pipeline_root: The root directory where the output artifact of component
+              will be saved.
+        """
+        warnings.warn(
+            'LocalClient is an Alpha[1] feature. It may be deprecated in the future.\n'
+            '[1] https://github.com/kubeflow/pipelines/blob/master/docs/release/feature-stages.md#alpha',
+            category=FutureWarning,
+        )
+
+        pipeline_root = pipeline_root or tempfile.tempdir
+        self._pipeline_root = pipeline_root
+
+    def _find_base_group(self, groups: List[dsl.OpsGroup],
+                         op_name: str) -> Union[dsl.OpsGroup, None]:
+        """Find the base group of op in candidate group list."""
+        if groups is None or len(groups) == 0:
+            return None
+        for group in groups:
+            if _get_op(group.ops, op_name):
+                return group
+            else:
+                _parent_group = self._find_base_group(group.groups, op_name)
+                if _parent_group:
+                    return group
+
+        return None
+
+    def _create_group_dag(self, pipeline_dag: _Dag,
+                          group: dsl.OpsGroup) -> _Dag:
+        """Create DAG within current group, it's a DAG of direct ops and direct
+        subgroups.
+
+        Each node of the DAG is either an op or a subgroup. For each
+        node in current group, if one of its DAG follows is also an op
+        in current group, add an edge to this follow op, otherwise, if
+        this follow belongs to subgroups, add an edge to its subgroup.
+        If this node has dependency from subgroups, then add an edge
+        from this subgroup to current node.
+        """
+        group_dag = _Dag([op.name for op in group.ops] +
+                         [g.name for g in group.groups])
+
+        for op in group.ops:
+            for follow in pipeline_dag.get_follows(op.name):
+                if _get_op(group.ops, follow) is not None:
+                    # add edge between direct ops
+                    group_dag.add_edge(op.name, follow)
+                else:
+                    _base_group = self._find_base_group(group.groups, follow)
+                    if _base_group:
+                        # add edge to direct subgroup
+                        group_dag.add_edge(op.name, _base_group.name)
+
+            for dependency in pipeline_dag.get_dependencies(op.name):
+                if _get_op(group.ops, dependency) is None:
+                    _base_group = self._find_base_group(group.groups,
+                                                        dependency)
+                    if _base_group:
+                        # add edge from direct subgroup
+                        group_dag.add_edge(_base_group.name, op.name)
+
+        return group_dag
+
+    def _create_op_dag(self, p: dsl.Pipeline) -> _Dag:
+        """Create the DAG of the pipeline ops."""
+        dag = _Dag(p.ops.keys())
+
+        for op in p.ops.values():
+            # dependencies defined by inputs
+            for input_value in op.inputs:
+                if isinstance(input_value, dsl.PipelineParam):
+                    input_param = _extract_pipeline_param(input_value.pattern)
+                    if input_param.op_name:
+                        dag.add_edge(input_param.op_name, op.name)
+                    else:
+                        logging.debug("%s depend on pipeline param", op.name)
+
+            # explicit dependencies of current op
+            for dependent in op.dependent_names:
+                dag.add_edge(dependent, op.name)
+        return dag
+
+    def _make_output_file_path_unique(self, run_name: str, op_name: str,
+                                      output_file: str) -> str:
+        """Alter the file path of output artifact to make sure it's unique in
+        local runner.
+
+        kfp compiler will bound a tmp file for each component output,
+        which is unique in kfp runtime, but not unique in local runner.
+        We alter the file path of the name of current run and op, to
+        make it unique in local runner.
+        """
+        if not output_file.startswith("/tmp/"):
+            return output_file
+        return f'{self._pipeline_root}/{run_name}/{op_name.lower()}/{output_file[len("/tmp/"):]}'
+
+    def _get_output_file_path(
+        self,
+        run_name: str,
+        pipeline: dsl.Pipeline,
+        op_name: str,
+        output_name: str = None,
+    ) -> str:
+        """Get the file path of component output."""
+
+        op_dependency = pipeline.ops[op_name]
+        if output_name is None and len(op_dependency.file_outputs) == 1:
+            output_name = next(iter(op_dependency.file_outputs.keys()))
+        output_file = op_dependency.file_outputs[output_name]
+        unique_output_file = self._make_output_file_path_unique(
+            run_name, op_name, output_file)
+        return unique_output_file
+
+    def _generate_cmd_for_subprocess_execution(
+        self,
+        run_name: str,
+        pipeline: dsl.Pipeline,
+        op: dsl.ContainerOp,
+        stack: Dict[str, Any],
+    ) -> List[str]:
+        """Generate shell command to run the op locally."""
+        cmd = op.command + op.arguments
+
+        # In debug mode, for `python -c cmd` format command, pydev will insert code before
+        # `cmd`, but there is no newline at the end of the inserted code, which will cause
+        # syntax error, so we add newline before `cmd`.
+        for i in range(len(cmd)):
+            if cmd[i] == "-c":
+                cmd[i + 1] = "\n" + cmd[i + 1]
+
+        for index, cmd_item in enumerate(cmd):
+            if cmd_item in stack:  # Argument is LoopArguments item
+                cmd[index] = str(stack[cmd_item])
+            elif cmd_item in op.file_outputs.values(
+            ):  # Argument is output file
+                output_name = next(
+                    filter(lambda item: item[1] == cmd_item,
+                           op.file_outputs.items()))[0]
+                output_param = op.outputs[output_name]
+                output_file = cmd_item
+                output_file = self._make_output_file_path_unique(
+                    run_name, output_param.op_name, output_file)
+
+                os.makedirs(os.path.dirname(output_file), exist_ok=True)
+                cmd[index] = output_file
+            elif (cmd_item in op.input_artifact_paths.values()
+                 ):  # Argument is input artifact file
+                input_name = next(
+                    filter(
+                        lambda item: item[1] == cmd_item,
+                        op.input_artifact_paths.items(),
+                    ))[0]
+                input_param_pattern = op.artifact_arguments[input_name]
+                pipeline_param = _extract_pipeline_param(input_param_pattern)
+                input_file = self._get_output_file_path(run_name, pipeline,
+                                                        pipeline_param.op_name,
+                                                        pipeline_param.name)
+
+                cmd[index] = input_file
+
+        return cmd
+
+    def _generate_cmd_for_docker_execution(
+        self,
+        run_name: str,
+        pipeline: dsl.Pipeline,
+        op: dsl.ContainerOp,
+        stack: Dict[str, Any],
+        docker_options: List[str] = []
+    ) -> List[str]:
+        """Generate the command to run the op in docker locally."""
+        cmd = self._generate_cmd_for_subprocess_execution(
+            run_name, pipeline, op, stack)
+
+        docker_cmd = [
+            "docker",
+            "run",
+            *docker_options,
+            "-v",
+            "{pipeline_root}:{pipeline_root}".format(
+                pipeline_root=self._pipeline_root),
+            op.image,
+        ] + cmd
+        return docker_cmd
+
+    def _run_group_dag(
+        self,
+        run_name: str,
+        pipeline: dsl.Pipeline,
+        pipeline_dag: _Dag,
+        current_group: dsl.OpsGroup,
+        stack: Dict[str, Any],
+        execution_mode: ExecutionMode,
+    ) -> bool:
+        """Run ops in current group in topological order.
+
+        Args:
+            pipeline: kfp.dsl.Pipeline
+            pipeline_dag: DAG of pipeline ops
+            current_group: current ops group
+            stack: stack to trace `LoopArguments`
+            execution_mode: Configuration to decide whether the client executes
+                component in docker or in local process.
+        Returns:
+            True if succeed to run the group dag.
+        """
+        group_dag = self._create_group_dag(pipeline_dag, current_group)
+
+        for node in group_dag.topological_sort():
+            subgroup = _get_subgroup(current_group.groups, node)
+            if subgroup is not None:  # Node of DAG is subgroup
+                success = self._run_group(run_name, pipeline, pipeline_dag, subgroup,
+                                stack, execution_mode)
+                if not success:
+                    return False
+            else:  # Node of DAG is op
+                op = _get_op(current_group.ops, node)
+
+                execution_mode = (
+                    execution_mode
+                    if execution_mode else LocalClient.ExecutionMode())
+                can_run_locally = execution_mode.mode == LocalClient.ExecutionMode.LOCAL
+                exclude = (
+                    op.image in execution_mode.images_to_exclude or
+                    op.name in execution_mode.ops_to_exclude)
+                if exclude:
+                    can_run_locally = not can_run_locally
+
+                if can_run_locally:
+                    cmd = self._generate_cmd_for_subprocess_execution(
+                        run_name, pipeline, op, stack)
+                else:
+                    cmd = self._generate_cmd_for_docker_execution(
+                        run_name, pipeline, op, stack, execution_mode.docker_options)
+                process = subprocess.Popen(
+                    cmd,
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    universal_newlines=True,
+                )
+                # TODO support async process
+                logging.info("start task：%s", op.name)
+                stdout, stderr = process.communicate()
+                if stdout:
+                    logging.info(stdout)
+                if stderr:
+                    logging.error(stderr)
+                if process.returncode != 0:
+                    logging.error(cmd)
+                    return False
+
+    def _run_group(
+        self,
+        run_name: str,
+        pipeline: dsl.Pipeline,
+        pipeline_dag: _Dag,
+        current_group: dsl.OpsGroup,
+        stack: Dict[str, Any],
+        execution_mode: ExecutionMode,
+    ) -> bool:
+        """Run all ops in current group.
+
+        Args:
+            run_name: str, the name of this run, can be used to query the run result
+            pipeline: kfp.dsl.Pipeline
+            pipeline_dag: DAG of pipeline ops
+            current_group: current ops group
+            stack: stack to trace `LoopArguments`
+            execution_mode: Configuration to decide whether the client executes
+                component in docker or in local process.
+        Returns:
+            True if succeed to run the group.
+        """
+        if current_group.type == dsl.ParallelFor.TYPE_NAME:
+            current_group = cast(dsl.ParallelFor, current_group)
+
+            if current_group.items_is_pipeline_param:
+                _loop_args = current_group.loop_args
+                _param_name = _loop_args.name[:-len(_loop_args
+                                                    .LOOP_ITEM_NAME_BASE) - 1]
+
+                _op_dependency = pipeline.ops[_loop_args.op_name]
+                _list_file = _op_dependency.file_outputs[_param_name]
+                _altered_list_file = self._make_output_file_path_unique(
+                    run_name, _loop_args.op_name, _list_file)
+                with open(_altered_list_file, "r") as f:
+                    _param_values = json.load(f)
+                for index, _param_value in enumerate(_param_values):
+                    if isinstance(_param_values, (dict, list)):
+                        _param_value = json.dumps(_param_value)
+                    stack[_loop_args.pattern] = _param_value
+                    loop_run_name = "{run_name}/{loop_index}".format(
+                        run_name=run_name, loop_index=index)
+                    success = self._run_group_dag(
+                        loop_run_name,
+                        pipeline,
+                        pipeline_dag,
+                        current_group,
+                        stack,
+                        execution_mode,
+                    )
+                    del stack[_loop_args.pattern]
+                    if not success:
+                        return False
+                return True
+            else:
+                raise Exception("Not implemented")
+        else:
+            return self._run_group_dag(run_name, pipeline, pipeline_dag, current_group,
+                                stack, execution_mode)
+
+    def create_run_from_pipeline_func(
+            self,
+            pipeline_func: Callable,
+            arguments: Mapping[str, str],
+            execution_mode: ExecutionMode = ExecutionMode(),
+    ):
+        """Runs a pipeline locally, either using Docker or in a local process.
+
+        Parameters:
+          pipeline_func: pipeline function
+          arguments: Arguments to the pipeline function provided as a dict, reference
+              to `kfp.client.create_run_from_pipeline_func`
+          execution_mode: Configuration to decide whether the client executes component
+              in docker or in local process.
+        """
+
+        class RunPipelineResult:
+
+            def __init__(self, client: LocalClient, pipeline: dsl.Pipeline,
+                         run_id: str, success: bool):
+                self._client = client
+                self._pipeline = pipeline
+                self.run_id = run_id
+                self._success = success
+
+            def get_output_file(self, op_name: str, output: str = None):
+                return self._client._get_output_file_path(
+                    self.run_id, self._pipeline, op_name, output)
+
+            def success(self) -> bool:
+                return self._success
+
+            def __repr__(self):
+                return "RunPipelineResult(run_id={})".format(self.run_id)
+
+        pipeline_name = sanitize_k8s_name(
+            getattr(pipeline_func, "_component_human_name", None) or
+            pipeline_func.__name__)
+        with dsl.Pipeline(pipeline_name) as pipeline:
+            pipeline_func(**arguments)
+
+        run_version = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+        run_name = pipeline.name.replace(" ", "_").lower() + "_" + run_version
+
+        pipeline_dag = self._create_op_dag(pipeline)
+        success = self._run_group(run_name, pipeline, pipeline_dag, pipeline.groups[0],
+                        {}, execution_mode)
+
+        return RunPipelineResult(self, pipeline, run_name, success=success)

--- a/kfp/_runners.py
+++ b/kfp/_runners.py
@@ -1,0 +1,95 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "run_pipeline_func_on_cluster",
+    "run_pipeline_func_locally",
+]
+
+from typing import Callable, List, Mapping, Optional
+
+from . import Client, LocalClient, dsl
+
+
+def run_pipeline_func_on_cluster(
+    pipeline_func: Callable,
+    arguments: Mapping[str, str],
+    run_name: str = None,
+    experiment_name: str = None,
+    kfp_client: Client = None,
+    pipeline_conf: dsl.PipelineConf = None,
+):
+    """Runs pipeline on KFP-enabled Kubernetes cluster.
+
+    This command compiles the pipeline function, creates or gets an experiment
+    and submits the pipeline for execution.
+
+    Feature stage:
+    [Alpha](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha)
+
+    Args:
+      pipeline_func: A function that describes a pipeline by calling components
+      and composing them into execution graph.
+      arguments: Arguments to the pipeline function provided as a dict.
+      run_name: Optional. Name of the run to be shown in the UI.
+      experiment_name: Optional. Name of the experiment to add the run to.
+      kfp_client: Optional. An instance of kfp.Client configured for the desired
+        KFP cluster.
+      pipeline_conf: Optional. kfp.dsl.PipelineConf instance. Can specify op
+        transforms, image pull secrets and other pipeline-level configuration
+        options.
+    """
+    kfp_client = kfp_client or Client()
+    return kfp_client.create_run_from_pipeline_func(pipeline_func, arguments,
+                                                    run_name, experiment_name,
+                                                    pipeline_conf)
+
+
+def run_pipeline_func_locally(
+        pipeline_func: Callable,
+        arguments: Mapping[str, str],
+        local_client: Optional[LocalClient] = None,
+        pipeline_root: Optional[str] = None,
+        execution_mode: LocalClient.ExecutionMode = LocalClient.ExecutionMode(),
+):
+    """Runs a pipeline locally, either using Docker or in a local process.
+
+    Feature stage:
+    [Alpha](https://github.com/kubeflow/pipelines/blob/master/docs/release/feature-stages.md#alpha)
+
+    In this alpha implementation, we support:
+      * Control flow: Condition, ParallelFor
+      * Data passing: InputValue, InputPath, OutputPath
+
+    And we don't support:
+      * Control flow: ExitHandler, Graph, SubGraph
+      * ContainerOp with environment variables, init containers, sidecars, pvolumes
+      * ResourceOp
+      * VolumeOp
+      * Caching
+
+    Args:
+      pipeline_func: A function that describes a pipeline by calling components
+        and composing them into execution graph.
+      arguments: Arguments to the pipeline function provided as a dict.
+        reference to `kfp.client.create_run_from_pipeline_func`.
+      local_client: Optional. An instance of kfp.LocalClient.
+      pipeline_root: Optional. The root directory where the output artifact of component
+        will be saved.
+      execution_mode: Configuration to decide whether the client executes component
+        in docker or in local process.
+    """
+    local_client = local_client or LocalClient(pipeline_root)
+    return local_client.create_run_from_pipeline_func(
+        pipeline_func, arguments, execution_mode=execution_mode)

--- a/kfp/auth/__init__.py
+++ b/kfp/auth/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Arrikto Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._tokencredentialsbase import TokenCredentialsBase, read_token_from_file
+from ._satvolumecredentials import ServiceAccountTokenVolumeCredentials
+
+KF_PIPELINES_SA_TOKEN_ENV = "KF_PIPELINES_SA_TOKEN_PATH"
+KF_PIPELINES_SA_TOKEN_PATH = "/var/run/secrets/kubeflow/pipelines/token"

--- a/kfp/auth/_satvolumecredentials.py
+++ b/kfp/auth/_satvolumecredentials.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Arrikto Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import logging
+
+from kubernetes.client import configuration
+
+from kfp import auth
+
+
+class ServiceAccountTokenVolumeCredentials(auth.TokenCredentialsBase):
+    """Audience-bound ServiceAccountToken in the local filesystem.
+
+    This is a credentials interface for audience-bound ServiceAccountTokens
+    found in the local filesystem, that get refreshed by the kubelet.
+
+    The constructor of the class expects a filesystem path.
+    If not provided, it uses the path stored in the environment variable
+    defined in ``auth.KF_PIPELINES_SA_TOKEN_ENV``.
+    If the environment variable is also empty, it falls back to the path
+    specified in ``auth.KF_PIPELINES_SA_TOKEN_PATH``.
+
+    This method of authentication is meant for use inside a Kubernetes cluster.
+
+    Relevant documentation:
+    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+    """
+
+    def __init__(self, path=None):
+        self._token_path = (
+            path or os.getenv(auth.KF_PIPELINES_SA_TOKEN_ENV) or
+            auth.KF_PIPELINES_SA_TOKEN_PATH)
+
+    def _get_token(self):
+        token = None
+        try:
+            token = auth.read_token_from_file(self._token_path)
+        except OSError as e:
+            logging.error("Failed to read a token from file '%s' (%s).",
+                          self._token_path, str(e))
+            raise
+        return token
+
+    def refresh_api_key_hook(self, config: configuration.Configuration):
+        """Refresh the api key.
+
+        This is a helper function for registering token refresh with swagger
+        generated clients.
+
+        Args:
+            config (kubernetes.client.configuration.Configuration):
+                The configuration object that the client uses.
+
+                The Configuration object of the kubernetes client's is the same
+                with kfp_server_api.configuration.Configuration.
+        """
+        config.api_key["authorization"] = self._get_token()

--- a/kfp/auth/_tokencredentialsbase.py
+++ b/kfp/auth/_tokencredentialsbase.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Arrikto Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+
+from kubernetes.client import configuration
+
+
+class TokenCredentialsBase(abc.ABC):
+
+    @abc.abstractmethod
+    def refresh_api_key_hook(self, config: configuration.Configuration):
+        """Refresh the api key.
+
+        This is a helper function for registering token refresh with swagger
+        generated clients.
+
+        All classes that inherit from TokenCredentialsBase must implement this
+        method to refresh the credentials.
+
+        Args:
+            config (kubernetes.client.configuration.Configuration):
+                The configuration object that the client uses.
+
+                The Configuration object of the kubernetes client's is the same
+                with kfp_server_api.configuration.Configuration.
+        """
+        raise NotImplementedError()
+
+
+def read_token_from_file(path=None):
+    """Read a token found in some file."""
+    token = None
+    with open(path, "r") as f:
+        token = f.read().strip()
+    return token

--- a/kfp/aws.py
+++ b/kfp/aws.py
@@ -1,0 +1,73 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def use_aws_secret(secret_name='aws-secret',
+                   aws_access_key_id_name='AWS_ACCESS_KEY_ID',
+                   aws_secret_access_key_name='AWS_SECRET_ACCESS_KEY',
+                   aws_region=None):
+    """An operator that configures the container to use AWS credentials.
+
+    AWS doesn't create secret along with kubeflow deployment and it requires users
+    to manually create credential secret with proper permissions.
+
+    ::
+
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-secret
+        type: Opaque
+        data:
+          AWS_ACCESS_KEY_ID: BASE64_YOUR_AWS_ACCESS_KEY_ID
+          AWS_SECRET_ACCESS_KEY: BASE64_YOUR_AWS_SECRET_ACCESS_KEY
+    """
+
+    def _use_aws_secret(task):
+        from kubernetes import client as k8s_client
+        task.container \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='AWS_ACCESS_KEY_ID',
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=aws_access_key_id_name
+                        )
+                    )
+                )
+            ) \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='AWS_SECRET_ACCESS_KEY',
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=aws_secret_access_key_name
+                        )
+                    )
+                )
+            )
+
+        if aws_region:
+            task.container \
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AWS_REGION',
+                        value=aws_region
+                    )
+                )
+        return task
+
+    return _use_aws_secret

--- a/kfp/azure.py
+++ b/kfp/azure.py
@@ -1,0 +1,53 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def use_azure_secret(secret_name='azcreds'):
+    """An operator that configures the container to use Azure user credentials.
+
+    The azcreds secret is created as part of the kubeflow deployment that
+    stores the client ID and secrets for the kubeflow azure service principal.
+
+    With this service principal, the container has a range of Azure APIs to access to.
+    """
+
+    def _use_azure_secret(task):
+        from kubernetes import client as k8s_client
+        (task.container.add_env_variable(
+            k8s_client.V1EnvVar(
+                name='AZ_SUBSCRIPTION_ID',
+                value_from=k8s_client.V1EnvVarSource(
+                    secret_key_ref=k8s_client.V1SecretKeySelector(
+                        name=secret_name, key='AZ_SUBSCRIPTION_ID')))
+        ).add_env_variable(
+            k8s_client.V1EnvVar(
+                name='AZ_TENANT_ID',
+                value_from=k8s_client.V1EnvVarSource(
+                    secret_key_ref=k8s_client.V1SecretKeySelector(
+                        name=secret_name, key='AZ_TENANT_ID')))
+        ).add_env_variable(
+            k8s_client.V1EnvVar(
+                name='AZ_CLIENT_ID',
+                value_from=k8s_client.V1EnvVarSource(
+                    secret_key_ref=k8s_client.V1SecretKeySelector(
+                        name=secret_name, key='AZ_CLIENT_ID'))))
+         .add_env_variable(
+             k8s_client.V1EnvVar(
+                 name='AZ_CLIENT_SECRET',
+                 value_from=k8s_client.V1EnvVarSource(
+                     secret_key_ref=k8s_client.V1SecretKeySelector(
+                         name=secret_name, key='AZ_CLIENT_SECRET')))))
+        return task
+
+    return _use_azure_secret

--- a/kfp/cli/__init__.py
+++ b/kfp/cli/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kfp/cli/cli.py
+++ b/kfp/cli/cli.py
@@ -1,0 +1,85 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+import click
+import typer
+
+from kfp._client import Client
+from kfp.cli.run import run
+from kfp.cli.recurring_run import recurring_run
+from kfp.cli.pipeline import pipeline
+from kfp.cli.diagnose_me_cli import diagnose_me
+from kfp.cli.experiment import experiment
+from kfp.cli.output import OutputFormat
+from kfp.cli import components
+
+_NO_CLIENT_COMMANDS = [
+    'diagnose_me',
+    'components'
+]
+
+@click.group()
+@click.option('--endpoint', help='Endpoint of the KFP API service to connect.')
+@click.option('--iap-client-id', help='Client ID for IAP protected endpoint.')
+@click.option(
+    '-n',
+    '--namespace',
+    default='kubeflow',
+    show_default=True,
+    help='Kubernetes namespace to connect to the KFP API.')
+@click.option(
+    '--other-client-id',
+    help='Client ID for IAP protected endpoint to obtain the refresh token.')
+@click.option(
+    '--other-client-secret',
+    help='Client ID for IAP protected endpoint to obtain the refresh token.')
+@click.option(
+    '--output',
+    type=click.Choice(list(map(lambda x: x.name, OutputFormat))),
+    default=OutputFormat.table.name,
+    show_default=True,
+    help='The formatting style for command output.')
+@click.pass_context
+def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
+        other_client_id: str, other_client_secret: str, output: OutputFormat):
+    """kfp is the command line interface to KFP service.
+
+    Feature stage:
+    [Alpha](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha)
+    """
+    if ctx.invoked_subcommand in _NO_CLIENT_COMMANDS:
+        # Do not create a client for these subcommands
+        return
+    ctx.obj['client'] = Client(endpoint, iap_client_id, namespace,
+                               other_client_id, other_client_secret)
+    ctx.obj['namespace'] = namespace
+    ctx.obj['output'] = output
+
+
+def main():
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
+    cli.add_command(run)
+    cli.add_command(recurring_run)
+    cli.add_command(pipeline)
+    cli.add_command(diagnose_me, 'diagnose_me')
+    cli.add_command(experiment)
+    cli.add_command(typer.main.get_command(components.app))
+    try:
+        cli(obj={}, auto_envvar_prefix='KFP')
+    except Exception as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)

--- a/kfp/cli/components.py
+++ b/kfp/cli/components.py
@@ -1,0 +1,415 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import configparser
+import contextlib
+import enum
+import pathlib
+import shutil
+import subprocess
+import tempfile
+from typing import Any, List, Optional
+
+_DOCKER_IS_PRESENT = True
+try:
+    import docker
+except ImportError:
+    _DOCKER_IS_PRESENT = False
+
+import typer
+
+import kfp
+
+_REQUIREMENTS_TXT = 'requirements.txt'
+
+_DOCKERFILE = 'Dockerfile'
+
+_DOCKERFILE_TEMPLATE = '''
+FROM {base_image}
+
+WORKDIR {component_root_dir}
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+{maybe_copy_kfp_package}
+RUN pip install --no-cache-dir {kfp_package_path}
+COPY . .
+'''
+
+_DOCKERIGNORE = '.dockerignore'
+
+# Location in which to write out shareable YAML for components.
+_COMPONENT_METADATA_DIR = 'component_metadata'
+
+_DOCKERIGNORE_TEMPLATE = '''
+{}/
+'''.format(_COMPONENT_METADATA_DIR)
+
+# Location at which v2 Python function-based components will stored
+# in containerized components.
+_COMPONENT_ROOT_DIR = pathlib.Path('/usr/local/src/kfp/components')
+
+
+@contextlib.contextmanager
+def _registered_modules():
+    registered_modules = {}
+    component_factory.REGISTERED_MODULES = registered_modules
+    try:
+        yield registered_modules
+    finally:
+        component_factory.REGISTERED_MODULES = None
+
+
+class _Engine(str, enum.Enum):
+    """Supported container build engines."""
+    DOCKER = 'docker'
+    KANIKO = 'kaniko'
+    CLOUD_BUILD = 'cloudbuild'
+
+
+app = typer.Typer()
+
+
+def _info(message: Any):
+    info = typer.style('INFO', fg=typer.colors.GREEN)
+    typer.echo('{}: {}'.format(info, message))
+
+
+def _warning(message: Any):
+    info = typer.style('WARNING', fg=typer.colors.YELLOW)
+    typer.echo('{}: {}'.format(info, message))
+
+
+def _error(message: Any):
+    info = typer.style('ERROR', fg=typer.colors.RED)
+    typer.echo('{}: {}'.format(info, message))
+
+
+class _ComponentBuilder():
+    """Helper class for building containerized v2 KFP components."""
+
+    def __init__(
+        self,
+        context_directory: pathlib.Path,
+        kfp_package_path: Optional[pathlib.Path] = None,
+        component_filepattern: str = '**/*.py',
+    ):
+        """ComponentBuilder builds containerized components.
+
+        Args:
+            context_directory: Directory containing one or more Python files
+            with one or more KFP v2 components.
+            kfp_package_path: Path to a pip-installable location for KFP.
+                This can either be pointing to KFP SDK root directory located in
+                a local clone of the KFP repo, or a git+https location.
+                If left empty, defaults to KFP on PyPi.
+        """
+        self._context_directory = context_directory
+        self._dockerfile = self._context_directory / _DOCKERFILE
+        self._component_filepattern = component_filepattern
+        self._components: List[
+            component_factory.component_factory.ComponentInfo] = []
+
+        # This is only set if we need to install KFP from local copy.
+        self._maybe_copy_kfp_package = ''
+
+        if kfp_package_path is None:
+            self._kfp_package_path = 'kfp=={}'.format(kfp.__version__)
+        elif kfp_package_path.is_dir():
+            _info('Building KFP package from local directory {}'.format(
+                typer.style(str(kfp_package_path), fg=typer.colors.CYAN)))
+            temp_dir = pathlib.Path(tempfile.mkdtemp())
+            try:
+                subprocess.run([
+                    'python3',
+                    kfp_package_path / 'setup.py',
+                    'bdist_wheel',
+                    '--dist-dir',
+                    str(temp_dir),
+                ],
+                               cwd=kfp_package_path)
+                wheel_files = list(temp_dir.glob('*.whl'))
+                if len(wheel_files) != 1:
+                    _error('Failed to find built KFP wheel under {}'.format(
+                        temp_dir))
+                    raise typer.Exit(1)
+
+                wheel_file = wheel_files[0]
+                shutil.copy(wheel_file, self._context_directory)
+                self._kfp_package_path = wheel_file.name
+                self._maybe_copy_kfp_package = 'COPY {wheel_name} {wheel_name}'.format(
+                    wheel_name=self._kfp_package_path)
+            except subprocess.CalledProcessError as e:
+                _error('Failed to build KFP wheel locally:\n{}'.format(e))
+                raise typer.Exit(1)
+            finally:
+                _info('Cleaning up temporary directory {}'.format(temp_dir))
+                shutil.rmtree(temp_dir)
+        else:
+            self._kfp_package_path = kfp_package_path
+
+        _info('Building component using KFP package path: {}'.format(
+            typer.style(str(self._kfp_package_path), fg=typer.colors.CYAN)))
+
+        self._context_directory_files = [
+            file.name
+            for file in self._context_directory.glob('*')
+            if file.is_file()
+        ]
+
+        self._component_files = [
+            file for file in self._context_directory.glob(
+                self._component_filepattern) if file.is_file()
+        ]
+
+        self._base_image = None
+        self._target_image = None
+        self._load_components()
+
+    def _load_components(self):
+        if not self._component_files:
+            _error(
+                'No component files found matching pattern `{}` in directory {}'
+                .format(self._component_filepattern, self._context_directory))
+            raise typer.Exit(1)
+
+        for python_file in self._component_files:
+            with _registered_modules() as component_modules:
+                module_name = python_file.name[:-len('.py')]
+                module_directory = python_file.parent
+                utils.load_module(
+                    module_name=module_name, module_directory=module_directory)
+
+                formatted_module_file = typer.style(
+                    str(python_file), fg=typer.colors.CYAN)
+                if not component_modules:
+                    _error('No KFP components found in file {}'.format(
+                        formatted_module_file))
+                    raise typer.Exit(1)
+
+                _info('Found {} component(s) in file {}:'.format(
+                    len(component_modules), formatted_module_file))
+                for name, component in component_modules.items():
+                    _info('{}: {}'.format(name, component))
+                    self._components.append(component)
+
+        base_images = set([info.base_image for info in self._components])
+        target_images = set([info.target_image for info in self._components])
+
+        if len(base_images) != 1:
+            _error('Found {} unique base_image values {}. Components'
+                   ' must specify the same base_image and target_image.'.format(
+                       len(base_images), base_images))
+            raise typer.Exit(1)
+
+        self._base_image = base_images.pop()
+        if self._base_image is None:
+            _error('Did not find a base_image specified in any of the'
+                   ' components. A base_image must be specified in order to'
+                   ' build the component.')
+            raise typer.Exit(1)
+        _info('Using base image: {}'.format(
+            typer.style(self._base_image, fg=typer.colors.YELLOW)))
+
+        if len(target_images) != 1:
+            _error('Found {} unique target_image values {}. Components'
+                   ' must specify the same base_image and'
+                   ' target_image.'.format(len(target_images), target_images))
+            raise typer.Exit(1)
+
+        self._target_image = target_images.pop()
+        if self._target_image is None:
+            _error('Did not find a target_image specified in any of the'
+                   ' components. A target_image must be specified in order'
+                   ' to build the component.')
+            raise typer.Exit(1)
+        _info('Using target image: {}'.format(
+            typer.style(self._target_image, fg=typer.colors.YELLOW)))
+
+    def _maybe_write_file(self,
+                          filename: str,
+                          contents: str,
+                          overwrite: bool = False):
+        formatted_filename = typer.style(filename, fg=typer.colors.CYAN)
+        if filename in self._context_directory_files:
+            _info('Found existing file {} under {}.'.format(
+                formatted_filename, self._context_directory))
+            if not overwrite:
+                _info('Leaving this file untouched.')
+                return
+            else:
+                _warning(
+                    'Overwriting existing file {}'.format(formatted_filename))
+        else:
+            _warning('{} not found under {}. Creating one.'.format(
+                formatted_filename, self._context_directory))
+
+        filepath = self._context_directory / filename
+        with open(filepath, 'w') as f:
+            f.write('# Generated by KFP.\n{}'.format(contents))
+        _info('Generated file {}.'.format(filepath))
+
+    def maybe_generate_requirements_txt(self):
+        self._maybe_write_file(_REQUIREMENTS_TXT, '')
+
+    def maybe_generate_dockerignore(self):
+        self._maybe_write_file(_DOCKERIGNORE, _DOCKERIGNORE_TEMPLATE)
+
+    def write_component_files(self):
+        for component_info in self._components:
+            filename = (
+                component_info.output_component_file or
+                component_info.function_name + '.yaml')
+            container_filename = (
+                self._context_directory / _COMPONENT_METADATA_DIR / filename)
+            container_filename.parent.mkdir(exist_ok=True, parents=True)
+            component_info.component_spec.save(container_filename)
+
+    def generate_kfp_config(self):
+        config = kfp_config.KFPConfig(config_directory=self._context_directory)
+        for component_info in self._components:
+            relative_path = component_info.module_path.relative_to(
+                self._context_directory)
+            config.add_component(
+                function_name=component_info.function_name, path=relative_path)
+        config.save()
+
+    def maybe_generate_dockerfile(self, overwrite_dockerfile: bool = False):
+        dockerfile_contents = _DOCKERFILE_TEMPLATE.format(
+            base_image=self._base_image,
+            maybe_copy_kfp_package=self._maybe_copy_kfp_package,
+            component_root_dir=_COMPONENT_ROOT_DIR,
+            kfp_package_path=self._kfp_package_path)
+
+        self._maybe_write_file(_DOCKERFILE, dockerfile_contents,
+                               overwrite_dockerfile)
+
+    def build_image(self, push_image: bool = True):
+        _info('Building image {} using Docker...'.format(
+            typer.style(self._target_image, fg=typer.colors.YELLOW)))
+        client = docker.from_env()
+
+        docker_log_prefix = typer.style('Docker', fg=typer.colors.CYAN)
+
+        try:
+            context = str(self._context_directory)
+            logs = client.api.build(
+                path=context,
+                dockerfile='Dockerfile',
+                tag=self._target_image,
+                decode=True,
+            )
+            for log in logs:
+                message = log.get('stream', '').rstrip('\n')
+                if message:
+                    _info('{}: {}'.format(docker_log_prefix, message))
+
+        except docker.errors.BuildError as e:
+            for log in e.build_log:
+                message = log.get('message', '').rstrip('\n')
+                if message:
+                    _error('{}: {}'.format(docker_log_prefix, message))
+            _error('{}: {}'.format(docker_log_prefix, e))
+            raise typer.Exit(1)
+
+        if not push_image:
+            return
+
+        _info('Pushing image {}...'.format(
+            typer.style(self._target_image, fg=typer.colors.YELLOW)))
+
+        try:
+            response = client.images.push(
+                self._target_image, stream=True, decode=True)
+            for log in response:
+                status = log.get('status', '').rstrip('\n')
+                layer = log.get('id', '')
+                if status:
+                    _info('{}: {} {}'.format(docker_log_prefix, layer, status))
+        except docker.errors.BuildError as e:
+            _error('{}: {}'.format(docker_log_prefix, e))
+            raise e
+
+        _info('Built and pushed component container {}'.format(
+            typer.style(self._target_image, fg=typer.colors.YELLOW)))
+
+
+@app.callback()
+def components():
+    """Builds shareable, containerized components."""
+    pass
+
+
+@app.command()
+def build(components_directory: pathlib.Path = typer.Argument(
+    ...,
+    help="Path to a directory containing one or more Python"
+    " files with KFP v2 components. The container will be built"
+    " with this directory as the context."),
+          component_filepattern: str = typer.Option(
+              '**/*.py',
+              help="Filepattern to use when searching for KFP components. The"
+              " default searches all Python files in the specified directory."),
+          engine: _Engine = typer.Option(
+              _Engine.DOCKER,
+              help="Engine to use to build the component's container."),
+          kfp_package_path: Optional[pathlib.Path] = typer.Option(
+              None, help="A pip-installable path to the KFP package."),
+          overwrite_dockerfile: bool = typer.Option(
+              False,
+              help="Set this to true to always generate a Dockerfile"
+              " as part of the build process"),
+          build_image: bool = typer.Option(
+            True, help="Build the container image."
+          ),
+          push_image: bool = typer.Option(
+              True, help="Push the built image to its remote repository.")):
+    """
+    Builds containers for KFP v2 Python-based components.
+    """
+    components_directory = components_directory.resolve()
+    if not components_directory.is_dir():
+        _error('{} does not seem to be a valid directory.'.format(
+            components_directory))
+        raise typer.Exit(1)
+
+    if build_image and (engine != _Engine.DOCKER):
+        _error('Currently, only `docker` is supported for --engine.')
+        raise typer.Exit(1)
+
+    if build_image and (engine == _Engine.DOCKER):
+        if not _DOCKER_IS_PRESENT:
+            _error(
+                'The `docker` Python package was not found in the current'
+                ' environment. Please run `pip install docker` to install it.'
+                ' Optionally, you can also  install KFP with all of its'
+                ' optional dependencies by running `pip install kfp[all]`.')
+            raise typer.Exit(1)
+
+    builder = _ComponentBuilder(
+        context_directory=components_directory,
+        kfp_package_path=kfp_package_path,
+        component_filepattern=component_filepattern,
+    )
+    builder.write_component_files()
+    builder.generate_kfp_config()
+
+    builder.maybe_generate_requirements_txt()
+    builder.maybe_generate_dockerignore()
+    builder.maybe_generate_dockerfile(overwrite_dockerfile=overwrite_dockerfile)
+
+    if build_image:
+        builder.build_image(push_image=push_image)
+
+
+if __name__ == '__main__':
+    app()

--- a/kfp/cli/diagnose_me/__init__.py
+++ b/kfp/cli/diagnose_me/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kfp/cli/diagnose_me/dev_env.py
+++ b/kfp/cli/diagnose_me/dev_env.py
@@ -1,0 +1,71 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for diagnostic data collection from development development."""
+
+import enum
+from kfp.cli.diagnose_me import utility
+
+
+class Commands(enum.Enum):
+    """Enum for gcloud and gsutil commands."""
+    PIP3_LIST = 1
+    PYTHON3_PIP_LIST = 2
+    PIP3_VERSION = 3
+    PYHYON3_PIP_VERSION = 4
+    WHICH_PYHYON3 = 5
+    WHICH_PIP3 = 6
+
+
+_command_string = {
+    Commands.PIP3_LIST: 'pip3 list',
+    Commands.PYTHON3_PIP_LIST: 'python3 -m pip list',
+    Commands.PIP3_VERSION: 'pip3 -V',
+    Commands.PYHYON3_PIP_VERSION: 'python3 -m pip -V',
+    Commands.WHICH_PYHYON3: 'which python3',
+    Commands.WHICH_PIP3: 'which pip3',
+}
+
+
+def get_dev_env_configuration(
+        configuration: Commands,
+        human_readable: bool = False) -> utility.ExecutorResponse:
+    """Captures the specified environment configuration.
+
+    Captures the developement environment configuration including PIP version and
+    Phython version as specifeid by configuration
+
+    Args:
+      configuration: Commands for specific information to be retrieved
+        - PIP3LIST: captures pip3 freeze results
+        - PYTHON3PIPLIST: captuers python3 -m pip freeze results
+        - PIP3VERSION: captuers pip3 -V results
+        - PYHYON3PIPVERSION: captuers python3 -m pip -V results
+      human_readable: If true all output will be in human readable form insted of
+        Json.
+
+    Returns:
+      A utility.ExecutorResponse with the output results for the specified
+      command.
+    """
+    command_list = _command_string[configuration].split(' ')
+    if not human_readable and configuration not in (
+            Commands.PIP3_VERSION,
+            Commands.PYHYON3_PIP_VERSION,
+            Commands.WHICH_PYHYON3,
+            Commands.WHICH_PIP3,
+    ):
+        command_list.extend(['--format', 'json'])
+
+    return utility.ExecutorResponse().execute_command(command_list)

--- a/kfp/cli/diagnose_me/dev_env_test.py
+++ b/kfp/cli/diagnose_me/dev_env_test.py
@@ -1,0 +1,63 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for diagnose_me.dev_env."""
+
+from typing import Text
+import unittest
+from unittest import mock
+from kfp.cli.diagnose_me import dev_env
+from kfp.cli.diagnose_me import utility
+
+
+class DevEnvTest(unittest.TestCase):
+
+    def test_Commands(self):
+        """Verify commands are formaated properly."""
+        for command in dev_env.Commands:
+            self.assertIsInstance(dev_env._command_string[command], Text)
+            self.assertNotIn('\t', dev_env._command_string[command])
+            self.assertNotIn('\n', dev_env._command_string[command])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_dev_env_configuration(self, mock_executor_response):
+        """Tests dev_env command execution."""
+        dev_env.get_dev_env_configuration(dev_env.Commands.PIP3_LIST)
+        mock_executor_response().execute_command.assert_called_with(
+            ['pip3', 'list', '--format', 'json'])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_dev_env_configuration_human_readable(self, mock_executor_response):
+        """Tests dev_env command execution."""
+        dev_env.get_dev_env_configuration(
+            dev_env.Commands.PIP3_LIST, human_readable=True)
+        mock_executor_response().execute_command.assert_called_with(
+            ['pip3', 'list'])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_dev_env_configuration_version(self, mock_executor_response):
+        """Tests dev_env command execution."""
+        # human readable = false should not set format flag for version calls
+        dev_env.get_dev_env_configuration(
+            dev_env.Commands.PIP3_VERSION, human_readable=False)
+        mock_executor_response().execute_command.assert_called_with(
+            ['pip3', '-V'])
+        dev_env.get_dev_env_configuration(
+            dev_env.Commands.PYHYON3_PIP_VERSION, human_readable=False)
+        mock_executor_response().execute_command.assert_called_with(
+            ['python3', '-m', 'pip', '-V'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/cli/diagnose_me/gcp.py
+++ b/kfp/cli/diagnose_me/gcp.py
@@ -1,0 +1,152 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for collecting GCP related environment configurations."""
+
+import enum
+from typing import List, Text, Optional
+from kfp.cli.diagnose_me import utility
+
+
+class Commands(enum.Enum):
+    """Enum for gcloud and gsutil commands."""
+    GET_APIS = 1
+    GET_CONTAINER_CLUSTERS = 2
+    GET_CONTAINER_IMAGES = 3
+    GET_DISKS = 4
+    GET_GCLOUD_DEFAULT = 5
+    GET_NETWORKS = 6
+    GET_QUOTAS = 7
+    GET_SCOPES = 8
+    GET_SERVICE_ACCOUNTS = 9
+    GET_STORAGE_BUCKETS = 10
+    GET_GCLOUD_VERSION = 11
+    GET_AUTH_LIST = 12
+
+
+_command_string = {
+    Commands.GET_APIS: 'services list',
+    Commands.GET_CONTAINER_CLUSTERS: 'container clusters list',
+    Commands.GET_CONTAINER_IMAGES: 'container images list',
+    Commands.GET_DISKS: 'compute disks list',
+    Commands.GET_GCLOUD_DEFAULT: 'config list --all',
+    Commands.GET_NETWORKS: 'compute networks list',
+    Commands.GET_QUOTAS: 'compute regions list',
+    Commands.GET_SCOPES: 'compute instances list',
+    Commands.GET_SERVICE_ACCOUNTS: 'iam service-accounts list',
+    Commands.GET_STORAGE_BUCKETS: 'ls',
+    Commands.GET_GCLOUD_VERSION: 'version',
+    Commands.GET_AUTH_LIST: 'auth list',
+}
+
+
+def execute_gcloud_command(
+        gcloud_command_list: List[Text],
+        project_id: Optional[Text] = None,
+        human_readable: Optional[bool] = False) -> utility.ExecutorResponse:
+    """Function for invoking gcloud command.
+
+    Args:
+      gcloud_command_list: a command string list to be past to gcloud example
+        format is ['config', 'list', '--all']
+      project_id: specificies the project to run the commands against if not
+        provided provided will use gcloud default project if one is configured
+        otherwise will return an error message.
+      human_readable: If false sets parameter --format json for all calls,
+        otherwie output will be in human readable format.
+
+    Returns:
+      utility.ExecutorResponse with outputs from stdout,stderr and execution code.
+    """
+    command_list = ['gcloud']
+    command_list.extend(gcloud_command_list)
+    if not human_readable:
+        command_list.extend(['--format', 'json'])
+
+    if project_id is not None:
+        command_list.extend(['--project', project_id])
+
+    return utility.ExecutorResponse().execute_command(command_list)
+
+
+def execute_gsutil_command(
+        gsutil_command_list: List[Text],
+        project_id: Optional[Text] = None) -> utility.ExecutorResponse:
+    """Function for invoking gsutil command.
+
+    This function takes in a gsutil parameter list and returns the results as a
+    list of dictionaries.
+    Args:
+      gsutil_command_list: a command string list to be past to gsutil example
+        format is ['config', 'list', '--all']
+      project_id: specific project to check the QUOTASs for,if no project id is
+        provided will use gcloud default project if one is configured otherwise
+        will return an erro massage.
+
+    Returns:
+      utility.ExecutorResponse with outputs from stdout,stderr and execution code.
+    """
+    command_list = ['gsutil']
+    command_list.extend(gsutil_command_list)
+
+    if project_id is not None:
+        command_list.extend(['-p', project_id])
+
+    return utility.ExecutorResponse().execute_command(command_list)
+
+
+def get_gcp_configuration(
+        configuration: Commands,
+        project_id: Optional[Text] = None,
+        human_readable: Optional[bool] = False) -> utility.ExecutorResponse:
+    """Captures the specified environment configuration.
+
+    Captures the environment configuration for the specified setting such as
+    NETWORKSing configuration, project QUOTASs, etc.
+
+    Args:
+      configuration: Commands for specific information to be retrieved
+        - APIS:  Captures a complete list of enabled APISs and their configuration
+          details under the specified project.
+        - CONTAINER_CLUSTERS: List all visible k8 clusters under the project.
+        - CONTAINER_IMAGES: List of all container images under the project
+          container repo.
+        - DISKS: List of storage allocated by the project including notebook
+          instances as well as k8 pds with corresponding state.
+        - GCLOUD_DEFAULT:  Environment default configuration for gcloud
+        - NETWORKS: List all NETWORKSs and their configuration under the project.
+        - QUOTAS:  Captures a complete list of  QUOTASs for project per
+          region,returns the results as a list of dictionaries.
+        - SCOPES: list of SCOPESs for each compute resources in the project.
+        - SERVICE_ACCOUNTS: List of all service accounts that are enabled under
+          this project.
+        - STORAGE_BUCKETS: list of buckets and corresponding access information.
+      project_id: specific project to check the QUOTASs for,if no project id is
+        provided will use gcloud default project if one is configured otherwise
+        will return an error message.
+      human_readable: If true all output will be in human readable form insted of
+        Json.
+
+    Returns:
+      A utility.ExecutorResponse with the output results for the specified
+      command.
+    """
+    # storage bucket call requires execute_gsutil_command
+    if configuration is Commands.GET_STORAGE_BUCKETS:
+        return execute_gsutil_command(
+            [_command_string[Commands.GET_STORAGE_BUCKETS]], project_id)
+
+    # For all other cases can execute the command directly
+    return execute_gcloud_command(_command_string[configuration].split(' '),
+                                  project_id, human_readable)

--- a/kfp/cli/diagnose_me/gcp_test.py
+++ b/kfp/cli/diagnose_me/gcp_test.py
@@ -1,0 +1,87 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for diagnose_me.gcp."""
+
+from typing import Text
+import unittest
+from unittest import mock
+from kfp.cli.diagnose_me import gcp
+from kfp.cli.diagnose_me import utility
+
+
+class GoogleCloudTest(unittest.TestCase):
+
+    @mock.patch.object(gcp, 'execute_gcloud_command', autospec=True)
+    def test_project_configuration_gcloud(self, mock_execute_gcloud_command):
+        """Tests gcloud commands."""
+        gcp.get_gcp_configuration(gcp.Commands.GET_APIS)
+        mock_execute_gcloud_command.assert_called_once_with(
+            ['services', 'list'], project_id=None, human_readable=False)
+
+    @mock.patch.object(gcp, 'execute_gsutil_command', autospec=True)
+    def test_project_configuration_gsutil(self, mock_execute_gsutil_command):
+        """Test Gsutil commands."""
+        gcp.get_gcp_configuration(gcp.Commands.GET_STORAGE_BUCKETS)
+        mock_execute_gsutil_command.assert_called_once_with(['ls'],
+                                                            project_id=None)
+
+    def test_Commands(self):
+        """Verify commands are formaated properly."""
+        for command in gcp.Commands:
+            self.assertIsInstance(gcp._command_string[command], Text)
+            self.assertNotIn('\t', gcp._command_string[command])
+            self.assertNotIn('\n', gcp._command_string[command])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_execute_gsutil_command(self, mock_executor_response):
+        """Test execute_gsutil_command."""
+        gcp.execute_gsutil_command(
+            [gcp._command_string[gcp.Commands.GET_STORAGE_BUCKETS]])
+        mock_executor_response().execute_command.assert_called_once_with(
+            ['gsutil', 'ls'])
+
+        gcp.execute_gsutil_command(
+            [gcp._command_string[gcp.Commands.GET_STORAGE_BUCKETS]],
+            project_id='test_project')
+        mock_executor_response().execute_command.assert_called_with(
+            ['gsutil', 'ls', '-p', 'test_project'])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_execute_gcloud_command(self, mock_executor_response):
+        """Test execute_gcloud_command."""
+        gcp.execute_gcloud_command(
+            gcp._command_string[gcp.Commands.GET_APIS].split(' '))
+        mock_executor_response().execute_command.assert_called_once_with(
+            ['gcloud', 'services', 'list', '--format', 'json'])
+
+        gcp.execute_gcloud_command(
+            gcp._command_string[gcp.Commands.GET_APIS].split(' '),
+            project_id='test_project')
+        # verify project id is added correctly
+        mock_executor_response().execute_command.assert_called_with([
+            'gcloud', 'services', 'list', '--format', 'json', '--project',
+            'test_project'
+        ])
+        # verify human_readable removes json fromat flag
+        gcp.execute_gcloud_command(
+            gcp._command_string[gcp.Commands.GET_APIS].split(' '),
+            project_id='test_project',
+            human_readable=True)
+        mock_executor_response().execute_command.assert_called_with(
+            ['gcloud', 'services', 'list', '--project', 'test_project'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/cli/diagnose_me/kubernetes_cluster.py
+++ b/kfp/cli/diagnose_me/kubernetes_cluster.py
@@ -1,0 +1,124 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for collecting diagnostic information on Kubernetes cluster."""
+
+import enum
+from typing import List, Text
+from kfp.cli.diagnose_me import utility
+
+
+class Commands(enum.Enum):
+    """Enum for kubernetes commands."""
+    GET_CONFIGURED_CONTEXT = 1
+    GET_PODS = 2
+    GET_PVCS = 3
+    GET_PVS = 4
+    GET_SECRETS = 5
+    GET_SERVICES = 6
+    GET_KUBECTL_VERSION = 7
+    GET_CONFIG_MAPS = 8
+
+
+_command_string = {
+    Commands.GET_CONFIGURED_CONTEXT: 'config view',
+    Commands.GET_PODS: 'get pods',
+    Commands.GET_PVCS: 'get pvc',
+    Commands.GET_PVS: 'get pv',
+    Commands.GET_SECRETS: 'get secrets',
+    Commands.GET_SERVICES: 'get services',
+    Commands.GET_KUBECTL_VERSION: 'version',
+    Commands.GET_CONFIG_MAPS: 'get configmaps',
+}
+
+
+def execute_kubectl_command(
+        kubectl_command_list: List[Text],
+        human_readable: bool = False) -> utility.ExecutorResponse:
+    """Invokes  the kubectl command.
+
+    Args:
+      kubectl_command_list: a command string list to be past to kubectl example
+        format is ['config', 'view']
+      human_readable: If false sets parameter -o json for all calls, otherwie
+        output will be in human readable format.
+
+    Returns:
+      utility.ExecutorResponse with outputs from stdout,stderr and execution code.
+    """
+    command_list = ['kubectl']
+    command_list.extend(kubectl_command_list)
+    if not human_readable:
+        command_list.extend(['-o', 'json'])
+
+    return utility.ExecutorResponse().execute_command(command_list)
+
+
+def get_kubectl_configuration(
+        configuration: Commands,
+        kubernetes_context: Text = None,
+        namespace: Text = None,
+        human_readable: bool = False) -> utility.ExecutorResponse:
+    """Captures the specified environment configuration.
+
+    Captures the environment state for the specified setting such as current
+    context, active pods, etc and returns it in as a dictionary format. if no
+    context is specified the system will use the current_context or error out of
+    none is specified.
+
+    Args:
+      configuration:
+        - K8_CONFIGURED_CONTEXT: returns all k8 configuration available in the
+          current env including current_context.
+        - PODS: returns all pods and their status details.
+        - PVCS: returns all PersistentVolumeClaim and their status details.
+        - SECRETS: returns all accessible k8 secrests.
+        - PVS: returns all PersistentVolume and their status details.
+        - SERVICES: returns all services and their status details.
+      kubernetes_context: Context to use to retrieve cluster specific commands, if
+        set to None calls will rely on current_context configured.
+      namespace: default name space to be used for the commaand, if not specifeid
+        --all-namespaces will be used.
+      human_readable: If true all output will be in human readable form insted of
+        Json.
+
+    Returns:
+      A list of dictionaries matching gcloud / gsutil output for the specified
+      configuration,or an error message if any occurs during execution.
+    """
+
+    if configuration in (Commands.GET_CONFIGURED_CONTEXT,
+                         Commands.GET_KUBECTL_VERSION):
+        return execute_kubectl_command(
+            (_command_string[configuration]).split(' '), human_readable)
+
+    execution_command = _command_string[configuration].split(' ')
+    if kubernetes_context:
+        execution_command.extend(['--context', kubernetes_context])
+    if namespace:
+        execution_command.extend(['--namespace', namespace])
+    else:
+        execution_command.extend(['--all-namespaces'])
+
+    return execute_kubectl_command(execution_command, human_readable)
+
+
+def _get_kfp_runtime() -> Text:
+    """Captures the current version of kpf in k8 cluster.
+
+    Returns:
+      Returns the run-time version of kfp in as a string.
+    """
+    # TODO(chavoshi) needs to be implemented.
+    raise NotImplementedError

--- a/kfp/cli/diagnose_me/kubernetes_cluster_test.py
+++ b/kfp/cli/diagnose_me/kubernetes_cluster_test.py
@@ -1,0 +1,76 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for diagnose_me.kubernetes_cluster."""
+
+from typing import Text
+import unittest
+from unittest import mock
+from kfp.cli.diagnose_me import kubernetes_cluster as dkc
+from kfp.cli.diagnose_me import utility
+
+
+class KubernetesClusterTest(unittest.TestCase):
+
+    @mock.patch.object(dkc, 'execute_kubectl_command', autospec=True)
+    def test_project_configuration_gcloud(self, mock_execute_kubectl_command):
+        """Tests gcloud commands."""
+        dkc.get_kubectl_configuration(dkc.Commands.GET_PODS)
+        mock_execute_kubectl_command.assert_called_once_with(
+            ['get', 'pods', '--all-namespaces'], human_readable=False)
+
+        dkc.get_kubectl_configuration(dkc.Commands.GET_CONFIGURED_CONTEXT)
+        mock_execute_kubectl_command.assert_called_with(['config', 'view'],
+                                                        human_readable=False)
+
+        dkc.get_kubectl_configuration(dkc.Commands.GET_KUBECTL_VERSION)
+        mock_execute_kubectl_command.assert_called_with(['version'],
+                                                        human_readable=False)
+
+        dkc.get_kubectl_configuration(
+            dkc.Commands.GET_PODS, kubernetes_context='test_context')
+        mock_execute_kubectl_command.assert_called_with(
+            ['get', 'pods', '--context', 'test_context', '--all-namespaces'],
+            human_readable=False)
+
+        dkc.get_kubectl_configuration(
+            dkc.Commands.GET_PODS, kubernetes_context='test_context')
+        mock_execute_kubectl_command.assert_called_with(
+            ['get', 'pods', '--context', 'test_context', '--all-namespaces'],
+            human_readable=False)
+
+    def test_Commands(self):
+        """Verify commands are formaated properly."""
+        for command in dkc.Commands:
+            self.assertIsInstance(dkc._command_string[command], Text)
+            self.assertNotIn('\t', dkc._command_string[command])
+            self.assertNotIn('\n', dkc._command_string[command])
+
+    @mock.patch.object(utility, 'ExecutorResponse', autospec=True)
+    def test_execute_kubectl_command(self, mock_executor_response):
+        """Test execute_gsutil_command."""
+        dkc.execute_kubectl_command(
+            [dkc._command_string[dkc.Commands.GET_KUBECTL_VERSION]])
+        mock_executor_response().execute_command.assert_called_once_with(
+            ['kubectl', 'version', '-o', 'json'])
+
+        dkc.execute_kubectl_command(
+            [dkc._command_string[dkc.Commands.GET_KUBECTL_VERSION]],
+            human_readable=True)
+        mock_executor_response().execute_command.assert_called_with(
+            ['kubectl', 'version'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/cli/diagnose_me/utility.py
+++ b/kfp/cli/diagnose_me/utility.py
@@ -1,0 +1,91 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Supporting tools and classes for diagnose_me."""
+
+import json
+import subprocess
+from typing import List, Text
+
+
+class ExecutorResponse(object):
+    """Class for keeping track of output of _executor methods.
+
+    Data model for executing commands and capturing their response. This class
+    defines the data model layer for execution results, based on MVC design
+    pattern.
+
+    TODO() This class should be extended to contain data structure to better
+    represent the underlying data instaed of dict for various response types.
+    """
+
+    def execute_command(self, command_list: List[Text]):
+        """Executes the command in command_list.
+
+        sets values for _stdout,_std_err, and returncode accordingly.
+
+        TODO(): This method is kept in ExecutorResponse for simplicity, however this
+        deviates from MVP design pattern. It should be factored out in future.
+
+        Args:
+          command_list: A List of strings that represts the command and parameters
+            to be executed.
+
+        Returns:
+          Instance of utility.ExecutorResponse.
+        """
+
+        try:
+            # TODO() switch to process.run to simplify the code.
+            process = subprocess.Popen(
+                command_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = process.communicate()
+            self._stdout = stdout.decode('utf-8')
+            self._stderr = stderr.decode('utf-8')
+            self._returncode = process.returncode
+        except OSError as e:
+            self._stderr = e
+            self._stdout = ''
+            self._returncode = e.errno
+        self._parse_raw_input()
+        return self
+
+    def _parse_raw_input(self):
+        """Parses the raw input and popluates _json and _parsed properies."""
+        try:
+            self._parsed_output = json.loads(self._stdout)
+            self._json = self._stdout
+        except json.JSONDecodeError:
+            self._json = json.dumps(self._stdout)
+            self._parsed_output = self._stdout
+
+    @property
+    def parsed_output(self) -> Text:
+        """Json load results of stdout or raw results if stdout was not
+        Json."""
+        return self._parsed_output
+
+    @property
+    def has_error(self) -> bool:
+        """Returns true if execution error code was not 0."""
+        return self._returncode != 0
+
+    @property
+    def json_output(self) -> Text:
+        """Run results in stdout in json format."""
+        return self._parsed_output
+
+    @property
+    def stderr(self):
+        return self._stderr

--- a/kfp/cli/diagnose_me/utility_test.py
+++ b/kfp/cli/diagnose_me/utility_test.py
@@ -1,0 +1,43 @@
+# Lint as: python3
+# Copyright 2019 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License,Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for diagnose_me.utility."""
+
+import unittest
+from kfp.cli.diagnose_me import utility
+
+
+class UtilityTest(unittest.TestCase):
+
+    def test_parse_raw_input_json(self):
+        """Testing json stdout is correctly parsed."""
+        response = utility.ExecutorResponse()
+        response._stdout = '{"key":"value"}'
+        response._parse_raw_input()
+
+        self.assertEqual(response._json, '{"key":"value"}')
+        self.assertEqual(response._parsed_output, {'key': 'value'})
+
+    def test_parse_raw_input_text(self):
+        """Testing non-json stdout is correctly parsed."""
+        response = utility.ExecutorResponse()
+        response._stdout = 'non-json string'
+        response._parse_raw_input()
+
+        self.assertEqual(response._json, '"non-json string"')
+        self.assertEqual(response._parsed_output, 'non-json string')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/cli/diagnose_me_cli.py
+++ b/kfp/cli/diagnose_me_cli.py
@@ -1,0 +1,107 @@
+# Lint as: python3
+"""CLI interface for KFP diagnose_me tool."""
+
+import json as json_library
+import sys
+from typing import Dict, Text
+import click
+from kfp.cli.diagnose_me import dev_env
+from kfp.cli.diagnose_me import gcp
+from kfp.cli.diagnose_me import kubernetes_cluster as k8
+from kfp.cli.diagnose_me import utility
+
+
+@click.group()
+def diagnose_me():
+    """Prints diagnoses information for KFP environment."""
+    pass
+
+
+@diagnose_me.command()
+@click.option(
+    '-j',
+    '--json',
+    is_flag=True,
+    help='Output in Json format, human readable format is set by default.')
+@click.option(
+    '-p',
+    '--project-id',
+    type=Text,
+    help='Target project id. It will use environment default if not specified.')
+@click.option(
+    '-n',
+    '--namespace',
+    type=Text,
+    help='Namespace to use for Kubernetes cluster.all-namespaces is used if not specified.'
+)
+@click.pass_context
+def diagnose_me(ctx: click.Context, json: bool, project_id: str,
+                namespace: str):
+    """Runs environment diagnostic with specified parameters.
+
+    Feature stage:
+    [Alpha](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha)
+    """
+    # validate kubectl, gcloud , and gsutil exist
+    local_env_gcloud_sdk = gcp.get_gcp_configuration(
+        gcp.Commands.GET_GCLOUD_VERSION,
+        project_id=project_id,
+        human_readable=False)
+    for app in ['Google Cloud SDK', 'gsutil', 'kubectl']:
+        if app not in local_env_gcloud_sdk.json_output:
+            raise RuntimeError(
+                '%s is not installed, gcloud, gsutil and kubectl are required '
+                % app + 'for this app to run. Please follow instructions at ' +
+                'https://cloud.google.com/sdk/install to install the SDK.')
+
+    click.echo('Collecting diagnostic information ...', file=sys.stderr)
+
+    # default behaviour dump all configurations
+    results = {}
+    for gcp_command in gcp.Commands:
+        results[gcp_command] = gcp.get_gcp_configuration(
+            gcp_command, project_id=project_id, human_readable=not json)
+
+    for k8_command in k8.Commands:
+        results[k8_command] = k8.get_kubectl_configuration(
+            k8_command, human_readable=not json)
+
+    for dev_env_command in dev_env.Commands:
+        results[dev_env_command] = dev_env.get_dev_env_configuration(
+            dev_env_command, human_readable=not json)
+
+    print_to_sdtout(results, not json)
+
+
+def print_to_sdtout(results: Dict[str, utility.ExecutorResponse],
+                    human_readable: bool):
+    """Viewer to print the ExecutorResponse results to stdout.
+
+    Args:
+      results: A dictionary with key:command names and val: Execution response
+      human_readable: Print results in human readable format. If set to True
+        command names will be printed as visual delimiters in new lines. If False
+        results are printed as a dictionary with command as key.
+    """
+
+    output_dict = {}
+    human_readable_result = []
+    for key, val in results.items():
+        if val.has_error:
+            output_dict[
+                key.
+                name] = 'Following error occurred during the diagnoses: %s' % val.stderr
+            continue
+
+        output_dict[key.name] = val.json_output
+        human_readable_result.append('================ %s ===================' %
+                                     (key.name))
+        human_readable_result.append(val.parsed_output)
+
+    if human_readable:
+        result = '\n'.join(human_readable_result)
+    else:
+        result = json_library.dumps(
+            output_dict, sort_keys=True, indent=2, separators=(',', ': '))
+
+    click.echo(result)

--- a/kfp/cli/experiment.py
+++ b/kfp/cli/experiment.py
@@ -1,0 +1,142 @@
+import click
+import json
+from typing import List
+
+from kfp.cli.output import print_output, OutputFormat
+import kfp_server_api
+from kfp_server_api.models.api_experiment import ApiExperiment
+
+
+@click.group()
+def experiment():
+    """Manage experiment resources."""
+    pass
+
+
+@experiment.command()
+@click.option('-d', '--description', help="Description of the experiment.")
+@click.argument("name")
+@click.pass_context
+def create(ctx: click.Context, description: str, name: str):
+    """Create an experiment."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.create_experiment(name, description=description)
+    _display_experiment(response, output_format)
+
+
+@experiment.command()
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m', '--max-size', default=100, help="Max size of the listed experiments.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list(ctx: click.Context, page_token: str, max_size: int, sort_by: str,
+         filter: str):
+    """List experiments."""
+    client = ctx.obj['client']
+    output_format = ctx.obj['output']
+
+    response = client.list_experiments(
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response.experiments:
+        _display_experiments(response.experiments, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No experiments found"
+        click.echo(msg)
+
+
+@experiment.command()
+@click.argument("experiment-id")
+@click.pass_context
+def get(ctx: click.Context, experiment_id: str):
+    """Get detailed information about an experiment."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.get_experiment(experiment_id)
+    _display_experiment(response, output_format)
+
+
+@experiment.command()
+@click.argument("experiment-id")
+@click.pass_context
+def delete(ctx: click.Context, experiment_id: str):
+    """Delete an experiment."""
+
+    confirmation = "Caution. The RunDetails page could have an issue" \
+                   " when it renders a run that has no experiment." \
+                   " Do you want to continue?"
+    if not click.confirm(confirmation):
+        return
+
+    client = ctx.obj["client"]
+
+    client.delete_experiment(experiment_id)
+    click.echo("{} is deleted.".format(experiment_id))
+
+
+def _display_experiments(experiments: List[ApiExperiment],
+                         output_format: OutputFormat):
+    headers = ["Experiment ID", "Name", "Created at"]
+    data = [
+        [exp.id, exp.name, exp.created_at.isoformat()] for exp in experiments
+    ]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _display_experiment(exp: kfp_server_api.ApiExperiment,
+                        output_format: OutputFormat):
+    table = [
+        ["ID", exp.id],
+        ["Name", exp.name],
+        ["Description", exp.description],
+        ["Created at", exp.created_at.isoformat()],
+    ]
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Experiment Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+    elif output_format == OutputFormat.json.name:
+        print_output(dict(table), [], output_format)
+
+
+@experiment.command()
+@click.option(
+    "--experiment-id",
+    default=None,
+    help="The ID of the experiment to archive, can only supply either an experiment ID or name.")
+@click.option(
+    "--experiment-name",
+    default=None,
+    help="The name of the experiment to archive, can only supply either an experiment ID or name.")
+@click.pass_context
+def archive(ctx: click.Context, experiment_id: str, experiment_name: str):
+    """Archive an experiment"""
+    client = ctx.obj["client"]
+
+    if (experiment_id is None) == (experiment_name is None):
+        raise ValueError('Either experiment_id or experiment_name is required')
+
+    if not experiment_id:
+        experiment = client.get_experiment(experiment_name=experiment_name)
+        experiment_id = experiment.id
+
+    client.archive_experiment(experiment_id=experiment_id)

--- a/kfp/cli/output.py
+++ b/kfp/cli/output.py
@@ -1,0 +1,63 @@
+# Copyright 2020 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import json
+from enum import Enum, unique
+from typing import Union
+
+from tabulate import tabulate
+
+
+@unique
+class OutputFormat(Enum):
+    """Enumerated class with the allowed output format constants."""
+    table = "table"
+    json = "json"
+
+
+def print_output(data: Union[list, dict],
+                 headers: list,
+                 output_format: str,
+                 table_format: str = "simple"):
+    """Prints the output from the cli command execution based on the specified
+    format.
+
+    Args:
+        data (Union[list, dict]): Nested list of values representing the rows to be printed.
+        headers (list): List of values representing the column names to be printed
+            for the ``data``.
+        output_format (str): The desired formatting of the text from the command output.
+        table_format (str): The formatting for the table ``output_format``.
+            Default value set to ``simple``.
+
+    Returns:
+        None: Prints the output.
+
+    Raises:
+        NotImplementedError: If the ``output_format`` is unknown.
+    """
+    if output_format == OutputFormat.table.name:
+        click.echo(tabulate(data, headers=headers, tablefmt=table_format))
+    elif output_format == OutputFormat.json.name:
+        if not headers:
+            output = data
+        else:
+            output = []
+            for row in data:
+                output.append(dict(zip(headers, row)))
+        click.echo(json.dumps(output, indent=4))
+    else:
+        raise NotImplementedError(
+            "Unknown Output Format: {}".format(output_format))

--- a/kfp/cli/pipeline.py
+++ b/kfp/cli/pipeline.py
@@ -1,0 +1,264 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import json
+from typing import List, Optional
+
+import kfp_server_api
+from kfp.cli.output import print_output, OutputFormat
+
+
+@click.group()
+def pipeline():
+    """Manage pipeline resources."""
+    pass
+
+
+@pipeline.command()
+@click.option("-p", "--pipeline-name", help="Name of the pipeline.")
+@click.option("-d", "--description", help="Description for the pipeline.")
+@click.argument("package-file")
+@click.pass_context
+def upload(ctx: click.Context,
+           pipeline_name: str,
+           package_file: str,
+           description: str = None):
+    """Upload a KFP pipeline."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+    if not pipeline_name:
+        pipeline_name = package_file.split(".")[0]
+
+    pipeline = client.upload_pipeline(package_file, pipeline_name, description)
+    _display_pipeline(pipeline, output_format)
+
+
+@pipeline.command()
+@click.option("-p", "--pipeline-id", help="ID of the pipeline", required=False)
+@click.option("-n", "--pipeline-name", help="Name of pipeline", required=False)
+@click.option(
+    "-v",
+    "--pipeline-version",
+    help="Name of the pipeline version",
+    required=True)
+@click.argument("package-file")
+@click.pass_context
+def upload_version(ctx: click.Context,
+                   package_file: str,
+                   pipeline_version: str,
+                   pipeline_id: Optional[str] = None,
+                   pipeline_name: Optional[str] = None):
+    """Upload a version of the KFP pipeline."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+    if bool(pipeline_id) == bool(pipeline_name):
+        raise ValueError("Need to supply 'pipeline-name' or 'pipeline-id'")
+    if pipeline_name is not None:
+        pipeline_id = client.get_pipeline_id(name=pipeline_name)
+        if pipeline_id is None:
+            raise ValueError("Can't find a pipeline with name: %s" %
+                             pipeline_name)
+    version = client.pipeline_uploads.upload_pipeline_version(
+        package_file, name=pipeline_version, pipelineid=pipeline_id)
+    _display_pipeline_version(version, output_format)
+
+
+@pipeline.command()
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m', '--max-size', default=100, help="Max size of the listed pipelines.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list(ctx: click.Context, page_token: str, max_size: int, sort_by: str,
+         filter: str):
+    """List uploaded KFP pipelines."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.list_pipelines(
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response.pipelines:
+        _print_pipelines(response.pipelines, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No pipelines found"
+        click.echo(msg)
+
+
+@pipeline.command()
+@click.argument("pipeline-id")
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m',
+    '--max-size',
+    default=100,
+    help="Max size of the listed pipeline versions.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list_versions(ctx: click.Context, pipeline_id: str, page_token: str,
+                  max_size: int, sort_by: str, filter: str):
+    """List versions of an uploaded KFP pipeline"""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.list_pipeline_versions(
+        pipeline_id,
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response.versions:
+        _print_pipeline_versions(response.versions, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No pipeline or version found"
+        click.echo(msg)
+
+
+@pipeline.command()
+@click.argument("version-id")
+@click.pass_context
+def delete_version(ctx: click.Context, version_id: str):
+    """Delete pipeline version.
+
+    Args:
+      version_id: id of the pipeline version.
+
+    Returns:
+      Object. If the method is called asynchronously, returns the request thread.
+
+    Throws:
+      Exception if pipeline version is not found.
+    """
+    client = ctx.obj["client"]
+    return client.delete_pipeline_version(version_id)
+
+
+@pipeline.command()
+@click.argument("pipeline-id")
+@click.pass_context
+def get(ctx: click.Context, pipeline_id: str):
+    """Get detailed information about an uploaded KFP pipeline"""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    pipeline = client.get_pipeline(pipeline_id)
+    _display_pipeline(pipeline, output_format)
+
+
+@pipeline.command()
+@click.argument("pipeline-id")
+@click.pass_context
+def delete(ctx: click.Context, pipeline_id: str):
+    """Delete an uploaded KFP pipeline."""
+    client = ctx.obj["client"]
+
+    client.delete_pipeline(pipeline_id)
+    click.echo(f"{pipeline_id} is deleted")
+
+
+def _print_pipelines(pipelines: List[kfp_server_api.ApiPipeline],
+                     output_format: OutputFormat):
+    headers = ["Pipeline ID", "Name", "Uploaded at"]
+    data = [[pipeline.id, pipeline.name,
+             pipeline.created_at.isoformat()] for pipeline in pipelines]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _print_pipeline_versions(versions: List[kfp_server_api.ApiPipelineVersion],
+                             output_format: OutputFormat):
+    headers = ["Version ID", "Version name", "Uploaded at", "Pipeline ID"]
+    data = [[
+        version.id, version.name,
+        version.created_at.isoformat(),
+        next(rr
+             for rr in version.resource_references
+             if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).key.id
+    ]
+            for version in versions]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _display_pipeline(pipeline: kfp_server_api.ApiPipeline,
+                      output_format: OutputFormat):
+    # Pipeline information
+    table = [["Pipeline ID", pipeline.id], ["Name", pipeline.name],
+             ["Description", pipeline.description],
+             ["Uploaded at", pipeline.created_at.isoformat()],
+             ["Version ID", pipeline.default_version.id]]
+
+    # Pipeline parameter details
+    headers = ["Parameter Name", "Default Value"]
+    data = []
+    if pipeline.parameters is not None:
+        data = [[param.name, param.value] for param in pipeline.parameters]
+
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Pipeline Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+        print_output(data, headers, output_format, table_format="grid")
+    elif output_format == OutputFormat.json.name:
+        output = dict()
+        output["Pipeline Details"] = dict(table)
+        params = []
+        for item in data:
+            params.append(dict(zip(headers, item)))
+        output["Pipeline Parameters"] = params
+        print_output(output, [], output_format)
+
+
+def _display_pipeline_version(version: kfp_server_api.ApiPipelineVersion,
+                              output_format: OutputFormat):
+    pipeline_id = next(
+        rr for rr in version.resource_references
+        if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).key.id
+    table = [["Pipeline ID", pipeline_id], ["Version name", version.name],
+             ["Uploaded at", version.created_at.isoformat()],
+             ["Version ID", version.id]]
+
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Pipeline Version Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+    elif output_format == OutputFormat.json.name:
+        print_output(dict(table), [], output_format)

--- a/kfp/cli/recurring_run.py
+++ b/kfp/cli/recurring_run.py
@@ -1,0 +1,213 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional
+import json
+import click
+from kfp.cli.output import print_output, OutputFormat
+import kfp_server_api
+
+
+@click.group()
+def recurring_run():
+    """Manage recurring-run resources"""
+    pass
+
+
+@recurring_run.command()
+@click.option(
+    '--catchup/--no-catchup',
+    help='Whether the recurring run should catch up if behind schedule.',
+    type=bool)
+@click.option(
+    '--cron-expression',
+    help='A cron expression representing a set of times, using 6 space-separated fields, e.g. "0 0 9 ? * 2-6".'
+)
+@click.option('--description', help='The description of the recurring run.')
+@click.option(
+    '--enable-caching/--disable-caching',
+    help='Optional. Whether or not to enable caching for the run.',
+    type=bool)
+@click.option(
+    '--enabled/--disabled',
+    help='A bool indicating whether the recurring run is enabled or disabled.',
+    type=bool)
+@click.option(
+    '--end-time',
+    help='The RFC3339 time string of the time when to end the job.')
+@click.option(
+    '--experiment-id',
+    help='The ID of the experiment to create the recurring run under, can only supply either an experiment ID or name.')
+@click.option(
+    '--experiment-name',
+    help='The name of the experiment to create the recurring run under, can only supply either an experiment ID or name.')
+@click.option('--job-name', help='The name of the recurring run.')
+@click.option(
+    '--interval-second',
+    help='Integer indicating the seconds between two recurring runs in for a periodic schedule.'
+)
+@click.option(
+    '--max-concurrency',
+    help='Integer indicating how many jobs can be run in parallel.',
+    type=int)
+@click.option(
+    '--pipeline-id',
+    help='The ID of the pipeline to use to create the recurring run.')
+@click.option(
+    '--pipeline-package-path',
+    help='Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).'
+)
+@click.option(
+    '--start-time',
+    help='The RFC3339 time string of the time when to start the job.')
+@click.option('--version-id', help='The id of a pipeline version.')
+@click.argument("args", nargs=-1)
+@click.pass_context
+def create(ctx: click.Context,
+           job_name: str,
+           experiment_id: Optional[str] = None,
+           experiment_name: Optional[str] = None,
+           catchup: Optional[bool] = None,
+           cron_expression: Optional[str] = None,
+           enabled: Optional[bool] = None,
+           description: Optional[str] = None,
+           enable_caching: Optional[bool] = None,
+           end_time: Optional[str] = None,
+           interval_second: Optional[int] = None,
+           max_concurrency: Optional[int] = None,
+           params: Optional[dict] = None,
+           pipeline_package_path: Optional[str] = None,
+           pipeline_id: Optional[str] = None,
+           start_time: Optional[str] = None,
+           version_id: Optional[str] = None,
+           args: Optional[List[str]] = None):
+    """Create a recurring run."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj['output']
+
+    if (experiment_id is None) == (experiment_name is None):
+        raise ValueError('Either experiment_id or experiment_name is required')
+    if not experiment_id:
+        experiment = client.create_experiment(experiment_name)
+        experiment_id = experiment.id
+
+    # Ensure we only split on the first equals char so the value can contain
+    # equals signs too.
+    split_args: List = [arg.split("=", 1) for arg in args or []]
+    params: Dict[str, Any] = dict(split_args)
+    recurring_run = client.create_recurring_run(
+        cron_expression=cron_expression,
+        description=description,
+        enabled=enabled,
+        enable_caching=enable_caching,
+        end_time=end_time,
+        experiment_id=experiment_id,
+        interval_second=interval_second,
+        job_name=job_name,
+        max_concurrency=max_concurrency,
+        no_catchup=not catchup,
+        params=params,
+        pipeline_package_path=pipeline_package_path,
+        pipeline_id=pipeline_id,
+        start_time=start_time,
+        version_id=version_id)
+
+    _display_recurring_run(recurring_run, output_format)
+
+
+@recurring_run.command()
+@click.option(
+    '-e',
+    '--experiment-id',
+    help='Parent experiment ID of listed recurring runs.')
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m',
+    '--max-size',
+    default=100,
+    help="Max size of the listed recurring runs.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list(ctx: click.Context, experiment_id: str, page_token: str, max_size: int,
+         sort_by: str, filter: str):
+    """List recurring runs"""
+    client = ctx.obj['client']
+    output_format = ctx.obj['output']
+
+    response = client.list_recurring_runs(
+        experiment_id=experiment_id,
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response.jobs:
+        _display_recurring_runs(response.jobs, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No recurring runs found"
+        click.echo(msg)
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def get(ctx: click.Context, job_id: str):
+    """Get detailed information about an experiment"""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.get_recurring_run(job_id)
+    _display_recurring_run(response, output_format)
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def delete(ctx: click.Context, job_id: str):
+    """Delete a recurring run"""
+    client = ctx.obj["client"]
+    client.delete_job(job_id)
+
+
+def _display_recurring_runs(recurring_runs: List[kfp_server_api.ApiJob],
+                            output_format: OutputFormat):
+    headers = ["Recurring Run ID", "Name"]
+    data = [[rr.id, rr.name] for rr in recurring_runs]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _display_recurring_run(recurring_run: kfp_server_api.ApiJob,
+                           output_format: OutputFormat):
+    table = [
+        ["Recurring Run ID", recurring_run.id],
+        ["Name", recurring_run.name],
+    ]
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Recurring Run Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+    elif output_format == OutputFormat.json.name:
+        print_output(dict(table), [], output_format)

--- a/kfp/cli/run.py
+++ b/kfp/cli/run.py
@@ -1,0 +1,228 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import subprocess
+import time
+import json
+import click
+import shutil
+import datetime
+from typing import List
+
+import kfp_server_api
+from kfp._client import Client
+from kfp.cli.output import print_output, OutputFormat
+
+
+@click.group()
+def run():
+    """manage run resources."""
+    pass
+
+
+@run.command()
+@click.option(
+    '-e', '--experiment-id', help='Parent experiment ID of listed runs.')
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m', '--max-size', default=100, help="Max size of the listed runs.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list(ctx: click.Context, experiment_id: str, page_token: str, max_size: int,
+         sort_by: str, filter: str):
+    """list recent KFP runs."""
+    client = ctx.obj['client']
+    output_format = ctx.obj['output']
+    response = client.list_runs(
+        experiment_id=experiment_id,
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response and response.runs:
+        _print_runs(response.runs, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = 'No runs found.'
+        click.echo(msg)
+
+
+@run.command()
+@click.option(
+    '-e',
+    '--experiment-name',
+    required=True,
+    help='Experiment name of the run.')
+@click.option('-r', '--run-name', help='Name of the run.')
+@click.option(
+    '-f',
+    '--package-file',
+    type=click.Path(exists=True, dir_okay=False),
+    help='Path of the pipeline package file.')
+@click.option('-p', '--pipeline-id', help='ID of the pipeline template.')
+@click.option('-n', '--pipeline-name', help='Name of the pipeline template.')
+@click.option(
+    '-w',
+    '--watch',
+    is_flag=True,
+    default=False,
+    help='Watch the run status until it finishes.')
+@click.option('-v', '--version', help='ID of the pipeline version.')
+@click.option(
+    '-t',
+    '--timeout',
+    default=0,
+    help='Wait for a run to complete until timeout in seconds.',
+    type=int)
+@click.argument('args', nargs=-1)
+@click.pass_context
+def submit(ctx: click.Context, experiment_name: str, run_name: str,
+           package_file: str, pipeline_id: str, pipeline_name: str, watch: bool,
+           timeout: int, version: str, args: List[str]):
+    """submit a KFP run."""
+    client = ctx.obj['client']
+    namespace = ctx.obj['namespace']
+    output_format = ctx.obj['output']
+    if not run_name:
+        run_name = experiment_name
+
+    if not pipeline_id and pipeline_name:
+        pipeline_id = client.get_pipeline_id(name=pipeline_name)
+
+    if not package_file and not pipeline_id and not version:
+        click.echo(
+            'You must provide one of [package_file, pipeline_id, version].',
+            err=True)
+        sys.exit(1)
+
+    arg_dict = dict(arg.split('=', maxsplit=1) for arg in args)
+
+    experiment = client.create_experiment(experiment_name)
+    run = client.run_pipeline(
+        experiment.id,
+        run_name,
+        package_file,
+        arg_dict,
+        pipeline_id,
+        version_id=version)
+    if timeout > 0:
+        _wait_for_run_completion(client, run.id, timeout, output_format)
+    else:
+        _display_run(client, namespace, run.id, watch, output_format)
+
+
+@run.command()
+@click.option(
+    '-w',
+    '--watch',
+    is_flag=True,
+    default=False,
+    help='Watch the run status until it finishes.')
+@click.option(
+    '-d',
+    '--detail',
+    is_flag=True,
+    default=False,
+    help='Get detailed information of the run in json format.')
+@click.argument('run-id')
+@click.pass_context
+def get(ctx: click.Context, watch: bool, detail: bool, run_id: str):
+    """display the details of a KFP run."""
+    client = ctx.obj['client']
+    namespace = ctx.obj['namespace']
+    output_format = ctx.obj['output']
+
+    _display_run(client, namespace, run_id, watch, output_format, detail)
+
+
+def _display_run(client: click.Context,
+                 namespace: str,
+                 run_id: str,
+                 watch: bool,
+                 output_format: OutputFormat,
+                 detail: bool = False):
+    run = client.get_run(run_id).run
+
+    if detail:
+        data = {
+            key:
+            value.isoformat() if isinstance(value, datetime.datetime) else value
+            for key, value in run.to_dict().items()
+            if key not in ['pipeline_spec'
+                          ]  # useless but too much detailed field
+        }
+        click.echo(data)
+        return
+
+    _print_runs([run], output_format)
+    if not watch:
+        return
+    argo_path = shutil.which('argo')
+    if not argo_path:
+        raise RuntimeError(
+            "argo isn't found in $PATH. It's necessary for watch. "
+            "Please make sure it's installed and available. "
+            "Installation instructions be found here - "
+            "https://github.com/argoproj/argo-workflows/releases")
+
+    argo_workflow_name = None
+    while True:
+        time.sleep(1)
+        run_detail = client.get_run(run_id)
+        run = run_detail.run
+        if run_detail.pipeline_runtime and run_detail.pipeline_runtime.workflow_manifest:
+            manifest = json.loads(run_detail.pipeline_runtime.workflow_manifest)
+            if manifest['metadata'] and manifest['metadata']['name']:
+                argo_workflow_name = manifest['metadata']['name']
+                break
+        if run_detail.run.status in ['Succeeded', 'Skipped', 'Failed', 'Error']:
+            click.echo('Run is finished with status {}.'.format(
+                run_detail.run.status))
+            return
+    if argo_workflow_name:
+        subprocess.run(
+            [argo_path, 'watch', argo_workflow_name, '-n', namespace])
+        _print_runs([run], output_format)
+
+
+def _wait_for_run_completion(client: Client, run_id: str, timeout: int,
+                             output_format: OutputFormat):
+    run_detail = client.wait_for_run_completion(run_id, timeout)
+    _print_runs([run_detail.run], output_format)
+
+
+def _print_runs(runs: List[kfp_server_api.ApiRun], output_format: OutputFormat):
+    headers = ['run id', 'name', 'status', 'created at', 'experiment id']
+    data = [[
+        run.id, run.name, run.status,
+        run.created_at.isoformat(),
+        next(rr
+             for rr in run.resource_references
+             if rr.key.type == kfp_server_api.ApiResourceType.EXPERIMENT).key.id
+    ]
+            for run in runs]
+    print_output(data, headers, output_format, table_format='grid')

--- a/kfp/compiler/__init__.py
+++ b/kfp/compiler/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .compiler import Compiler
+from ..containers._component_builder import build_python_component, build_docker_image, VersionedDependency

--- a/kfp/compiler/_data_passing_rewriter.py
+++ b/kfp/compiler/_data_passing_rewriter.py
@@ -1,0 +1,479 @@
+import copy
+import json
+import os
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from kfp.dsl import _component_bridge
+from kfp import dsl
+
+
+def fix_big_data_passing(workflow: dict) -> dict:
+    '''fix_big_data_passing converts a workflow where some artifact data is passed as parameters and converts it to a workflow where this data is passed as artifacts.
+    Args:
+        workflow: The workflow to fix
+    Returns:
+        The fixed workflow
+
+    Motivation:
+    DSL compiler only supports passing Argo parameters.
+    Due to the convoluted nature of the DSL compiler, the artifact consumption and passing has been implemented on top of that using parameter passing. The artifact data is passed as parameters and the consumer template creates an artifact/file out of that data.
+    Due to the limitations of Kubernetes and Argo this scheme cannot pass data larger than few kilobytes preventing any serious use of artifacts.
+
+    This function rewrites the compiled workflow so that the data consumed as artifact is passed as artifact.
+    It also prunes the unused parameter outputs. This is important since if a big piece of data is ever returned through a file that is also output as parameter, the execution will fail.
+    This makes is possible to pass large amounts of data.
+
+    Implementation:
+    1. Index the DAGs to understand how data is being passed and which inputs/outputs are connected to each other.
+    2. Search for direct data consumers in container/resource templates and some DAG task attributes (e.g. conditions and loops) to find out which inputs are directly consumed as parameters/artifacts.
+    3. Propagate the consumption information upstream to all inputs/outputs all the way up to the data producers.
+    4. Convert the inputs, outputs and arguments based on how they're consumed downstream.
+    '''
+    workflow = copy.deepcopy(workflow)
+
+    container_templates = [
+        template for template in workflow['spec']['templates']
+        if 'container' in template
+    ]
+    dag_templates = [
+        template for template in workflow['spec']['templates']
+        if 'dag' in template
+    ]
+    resource_templates = [
+        template for template in workflow['spec']['templates']
+        if 'resource' in template
+    ]  # TODO: Handle these
+    resource_template_names = set(
+        template['name'] for template in resource_templates)
+
+    # 1. Index the DAGs to understand how data is being passed and which inputs/outputs are connected to each other.
+    template_input_to_parent_dag_inputs = {
+    }  # (task_template_name, task_input_name) -> Set[(dag_template_name, dag_input_name)]
+    template_input_to_parent_task_outputs = {
+    }  # (task_template_name, task_input_name) -> Set[(upstream_template_name, upstream_output_name)]
+    template_input_to_parent_constant_arguments = {
+    }  #(task_template_name, task_input_name) -> Set[argument_value] # Unused
+    dag_output_to_parent_template_outputs = {
+    }  # (dag_template_name, output_name) -> Set[(upstream_template_name, upstream_output_name)]
+
+    for template in dag_templates:
+        dag_template_name = template['name']
+        # Indexing task arguments
+        dag_tasks = template['dag']['tasks']
+        task_name_to_template_name = {
+            task['name']: task['template'] for task in dag_tasks
+        }
+        for task in dag_tasks:
+            task_template_name = task['template']
+            parameter_arguments = task.get('arguments',
+                                           {}).get('parameters', {})
+            for parameter_argument in parameter_arguments:
+                task_input_name = parameter_argument['name']
+                argument_value = parameter_argument['value']
+
+                argument_placeholder_parts = deconstruct_single_placeholder(
+                    argument_value)
+                if not argument_placeholder_parts:  # Argument is considered to be constant string
+                    template_input_to_parent_constant_arguments.setdefault(
+                        (task_template_name, task_input_name),
+                        set()).add(argument_value)
+
+                placeholder_type = argument_placeholder_parts[0]
+                if placeholder_type not in ('inputs', 'outputs', 'tasks',
+                                            'steps', 'workflow', 'pod', 'item'):
+                    # Do not fail on Jinja or other double-curly-brace templates
+                    continue
+                if placeholder_type == 'inputs':
+                    assert argument_placeholder_parts[1] == 'parameters'
+                    dag_input_name = argument_placeholder_parts[2]
+                    template_input_to_parent_dag_inputs.setdefault(
+                        (task_template_name, task_input_name), set()).add(
+                            (dag_template_name, dag_input_name))
+                elif placeholder_type == 'tasks':
+                    upstream_task_name = argument_placeholder_parts[1]
+                    assert argument_placeholder_parts[2] == 'outputs'
+                    assert argument_placeholder_parts[3] == 'parameters'
+                    upstream_output_name = argument_placeholder_parts[4]
+                    upstream_template_name = task_name_to_template_name[
+                        upstream_task_name]
+                    template_input_to_parent_task_outputs.setdefault(
+                        (task_template_name, task_input_name), set()).add(
+                            (upstream_template_name, upstream_output_name))
+                elif placeholder_type == 'item' or placeholder_type == 'workflow' or placeholder_type == 'pod':
+                    # Treat loop variables as constant values
+                    # workflow.parameters.* placeholders are not supported, but the DSL compiler does not produce those.
+                    template_input_to_parent_constant_arguments.setdefault(
+                        (task_template_name, task_input_name),
+                        set()).add(argument_value)
+                else:
+                    raise AssertionError
+
+                dag_input_name = extract_input_parameter_name(argument_value)
+                if dag_input_name:
+                    template_input_to_parent_dag_inputs.setdefault(
+                        (task_template_name, task_input_name), set()).add(
+                            (dag_template_name, dag_input_name))
+                else:
+                    template_input_to_parent_constant_arguments.setdefault(
+                        (task_template_name, task_input_name),
+                        set()).add(argument_value)
+
+            # Indexing DAG outputs (Does DSL compiler produce them?)
+            for dag_output in task.get('outputs', {}).get('parameters', {}):
+                dag_output_name = dag_output['name']
+                output_value = dag_output['value']
+                argument_placeholder_parts = deconstruct_single_placeholder(
+                    output_value)
+                placeholder_type = argument_placeholder_parts[0]
+                if not argument_placeholder_parts:  # Argument is considered to be constant string
+                    raise RuntimeError(
+                        'Constant DAG output values are not supported for now.')
+                if placeholder_type == 'inputs':
+                    raise RuntimeError(
+                        'Pass-through DAG inputs/outputs are not supported')
+                elif placeholder_type == 'tasks':
+                    upstream_task_name = argument_placeholder_parts[1]
+                    assert argument_placeholder_parts[2] == 'outputs'
+                    assert argument_placeholder_parts[3] == 'parameters'
+                    upstream_output_name = argument_placeholder_parts[4]
+                    upstream_template_name = task_name_to_template_name[
+                        upstream_task_name]
+                    dag_output_to_parent_template_outputs.setdefault(
+                        (dag_template_name, dag_output_name), set()).add(
+                            (upstream_template_name, upstream_output_name))
+                elif placeholder_type == 'item' or placeholder_type == 'workflow' or placeholder_type == 'pod':
+                    raise RuntimeError(
+                        'DAG output value "{}" is not supported.'.format(
+                            output_value))
+                else:
+                    raise AssertionError(
+                        'Unexpected placeholder type "{}".'.format(
+                            placeholder_type))
+    # Finshed indexing the DAGs
+
+    # 2. Search for direct data consumers in container/resource templates and some DAG task attributes (e.g. conditions and loops) to find out which inputs are directly consumed as parameters/artifacts.
+    inputs_directly_consumed_as_parameters = set()
+    inputs_directly_consumed_as_artifacts = set()
+    outputs_directly_consumed_as_parameters = set()
+
+    # Searching for artifact input consumers in container template inputs
+    for template in container_templates:
+        template_name = template['name']
+        for input_artifact in template.get('inputs', {}).get('artifacts', {}):
+            raw_data = input_artifact['raw']['data']  # The structure must exist
+            # The raw data must be a single input parameter reference. Otherwise (e.g. it's a string or a string with multiple inputs) we should not do the conversion to artifact passing.
+            input_name = extract_input_parameter_name(raw_data)
+            if input_name:
+                inputs_directly_consumed_as_artifacts.add(
+                    (template_name, input_name))
+                del input_artifact[
+                    'raw']  # Deleting the "default value based" data passing hack so that it's replaced by the "argument based" way of data passing.
+                input_artifact[
+                    'name'] = input_name  # The input artifact name should be the same as the original input parameter name
+
+    # Searching for parameter input consumers in DAG templates (.when, .withParam, etc)
+    for template in dag_templates:
+        template_name = template['name']
+        dag_tasks = template['dag']['tasks']
+        task_name_to_template_name = {
+            task['name']: task['template'] for task in dag_tasks
+        }
+        for task in template['dag']['tasks']:
+            # We do not care about the inputs mentioned in task arguments since we will be free to switch them from parameters to artifacts
+            # TODO: Handle cases where argument value is a string containing placeholders (not just consisting of a single placeholder) or the input name contains placeholder
+            task_without_arguments = task.copy()  # Shallow copy
+            task_without_arguments.pop('arguments', None)
+            placeholders = extract_all_placeholders(task_without_arguments)
+            for placeholder in placeholders:
+                parts = placeholder.split('.')
+                placeholder_type = parts[0]
+                if placeholder_type not in ('inputs', 'outputs', 'tasks',
+                                            'steps', 'workflow', 'pod', 'item'):
+                    # Do not fail on Jinja or other double-curly-brace templates
+                    continue
+                if placeholder_type == 'inputs':
+                    if parts[1] == 'parameters':
+                        input_name = parts[2]
+                        inputs_directly_consumed_as_parameters.add(
+                            (template_name, input_name))
+                    else:
+                        raise AssertionError
+                elif placeholder_type == 'tasks':
+                    upstream_task_name = parts[1]
+                    assert parts[2] == 'outputs'
+                    assert parts[3] == 'parameters'
+                    upstream_output_name = parts[4]
+                    upstream_template_name = task_name_to_template_name[
+                        upstream_task_name]
+                    outputs_directly_consumed_as_parameters.add(
+                        (upstream_template_name, upstream_output_name))
+                elif placeholder_type == 'workflow' or placeholder_type == 'pod':
+                    pass
+                elif placeholder_type == 'item':
+                    raise AssertionError(
+                        'The "{{item}}" placeholder is not expected outside task arguments.'
+                    )
+                else:
+                    raise AssertionError(
+                        'Unexpected placeholder type "{}".'.format(
+                            placeholder_type))
+
+    # Searching for parameter input consumers in container and resource templates
+    for template in container_templates + resource_templates:
+        template_name = template['name']
+        placeholders = extract_all_placeholders(template)
+        for placeholder in placeholders:
+            parts = placeholder.split('.')
+            placeholder_type = parts[0]
+            if placeholder_type not in ('inputs', 'outputs', 'tasks', 'steps',
+                                        'workflow', 'pod', 'item'):
+                # Do not fail on Jinja or other double-curly-brace templates
+                continue
+
+            if placeholder_type == 'workflow' or placeholder_type == 'pod':
+                pass
+            elif placeholder_type == 'inputs':
+                if parts[1] == 'parameters':
+                    input_name = parts[2]
+                    inputs_directly_consumed_as_parameters.add(
+                        (template_name, input_name))
+                elif parts[1] == 'artifacts':
+                    raise AssertionError(
+                        'Found unexpected Argo input artifact placeholder in container template: {}'
+                        .format(placeholder))
+                else:
+                    raise AssertionError(
+                        'Found unexpected Argo input placeholder in container template: {}'
+                        .format(placeholder))
+            else:
+                raise AssertionError(
+                    'Found unexpected Argo placeholder in container template: {}'
+                    .format(placeholder))
+
+    # Finished indexing data consumers
+
+    # 3. Propagate the consumption information upstream to all inputs/outputs all the way up to the data producers.
+    inputs_consumed_as_parameters = set()
+    inputs_consumed_as_artifacts = set()
+
+    outputs_consumed_as_parameters = set()
+    outputs_consumed_as_artifacts = set()
+
+    def mark_upstream_ios_of_input(template_input, marked_inputs,
+                                   marked_outputs):
+        # Stopping if the input has already been visited to save time and handle recursive calls
+        if template_input in marked_inputs:
+            return
+        marked_inputs.add(template_input)
+
+        upstream_inputs = template_input_to_parent_dag_inputs.get(
+            template_input, [])
+        for upstream_input in upstream_inputs:
+            mark_upstream_ios_of_input(upstream_input, marked_inputs,
+                                       marked_outputs)
+
+        upstream_outputs = template_input_to_parent_task_outputs.get(
+            template_input, [])
+        for upstream_output in upstream_outputs:
+            mark_upstream_ios_of_output(upstream_output, marked_inputs,
+                                        marked_outputs)
+
+    def mark_upstream_ios_of_output(template_output, marked_inputs,
+                                    marked_outputs):
+        # Stopping if the output has already been visited to save time and handle recursive calls
+        if template_output in marked_outputs:
+            return
+        marked_outputs.add(template_output)
+
+        upstream_outputs = dag_output_to_parent_template_outputs.get(
+            template_output, [])
+        for upstream_output in upstream_outputs:
+            mark_upstream_ios_of_output(upstream_output, marked_inputs,
+                                        marked_outputs)
+
+    for input in inputs_directly_consumed_as_parameters:
+        mark_upstream_ios_of_input(input, inputs_consumed_as_parameters,
+                                   outputs_consumed_as_parameters)
+    for input in inputs_directly_consumed_as_artifacts:
+        mark_upstream_ios_of_input(input, inputs_consumed_as_artifacts,
+                                   outputs_consumed_as_artifacts)
+    for output in outputs_directly_consumed_as_parameters:
+        mark_upstream_ios_of_output(output, inputs_consumed_as_parameters,
+                                    outputs_consumed_as_parameters)
+
+    # 4. Convert the inputs, outputs and arguments based on how they're consumed downstream.
+
+    # Container templates already output all data as artifacts, so we do not need to convert their outputs to artifacts. (But they also output data as parameters and we need to fix that.)
+
+    # Convert DAG argument passing from parameter to artifacts as needed
+    for template in dag_templates:
+        # Converting DAG inputs
+        inputs = template.get('inputs', {})
+        input_parameters = inputs.get('parameters', [])
+        input_artifacts = inputs.setdefault('artifacts', [])  # Should be empty
+        for input_parameter in input_parameters:
+            input_name = input_parameter['name']
+            if (template['name'], input_name) in inputs_consumed_as_artifacts:
+                input_artifacts.append({
+                    'name': input_name,
+                })
+
+        # Converting DAG outputs
+        outputs = template.get('outputs', {})
+        output_parameters = outputs.get('parameters', [])
+        output_artifacts = outputs.setdefault('artifacts',
+                                              [])  # Should be empty
+        for output_parameter in output_parameters:
+            output_name = output_parameter['name']
+            if (template['name'], output_name) in outputs_consumed_as_artifacts:
+                parameter_reference_placeholder = output_parameter['valueFrom'][
+                    'parameter']
+                output_artifacts.append({
+                    'name':
+                        output_name,
+                    'from':
+                        parameter_reference_placeholder.replace(
+                            '.parameters.', '.artifacts.'),
+                })
+
+        # Converting DAG task arguments
+        tasks = template.get('dag', {}).get('tasks', [])
+        for task in tasks:
+            task_arguments = task.get('arguments', {})
+            parameter_arguments = task_arguments.get('parameters', [])
+            artifact_arguments = task_arguments.setdefault('artifacts', [])
+            for parameter_argument in parameter_arguments:
+                input_name = parameter_argument['name']
+                if (task['template'],
+                        input_name) in inputs_consumed_as_artifacts:
+                    argument_value = parameter_argument[
+                        'value']  # argument parameters always use "value"; output parameters always use "valueFrom" (container/DAG/etc)
+                    argument_placeholder_parts = deconstruct_single_placeholder(
+                        argument_value)
+                    # If the argument is consumed as artifact downstream:
+                    # Pass DAG inputs and DAG/container task outputs as usual;
+                    # Everything else (constant strings, loop variables, resource task outputs) is passed as raw artifact data. Argo properly replaces placeholders in it.
+                    if argument_placeholder_parts and argument_placeholder_parts[
+                            0] in [
+                                'inputs', 'tasks'
+                            ] and not (argument_placeholder_parts[0] == 'tasks'
+                                       and argument_placeholder_parts[1]
+                                       in resource_template_names):
+                        artifact_arguments.append({
+                            'name':
+                                input_name,
+                            'from':
+                                argument_value.replace('.parameters.',
+                                                       '.artifacts.'),
+                        })
+                    else:
+                        artifact_arguments.append({
+                            'name': input_name,
+                            'raw': {
+                                'data': argument_value,
+                            },
+                        })
+
+    # Remove input parameters unless they're used downstream. This also removes unused container template inputs if any.
+    for template in container_templates + dag_templates:
+        inputs = template.get('inputs', {})
+        inputs['parameters'] = [
+            input_parameter for input_parameter in inputs.get('parameters', [])
+            if (template['name'],
+                input_parameter['name']) in inputs_consumed_as_parameters
+        ]
+
+    # Remove output parameters unless they're used downstream
+    for template in container_templates + dag_templates:
+        outputs = template.get('outputs', {})
+        outputs['parameters'] = [
+            output_parameter
+            for output_parameter in outputs.get('parameters', [])
+            if (template['name'],
+                output_parameter['name']) in outputs_consumed_as_parameters
+        ]
+
+    # Remove DAG parameter arguments unless they're used downstream
+    for template in dag_templates:
+        tasks = template.get('dag', {}).get('tasks', [])
+        for task in tasks:
+            task_arguments = task.get('arguments', {})
+            task_arguments['parameters'] = [
+                parameter_argument
+                for parameter_argument in task_arguments.get('parameters', [])
+                if (task['template'],
+                    parameter_argument['name']) in inputs_consumed_as_parameters
+            ]
+
+    # Fix Workflow parameter arguments that are consumed as artifacts downstream
+    #
+    workflow_spec = workflow['spec']
+    entrypoint_template_name = workflow_spec['entrypoint']
+    workflow_arguments = workflow_spec['arguments']
+    parameter_arguments = workflow_arguments.get('parameters', [])
+    artifact_arguments = workflow_arguments.get('artifacts',
+                                                [])  # Should be empty
+    for parameter_argument in parameter_arguments:
+        input_name = parameter_argument['name']
+        if (entrypoint_template_name,
+                input_name) in inputs_consumed_as_artifacts:
+            artifact_arguments.append({
+                'name': input_name,
+                'raw': {
+                    'data': '{{workflow.parameters.' + input_name + '}}',
+                },
+            })
+    if artifact_arguments:
+        workflow_arguments['artifacts'] = artifact_arguments
+
+    clean_up_empty_workflow_structures(workflow)
+    return workflow
+
+
+def clean_up_empty_workflow_structures(workflow: dict):
+    templates = workflow['spec']['templates']
+    for template in templates:
+        inputs = template.setdefault('inputs', {})
+        if not inputs.setdefault('parameters', []):
+            del inputs['parameters']
+        if not inputs.setdefault('artifacts', []):
+            del inputs['artifacts']
+        if not inputs:
+            del template['inputs']
+        outputs = template.setdefault('outputs', {})
+        if not outputs.setdefault('parameters', []):
+            del outputs['parameters']
+        if not outputs.setdefault('artifacts', []):
+            del outputs['artifacts']
+        if not outputs:
+            del template['outputs']
+        if 'dag' in template:
+            for task in template['dag'].get('tasks', []):
+                arguments = task.setdefault('arguments', {})
+                if not arguments.setdefault('parameters', []):
+                    del arguments['parameters']
+                if not arguments.setdefault('artifacts', []):
+                    del arguments['artifacts']
+                if not arguments:
+                    del task['arguments']
+
+
+def extract_all_placeholders(template: dict) -> Set[str]:
+    template_str = json.dumps(template)
+    placeholders = set(re.findall('{{([-._a-zA-Z0-9]+)}}', template_str))
+    return placeholders
+
+
+def extract_input_parameter_name(s: str) -> Optional[str]:
+    match = re.fullmatch('{{inputs.parameters.([-_a-zA-Z0-9]+)}}', s)
+    if not match:
+        return None
+    (input_name,) = match.groups()
+    return input_name
+
+
+def deconstruct_single_placeholder(s: str) -> List[str]:
+    if not re.fullmatch('{{[-._a-zA-Z0-9]+}}', s):
+        return None
+    return s.lstrip('{').rstrip('}').split('.')

--- a/kfp/compiler/_data_passing_using_volume.py
+++ b/kfp/compiler/_data_passing_using_volume.py
@@ -1,0 +1,254 @@
+#/bin/env python3
+
+import copy
+import json
+import os
+import re
+import warnings
+from typing import List, Optional, Set
+
+
+def rewrite_data_passing_to_use_volumes(
+    workflow: dict,
+    volume: dict,
+    path_prefix: str = 'artifact_data/',
+) -> dict:
+    """Converts Argo workflow that passes data using artifacts to workflow that
+    passes data using a single multi-write volume.
+
+    Implementation: Changes file passing system from passing Argo artifacts to passing parameters holding volumeMount subPaths.
+
+    Limitations:
+    * All artifact file names must be the same (e.g. "data"). E.g. "/tmp/outputs/my_out_1/data".
+      Otherwise consumer component that can receive data from different producers won't be able to specify input file path since files from different upstreams will have different names.
+    * Passing constant arguments to artifact inputs is not supported for now. Only references can be passed.
+
+    Args:
+        workflow: Workflow (dict) that needs to be converted.
+        volume: Kubernetes spec (dict) of a volume that should be used for data passing. The volume should support multi-write (READ_WRITE_MANY) if the workflow has any parallel steps. Example: {'persistentVolumeClaim': {'claimName': 'my-pvc'}}
+
+    Returns:
+        Converted workflow (dict).
+    """
+
+    # Limitation: All artifact file names must be the same (e.g. "data"). E.g. "/tmp/outputs/my_out_1/data".
+    # Otherwise consumer component that can receive data from different producers won't be able to specify input file path since files from different upstreams will have different names.
+    # Maybe this limitation can be lifted, but it is not trivial. Maybe with DSL compile it's easier since the graph it creates is usually a tree. But recursion creates a real graph.
+    # Limitation: Passing constant values to artifact inputs is not supported for now.
+
+    # Idea: Passing volumeMount subPaths instead of artifcats
+
+    workflow = copy.deepcopy(workflow)
+    templates = workflow['spec']['templates']
+
+    container_templates = [
+        template for template in templates if 'container' in template
+    ]
+    dag_templates = [template for template in templates if 'dag' in template]
+    steps_templates = [
+        template for template in templates if 'steps' in template
+    ]
+
+    execution_data_dir = path_prefix + '{{workflow.uid}}_{{pod.name}}/'
+
+    data_volume_name = 'data-storage'
+    volume['name'] = data_volume_name
+
+    subpath_parameter_name_suffix = '-subpath'
+
+    def convert_artifact_reference_to_parameter_reference(
+            reference: str) -> str:
+        parameter_reference = re.sub(
+            r'{{([^}]+)\.artifacts\.([^}]+)}}',
+            r'{{\1.parameters.\2' + subpath_parameter_name_suffix +
+            '}}',  # re.escape(subpath_parameter_name_suffix) escapes too much.
+            reference,
+        )
+        return parameter_reference
+
+    # Adding the data storage volume to the workflow
+    workflow['spec'].setdefault('volumes', []).append(volume)
+
+    all_artifact_file_names = set(
+    )  # All artifacts should have same file name (usually, "data"). This variable holds all different artifact names for verification.
+
+    # Rewriting container templates
+    for template in templates:
+        if 'container' not in template and 'script' not in template:
+            continue
+        container_spec = template['container'] or template['steps']
+        # Inputs
+        input_artifacts = template.get('inputs', {}).get('artifacts', [])
+        if input_artifacts:
+            input_parameters = template.setdefault('inputs', {}).setdefault(
+                'parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for input_artifact in input_artifacts:
+                subpath_parameter_name = input_artifact[
+                    'name'] + subpath_parameter_name_suffix  # TODO: Maybe handle clashing names.
+                artifact_file_name = os.path.basename(input_artifact['path'])
+                all_artifact_file_names.add(artifact_file_name)
+                artifact_dir = os.path.dirname(input_artifact['path'])
+                volume_mounts.append({
+                    'mountPath':
+                        artifact_dir,
+                    'name':
+                        data_volume_name,
+                    'subPath':
+                        '{{inputs.parameters.' + subpath_parameter_name + '}}',
+                    'readOnly':
+                        True,
+                })
+                input_parameters.append({
+                    'name': subpath_parameter_name,
+                })
+        template.get('inputs', {}).pop('artifacts', None)
+
+        # Outputs
+        output_artifacts = template.get('outputs', {}).get('artifacts', [])
+        if output_artifacts:
+            output_parameters = template.setdefault('outputs', {}).setdefault(
+                'parameters', [])
+            del template.get('outputs', {})['artifacts']
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for output_artifact in output_artifacts:
+                output_name = output_artifact['name']
+                subpath_parameter_name = output_name + subpath_parameter_name_suffix  # TODO: Maybe handle clashing names.
+                artifact_file_name = os.path.basename(output_artifact['path'])
+                all_artifact_file_names.add(artifact_file_name)
+                artifact_dir = os.path.dirname(output_artifact['path'])
+                output_subpath = execution_data_dir + output_name
+                volume_mounts.append({
+                    'mountPath': artifact_dir,
+                    'name': data_volume_name,
+                    'subPath':
+                        output_subpath,  # TODO: Switch to subPathExpr when it's out of beta: https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath-with-expanded-environment-variables
+                })
+                output_parameters.append({
+                    'name': subpath_parameter_name,
+                    'value': output_subpath,  # Requires Argo 2.3.0+
+                })
+            whitelist = ['mlpipeline-ui-metadata', 'mlpipeline-metrics']
+            output_artifacts = [artifact for artifact in output_artifacts if artifact['name'] in whitelist]
+            if not output_artifacts:
+              template.get('outputs', {}).pop('artifacts', None)
+            else:
+                template.get('outputs', {}).update({'artifacts': output_artifacts})
+
+    # Rewrite DAG templates
+    for template in templates:
+        if 'dag' not in template and 'steps' not in template:
+            continue
+
+        # Inputs
+        input_artifacts = template.get('inputs', {}).get('artifacts', [])
+        if input_artifacts:
+            input_parameters = template.setdefault('inputs', {}).setdefault(
+                'parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for input_artifact in input_artifacts:
+                subpath_parameter_name = input_artifact[
+                    'name'] + subpath_parameter_name_suffix  # TODO: Maybe handle clashing names.
+                input_parameters.append({
+                    'name': subpath_parameter_name,
+                })
+        template.get('inputs', {}).pop('artifacts', None)
+
+        # Outputs
+        output_artifacts = template.get('outputs', {}).get('artifacts', [])
+        if output_artifacts:
+            output_parameters = template.setdefault('outputs', {}).setdefault(
+                'parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for output_artifact in output_artifacts:
+                output_name = output_artifact['name']
+                subpath_parameter_name = output_name + subpath_parameter_name_suffix  # TODO: Maybe handle clashing names.
+                output_parameters.append({
+                    'name': subpath_parameter_name,
+                    'valueFrom': {
+                        'parameter':
+                            convert_artifact_reference_to_parameter_reference(
+                                output_artifact['from'])
+                    },
+                })
+        template.get('outputs', {}).pop('artifacts', None)
+
+        # Arguments
+        for task in template.get('dag', {}).get('tasks', []) + [
+                steps for group in template.get('steps', []) for steps in group
+        ]:
+            argument_artifacts = task.get('arguments', {}).get('artifacts', [])
+            if argument_artifacts:
+                argument_parameters = task.setdefault('arguments',
+                                                      {}).setdefault(
+                                                          'parameters', [])
+                for argument_artifact in argument_artifacts:
+                    if 'from' not in argument_artifact:
+                        raise NotImplementedError(
+                            'Volume-based data passing rewriter does not support constant artifact arguments at this moment. Only references can be passed.'
+                        )
+                    subpath_parameter_name = argument_artifact[
+                        'name'] + subpath_parameter_name_suffix  # TODO: Maybe handle clashing names.
+                    argument_parameters.append({
+                        'name':
+                            subpath_parameter_name,
+                        'value':
+                            convert_artifact_reference_to_parameter_reference(
+                                argument_artifact['from']),
+                    })
+            task.get('arguments', {}).pop('artifacts', None)
+
+        # There should not be any artifact references in any other part of DAG template (only parameter references)
+
+    # Check that all artifacts have the same file names
+    if len(all_artifact_file_names) > 1:
+        warnings.warn(
+            'Detected different artifact file names: [{}]. The workflow can fail at runtime. Please use the same file name (e.g. "data") for all artifacts.'
+            .format(', '.join(all_artifact_file_names)))
+
+    # Fail if workflow has argument artifacts
+    workflow_argument_artifacts = workflow['spec'].get('arguments',
+                                                       {}).get('artifacts', [])
+    if workflow_argument_artifacts:
+        raise NotImplementedError(
+            'Volume-based data passing rewriter does not support constant artifact arguments at this moment. Only references can be passed.'
+        )
+
+    return workflow
+
+
+if __name__ == '__main__':
+    """Converts Argo workflow that passes data using artifacts to workflow that
+    passes data using a single multi-write volume."""
+
+    import argparse
+    import io
+    import yaml
+
+    parser = argparse.ArgumentParser(
+        prog='data_passing_using_volume',
+        epilog='''Example: data_passing_using_volume.py --input argo/examples/artifact-passing.yaml --output argo/examples/artifact-passing-volumes.yaml --volume "persistentVolumeClaim: {claimName: my-pvc}"'''
+    )
+    parser.add_argument(
+        "--input",
+        type=argparse.FileType('r'),
+        required=True,
+        help='Path to workflow that needs to be converted.')
+    parser.add_argument(
+        "--output",
+        type=argparse.FileType('w'),
+        required=True,
+        help='Path where to write converted workflow.')
+    parser.add_argument(
+        "--volume",
+        type=str,
+        required=True,
+        help='''Kubernetes spec (YAML) of a volume that should be used for data passing. The volume should support multi-write (READ_WRITE_MANY) if the workflow has any parallel steps. Example: "persistentVolumeClaim: {claimName: my-pvc}".'''
+    )
+    args = parser.parse_args()
+
+    input_workflow = yaml.safe_load(args.input)
+    volume = yaml.safe_load(io.StringIO(args.volume))
+    output_workflow = rewrite_data_passing_to_use_volumes(
+        input_workflow, volume)
+    yaml.dump(output_workflow, args.output)

--- a/kfp/compiler/_default_transformers.py
+++ b/kfp/compiler/_default_transformers.py
@@ -1,0 +1,92 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from kubernetes import client as k8s_client
+from typing import Callable, Dict, Optional, Text
+from kfp.dsl._container_op import BaseOp, ContainerOp
+
+
+def add_pod_env(op: BaseOp) -> BaseOp:
+    """Adds environment info if the Pod has the label `add-pod-env = true`.
+    """
+    if isinstance(
+            op, ContainerOp
+    ) and op.pod_labels and 'add-pod-env' in op.pod_labels and op.pod_labels[
+            'add-pod-env'] == 'true':
+        return add_kfp_pod_env(op)
+
+
+def add_kfp_pod_env(op: BaseOp) -> BaseOp:
+    """Adds KFP pod environment info to the specified ContainerOp."""
+    if not isinstance(op, ContainerOp):
+        warnings.warn(
+            'Trying to add default KFP environment variables to an Op that is '
+            'not a ContainerOp. Ignoring request.')
+        return op
+
+    op.container.add_env_variable(
+        k8s_client.V1EnvVar(
+            name='KFP_POD_NAME',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(
+                    field_path='metadata.name')))
+    ).add_env_variable(
+        k8s_client.V1EnvVar(
+            name='KFP_POD_UID',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(
+                    field_path='metadata.uid')))
+    ).add_env_variable(
+        k8s_client.V1EnvVar(
+            name='KFP_NAMESPACE',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(
+                    field_path='metadata.namespace')))
+    ).add_env_variable(
+        k8s_client.V1EnvVar(
+            name='WORKFLOW_ID',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(
+                    field_path="metadata.labels['workflows.argoproj.io/workflow']"
+                )))
+    ).add_env_variable(
+        k8s_client.V1EnvVar(
+            name='KFP_RUN_ID',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(
+                    field_path="metadata.labels['pipeline/runid']")))
+    ).add_env_variable(
+        k8s_client.V1EnvVar(
+            name='ENABLE_CACHING',
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client
+                .V1ObjectFieldSelector(
+                    field_path="metadata.labels['pipelines.kubeflow.org/enable_caching']"
+                ))))
+    return op
+
+
+def add_pod_labels(labels: Optional[Dict] = None) -> Callable:
+    """Adds provided pod labels to each pod."""
+
+    def _add_pod_labels(task):
+        for k, v in labels.items():
+            # Only append but not update.
+            # This is needed to bypass TFX pipelines/components.
+            if k not in task.pod_labels:
+                task.add_pod_label(k, v)
+        return task
+
+    return _add_pod_labels

--- a/kfp/compiler/_k8s_helper.py
+++ b/kfp/compiler/_k8s_helper.py
@@ -1,0 +1,90 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from kfp import dsl
+
+
+def sanitize_k8s_name(name, allow_capital_underscore=False):
+    """From _make_kubernetes_name sanitize_k8s_name cleans and converts the
+    names in the workflow.
+
+    Args:
+      name: original name,
+      allow_capital_underscore: whether to allow capital letter and underscore
+        in this name.
+
+    Returns:
+      sanitized name.
+    """
+    if allow_capital_underscore:
+        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z]+', '-',
+                                        name)).lstrip('-').rstrip('-')
+    else:
+        return re.sub('-+', '-', re.sub('[^-0-9a-z]+', '-',
+                                        name.lower())).lstrip('-').rstrip('-')
+
+
+def convert_k8s_obj_to_json(k8s_obj):
+    """Builds a JSON K8s object.
+
+    If obj is None, return None.
+    If obj is str, int, long, float, bool, return directly.
+    If obj is datetime.datetime, datetime.date
+        convert to string in iso8601 format.
+    If obj is list, sanitize each element in the list.
+    If obj is dict, return the dict.
+    If obj is swagger model, return the properties dict.
+
+    Args:
+      obj: The data to serialize.
+    Returns: The serialized form of data.
+    """
+
+    from six import text_type, integer_types, iteritems
+    PRIMITIVE_TYPES = (float, bool, bytes, text_type) + integer_types
+    from datetime import date, datetime
+    if k8s_obj is None:
+        return None
+    elif isinstance(k8s_obj, PRIMITIVE_TYPES):
+        return k8s_obj
+    elif isinstance(k8s_obj, list):
+        return [convert_k8s_obj_to_json(sub_obj) for sub_obj in k8s_obj]
+    elif isinstance(k8s_obj, tuple):
+        return tuple(convert_k8s_obj_to_json(sub_obj) for sub_obj in k8s_obj)
+    elif isinstance(k8s_obj, (datetime, date)):
+        return k8s_obj.isoformat()
+    elif isinstance(k8s_obj, dsl.PipelineParam):
+        if isinstance(k8s_obj.value, str):
+            return k8s_obj.value
+        return '{{inputs.parameters.%s}}' % k8s_obj.full_name
+
+    if isinstance(k8s_obj, dict):
+        obj_dict = k8s_obj
+    else:
+        # Convert model obj to dict except
+        # attributes `swagger_types`, `attribute_map`
+        # and attributes which value is not None.
+        # Convert attribute name to json key in
+        # model definition for request.
+        obj_dict = {
+            k8s_obj.attribute_map[attr]: getattr(k8s_obj, attr)
+            for attr in k8s_obj.attribute_map
+            if getattr(k8s_obj, attr) is not None
+        }
+
+    return {
+        key: convert_k8s_obj_to_json(val) for key, val in iteritems(obj_dict)
+    }

--- a/kfp/compiler/_op_to_template.py
+++ b/kfp/compiler/_op_to_template.py
@@ -1,0 +1,364 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+import warnings
+import yaml
+import copy
+from collections import OrderedDict
+from typing import Union, List, Any, Callable, TypeVar, Dict
+
+from kfp.compiler._k8s_helper import convert_k8s_obj_to_json
+from kfp import dsl
+from kfp.dsl._container_op import BaseOp
+
+# generics
+T = TypeVar('T')
+
+
+def _process_obj(obj: Any, map_to_tmpl_var: dict):
+    """Recursively sanitize and replace any PipelineParam (instances and
+    serialized strings) in the object with the corresponding template variables
+    (i.e. '{{inputs.parameters.<PipelineParam.full_name>}}').
+
+    Args:
+      obj: any obj that may have PipelineParam
+      map_to_tmpl_var: a dict that maps an unsanitized pipeline
+                       params signature into a template var
+    """
+    # serialized str might be unsanitized
+    if isinstance(obj, str):
+        # get signature
+        param_tuples = dsl.match_serialized_pipelineparam(obj)
+        if not param_tuples:
+            return obj
+        # replace all unsanitized signature with template var
+        for param_tuple in param_tuples:
+            obj = re.sub(param_tuple.pattern,
+                         map_to_tmpl_var[param_tuple.pattern], obj)
+
+    # list
+    if isinstance(obj, list):
+        return [_process_obj(item, map_to_tmpl_var) for item in obj]
+
+    # tuple
+    if isinstance(obj, tuple):
+        return tuple((_process_obj(item, map_to_tmpl_var) for item in obj))
+
+    # dict
+    if isinstance(obj, dict):
+        return {
+            _process_obj(key, map_to_tmpl_var):
+            _process_obj(value, map_to_tmpl_var) for key, value in obj.items()
+        }
+
+    # pipelineparam
+    if isinstance(obj, dsl.PipelineParam):
+        # if not found in unsanitized map, then likely to be sanitized
+        return map_to_tmpl_var.get(
+            str(obj), '{{inputs.parameters.%s}}' % obj.full_name)
+
+    # k8s objects (generated from swaggercodegen)
+    if hasattr(obj, 'attribute_map') and isinstance(obj.attribute_map, dict):
+        # process everything inside recursively
+        for key in obj.attribute_map.keys():
+            setattr(obj, key, _process_obj(getattr(obj, key), map_to_tmpl_var))
+        # return json representation of the k8s obj
+        return convert_k8s_obj_to_json(obj)
+
+    # do nothing
+    return obj
+
+
+def _process_base_ops(op: BaseOp):
+    """Recursively go through the attrs listed in `attrs_with_pipelineparams`
+    and sanitize and replace pipeline params with template var string.
+
+    Returns a processed `BaseOp`.
+
+    NOTE this is an in-place update to `BaseOp`'s attributes (i.e. the ones
+    specified in `attrs_with_pipelineparams`, all `PipelineParam` are replaced
+    with the corresponding template variable strings).
+
+    Args:
+        op {BaseOp}: class that inherits from BaseOp
+
+    Returns:
+        BaseOp
+    """
+
+    # map param's (unsanitized pattern or serialized str pattern) -> input param var str
+    map_to_tmpl_var = {(param.pattern or str(param)):
+                       '{{inputs.parameters.%s}}' % param.full_name
+                       for param in op.inputs}
+
+    # process all attr with pipelineParams except inputs and outputs parameters
+    for key in op.attrs_with_pipelineparams:
+        setattr(op, key, _process_obj(getattr(op, key), map_to_tmpl_var))
+
+    return op
+
+
+def _parameters_to_json(params: List[dsl.PipelineParam]):
+    """Converts a list of PipelineParam into an argo `parameter` JSON obj."""
+    _to_json = (lambda param: dict(name=param.full_name, value=param.value)
+                if param.value else dict(name=param.full_name))
+    params = [_to_json(param) for param in params]
+    # Sort to make the results deterministic.
+    params.sort(key=lambda x: x['name'])
+    return params
+
+
+def _inputs_to_json(
+    inputs_params: List[dsl.PipelineParam],
+    input_artifact_paths: Dict[str, str] = None,
+    artifact_arguments: Dict[str, str] = None,
+) -> Dict[str, Dict]:
+    """Converts a list of PipelineParam into an argo `inputs` JSON obj."""
+    parameters = _parameters_to_json(inputs_params)
+
+    # Building the input artifacts section
+    artifacts = []
+    for name, path in (input_artifact_paths or {}).items():
+        artifact = {'name': name, 'path': path}
+        if name in artifact_arguments:  # The arguments should be compiled as DAG task arguments, not template's default values, but in the current DSL-compiler implementation it's too hard to make that work when passing artifact references.
+            artifact['raw'] = {'data': str(artifact_arguments[name])}
+        artifacts.append(artifact)
+    artifacts.sort(
+        key=lambda x: x['name'])  #Stabilizing the input artifact ordering
+
+    inputs_dict = {}
+    if parameters:
+        inputs_dict['parameters'] = parameters
+    if artifacts:
+        inputs_dict['artifacts'] = artifacts
+    return inputs_dict
+
+
+def _outputs_to_json(op: BaseOp, outputs: Dict[str, dsl.PipelineParam],
+                     param_outputs: Dict[str,
+                                         str], output_artifacts: List[dict]):
+    """Creates an argo `outputs` JSON obj."""
+    if isinstance(op, dsl.ResourceOp):
+        value_from_key = "jsonPath"
+    else:
+        value_from_key = "path"
+    output_parameters = []
+    for param in set(outputs.values()):  # set() dedupes output references
+        output_parameters.append({
+            'name': param.full_name,
+            'valueFrom': {
+                value_from_key: param_outputs[param.name]
+            }
+        })
+    output_parameters.sort(key=lambda x: x['name'])
+    ret = {}
+    if output_parameters:
+        ret['parameters'] = output_parameters
+    if output_artifacts:
+        ret['artifacts'] = output_artifacts
+
+    return ret
+
+
+# TODO: generate argo python classes from swagger and use convert_k8s_obj_to_json??
+def _op_to_template(op: BaseOp):
+    """Generate template given an operator inherited from BaseOp."""
+
+    # Display name
+    if op.display_name:
+        op.add_pod_annotation('pipelines.kubeflow.org/task_display_name',
+                              op.display_name)
+
+    # Caching option
+    op.add_pod_label('pipelines.kubeflow.org/enable_caching',
+                     str(op.enable_caching).lower())
+
+    # NOTE in-place update to BaseOp
+    # replace all PipelineParams with template var strings
+    processed_op = _process_base_ops(op)
+
+    if isinstance(op, dsl.ContainerOp):
+        output_artifact_paths = OrderedDict(op.output_artifact_paths)
+        # This should have been as easy as output_artifact_paths.update(op.file_outputs), but the _outputs_to_json function changes the output names and we must do the same here, so that the names are the same
+        output_artifact_paths.update(
+            sorted(((param.full_name, processed_op.file_outputs[param.name])
+                    for param in processed_op.outputs.values()),
+                   key=lambda x: x[0]))
+
+        output_artifacts = [{
+            'name': name,
+            'path': path
+        } for name, path in output_artifact_paths.items()]
+
+        # workflow template
+        template = {
+            'name': processed_op.name,
+            'container': convert_k8s_obj_to_json(processed_op.container)
+        }
+    elif isinstance(op, dsl.ResourceOp):
+        # no output artifacts
+        output_artifacts = []
+
+        # workflow template
+        processed_op.resource["manifest"] = yaml.dump(
+            convert_k8s_obj_to_json(processed_op.k8s_resource),
+            default_flow_style=False)
+        template = {
+            'name': processed_op.name,
+            'resource': convert_k8s_obj_to_json(processed_op.resource)
+        }
+
+    # inputs
+    input_artifact_paths = processed_op.input_artifact_paths if isinstance(
+        processed_op, dsl.ContainerOp) else None
+    artifact_arguments = processed_op.artifact_arguments if isinstance(
+        processed_op, dsl.ContainerOp) else None
+    inputs = _inputs_to_json(processed_op.inputs, input_artifact_paths,
+                             artifact_arguments)
+    if inputs:
+        template['inputs'] = inputs
+
+    # outputs
+    if isinstance(op, dsl.ContainerOp):
+        param_outputs = processed_op.file_outputs
+    elif isinstance(op, dsl.ResourceOp):
+        param_outputs = processed_op.attribute_outputs
+    outputs_dict = _outputs_to_json(op, processed_op.outputs, param_outputs,
+                                    output_artifacts)
+    if outputs_dict:
+        template['outputs'] = outputs_dict
+
+    # pod spec used for runtime container settings
+    podSpecPatch = {}
+
+    # node selector
+    if processed_op.node_selector:
+        copy_node_selector = copy.deepcopy(processed_op.node_selector)
+        for key, value in processed_op.node_selector.items():
+            if re.match('^{{inputs.parameters.*}}$', key) or re.match(
+                    '^{{inputs.parameters.*}}$', value):
+                if not 'nodeSelector' in podSpecPatch:
+                    podSpecPatch['nodeSelector'] = {}
+                podSpecPatch["nodeSelector"][key] = value
+                del copy_node_selector[
+                    key]  # avoid to change the dict when iterating it
+        if processed_op.node_selector:
+            template['nodeSelector'] = copy_node_selector
+
+    # tolerations
+    if processed_op.tolerations:
+        template['tolerations'] = processed_op.tolerations
+
+    # affinity
+    if processed_op.affinity:
+        template['affinity'] = convert_k8s_obj_to_json(processed_op.affinity)
+
+    # metadata
+    if processed_op.pod_annotations or processed_op.pod_labels:
+        template['metadata'] = {}
+        if processed_op.pod_annotations:
+            template['metadata']['annotations'] = processed_op.pod_annotations
+        if processed_op.pod_labels:
+            template['metadata']['labels'] = processed_op.pod_labels
+    # retries
+    if processed_op.num_retries or processed_op.retry_policy:
+        template['retryStrategy'] = {}
+        if processed_op.num_retries:
+            template['retryStrategy']['limit'] = processed_op.num_retries
+        if processed_op.retry_policy:
+            template['retryStrategy']['retryPolicy'] = processed_op.retry_policy
+            if not processed_op.num_retries:
+                warnings.warn('retry_policy is set, but num_retries is not')
+        backoff_dict = {}
+        if processed_op.backoff_duration:
+            backoff_dict['duration'] = processed_op.backoff_duration
+        if processed_op.backoff_factor:
+            backoff_dict['factor'] = processed_op.backoff_factor
+        if processed_op.backoff_max_duration:
+            backoff_dict['maxDuration'] = processed_op.backoff_max_duration
+        if backoff_dict:
+            template['retryStrategy']['backoff'] = backoff_dict
+
+    # timeout
+    if processed_op.timeout:
+        template['activeDeadlineSeconds'] = processed_op.timeout
+
+    # initContainers
+    if processed_op.init_containers:
+        template['initContainers'] = processed_op.init_containers
+
+    # sidecars
+    if processed_op.sidecars:
+        template['sidecars'] = processed_op.sidecars
+
+    # volumes
+    if processed_op.volumes:
+        template['volumes'] = [
+            convert_k8s_obj_to_json(volume) for volume in processed_op.volumes
+        ]
+        template['volumes'].sort(key=lambda x: x['name'])
+
+    # Runtime resource requests
+    if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
+        for setting, val in op.container['resources'].items():
+            for resource, param in val.items():
+                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu', 'ephemeral-storage'] or re.match('^{{inputs.parameters.*}}$', resource))\
+                    and re.match('^{{inputs.parameters.*}}$', str(param)):
+                    if not 'containers' in podSpecPatch:
+                        podSpecPatch['containers'] = [{
+                                'name': 'main',
+                                'resources': {}
+                            }]
+                    if setting not in podSpecPatch['containers'][0][
+                            'resources']:
+                        podSpecPatch['containers'][0]['resources'][setting] = {
+                            resource: param
+                        }
+                    else:
+                        podSpecPatch['containers'][0]['resources'][setting][
+                            resource] = param
+                    del template['container']['resources'][setting][resource]
+                    if not template['container']['resources'][setting]:
+                        del template['container']['resources'][setting]
+
+    if isinstance(op, dsl.ContainerOp) and op._metadata and not op.is_v2:
+        template.setdefault('metadata', {}).setdefault(
+            'annotations',
+            {})['pipelines.kubeflow.org/component_spec'] = json.dumps(
+                op._metadata.to_dict(), sort_keys=True)
+
+    if hasattr(op, '_component_ref'):
+        template.setdefault('metadata', {}).setdefault(
+            'annotations',
+            {})['pipelines.kubeflow.org/component_ref'] = json.dumps(
+                op._component_ref.to_dict(), sort_keys=True)
+
+    if hasattr(op, '_parameter_arguments') and op._parameter_arguments:
+        template.setdefault('metadata', {}).setdefault(
+            'annotations',
+            {})['pipelines.kubeflow.org/arguments.parameters'] = json.dumps(
+                op._parameter_arguments, sort_keys=True)
+
+    if isinstance(op, dsl.ContainerOp) and op.execution_options:
+        if op.execution_options.caching_strategy.max_cache_staleness:
+            template.setdefault('metadata', {}).setdefault(
+                'annotations',
+                {})['pipelines.kubeflow.org/max_cache_staleness'] = str(
+                    op.execution_options.caching_strategy.max_cache_staleness)
+
+    if podSpecPatch:
+        template['podSpecPatch'] = json.dumps(podSpecPatch)
+    return template

--- a/kfp/compiler/compiler.py
+++ b/kfp/compiler/compiler.py
@@ -1,0 +1,1256 @@
+# Copyright 2018-2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+import json
+from collections import defaultdict, OrderedDict
+from deprecated import deprecated
+import inspect
+import re
+import tarfile
+import uuid
+import warnings
+import zipfile
+from typing import Callable, Set, List, Text, Dict, Tuple, Any, Union, Optional
+
+import kfp
+from kfp.dsl import _for_loop
+from kfp.compiler import _data_passing_rewriter
+
+from kfp import dsl
+from kfp.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name
+from kfp.compiler._op_to_template import _op_to_template, _process_obj
+from kfp.compiler._default_transformers import add_pod_env, add_pod_labels
+
+from kfp.components.structures import InputSpec
+from kfp.components._yaml_utils import dump_yaml
+from kfp.dsl._metadata import _extract_pipeline_metadata
+from kfp.dsl._ops_group import OpsGroup
+from kfp.dsl._pipeline_param import extract_pipelineparams_from_any, PipelineParam
+
+_SDK_VERSION_LABEL = 'pipelines.kubeflow.org/kfp_sdk_version'
+_SDK_ENV_LABEL = 'pipelines.kubeflow.org/pipeline-sdk-type'
+_SDK_ENV_DEFAULT = 'kfp'
+
+
+class Compiler(object):
+    """DSL Compiler that compiles pipeline functions into workflow yaml.
+
+    Example:
+      How to use the compiler to construct workflow yaml::
+
+        @dsl.pipeline(
+          name='name',
+          description='description'
+        )
+        def my_pipeline(a: int = 1, b: str = "default value"):
+          ...
+
+        Compiler().compile(my_pipeline, 'path/to/workflow.yaml')
+    """
+
+    def __init__(self,
+                 mode: dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode
+                 .V1_LEGACY,
+                 launcher_image: Optional[str] = None):
+        """Creates a KFP compiler for compiling pipeline functions for
+        execution.
+
+        Args:
+          mode: The pipeline execution mode to use, defaults to kfp.dsl.PipelineExecutionMode.V1_LEGACY.
+          launcher_image: (Deprecated) Not used in V1_LEGACY mode.
+        """
+        if mode != dsl.PipelineExecutionMode.V1_LEGACY:
+            raise ValueError('Only V1_LEGACY execution mode is supported in this SDK version.')
+
+        self._mode = mode
+        self._launcher_image = launcher_image
+        self._pipeline_name_param: Optional[dsl.PipelineParam] = None
+        self._pipeline_root_param: Optional[dsl.PipelineParam] = None
+
+    def _get_groups_for_ops(self, root_group):
+        """Helper function to get belonging groups for each op.
+
+        Each pipeline has a root group. Each group has a list of operators (leaf) and groups.
+        This function traverse the tree and get all ancestor groups for all operators.
+
+        Returns:
+          A dict. Key is the operator's name. Value is a list of ancestor groups including the
+                  op itself. The list of a given operator is sorted in a way that the farthest
+                  group is the first and operator itself is the last.
+        """
+
+        def _get_op_groups_helper(current_groups, ops_to_groups):
+            root_group = current_groups[-1]
+            for g in root_group.groups:
+                # Add recursive opsgroup in the ops_to_groups
+                # such that the i/o dependency can be propagated to the ancester opsgroups
+                if g.recursive_ref:
+                    ops_to_groups[g.name] = [x.name for x in current_groups
+                                            ] + [g.name]
+                    continue
+                current_groups.append(g)
+                _get_op_groups_helper(current_groups, ops_to_groups)
+                del current_groups[-1]
+            for op in root_group.ops:
+                ops_to_groups[op.name] = [x.name for x in current_groups
+                                         ] + [op.name]
+
+        ops_to_groups = {}
+        current_groups = [root_group]
+        _get_op_groups_helper(current_groups, ops_to_groups)
+        return ops_to_groups
+
+    #TODO: combine with the _get_groups_for_ops
+    def _get_groups_for_opsgroups(self, root_group):
+        """Helper function to get belonging groups for each opsgroup.
+
+        Each pipeline has a root group. Each group has a list of operators (leaf) and groups.
+        This function traverse the tree and get all ancestor groups for all opsgroups.
+
+        Returns:
+          A dict. Key is the opsgroup's name. Value is a list of ancestor groups including the
+                  opsgroup itself. The list of a given opsgroup is sorted in a way that the farthest
+                  group is the first and opsgroup itself is the last.
+        """
+
+        def _get_opsgroup_groups_helper(current_groups, opsgroups_to_groups):
+            root_group = current_groups[-1]
+            for g in root_group.groups:
+                # Add recursive opsgroup in the ops_to_groups
+                # such that the i/o dependency can be propagated to the ancester opsgroups
+                if g.recursive_ref:
+                    continue
+                opsgroups_to_groups[g.name] = [x.name for x in current_groups
+                                              ] + [g.name]
+                current_groups.append(g)
+                _get_opsgroup_groups_helper(current_groups, opsgroups_to_groups)
+                del current_groups[-1]
+
+        opsgroups_to_groups = {}
+        current_groups = [root_group]
+        _get_opsgroup_groups_helper(current_groups, opsgroups_to_groups)
+        return opsgroups_to_groups
+
+    def _get_groups(self, root_group):
+        """Helper function to get all groups (not including ops) in a
+        pipeline."""
+
+        def _get_groups_helper(group):
+            groups = {group.name: group}
+            for g in group.groups:
+                # Skip the recursive opsgroup because no templates
+                # need to be generated for the recursive opsgroups.
+                if not g.recursive_ref:
+                    groups.update(_get_groups_helper(g))
+            return groups
+
+        return _get_groups_helper(root_group)
+
+    def _get_uncommon_ancestors(self, op_groups, opsgroup_groups, op1, op2):
+        """Helper function to get unique ancestors between two ops.
+
+        For example, op1's ancestor groups are [root, G1, G2, G3, op1],
+        op2's ancestor groups are [root, G1, G4, op2], then it returns a
+        tuple ([G2, G3, op1], [G4, op2]).
+        """
+        #TODO: extract a function for the following two code module
+        if op1.name in op_groups:
+            op1_groups = op_groups[op1.name]
+        elif op1.name in opsgroup_groups:
+            op1_groups = opsgroup_groups[op1.name]
+        else:
+            raise ValueError(op1.name + ' does not exist.')
+
+        if op2.name in op_groups:
+            op2_groups = op_groups[op2.name]
+        elif op2.name in opsgroup_groups:
+            op2_groups = opsgroup_groups[op2.name]
+        else:
+            raise ValueError(op2.name + ' does not exist.')
+
+        both_groups = [op1_groups, op2_groups]
+        common_groups_len = sum(
+            1 for x in zip(*both_groups) if x == (x[0],) * len(x))
+        group1 = op1_groups[common_groups_len:]
+        group2 = op2_groups[common_groups_len:]
+        return (group1, group2)
+
+    def _get_condition_params_for_ops(self, root_group):
+        """Get parameters referenced in conditions of ops."""
+        conditions = defaultdict(set)
+
+        def _get_condition_params_for_ops_helper(group,
+                                                 current_conditions_params):
+            new_current_conditions_params = current_conditions_params
+            if group.type == 'condition':
+                new_current_conditions_params = list(current_conditions_params)
+                if isinstance(group.condition.operand1, dsl.PipelineParam):
+                    new_current_conditions_params.append(
+                        group.condition.operand1)
+                if isinstance(group.condition.operand2, dsl.PipelineParam):
+                    new_current_conditions_params.append(
+                        group.condition.operand2)
+            for op in group.ops:
+                for param in new_current_conditions_params:
+                    conditions[op.name].add(param)
+            for g in group.groups:
+                # If the subgroup is a recursive opsgroup, propagate the pipelineparams
+                # in the condition expression, similar to the ops.
+                if g.recursive_ref:
+                    for param in new_current_conditions_params:
+                        conditions[g.name].add(param)
+                else:
+                    _get_condition_params_for_ops_helper(
+                        g, new_current_conditions_params)
+
+        _get_condition_params_for_ops_helper(root_group, [])
+        return conditions
+
+    def _get_next_group_or_op(cls, to_visit: List, already_visited: Set):
+        """Get next group or op to visit."""
+        if len(to_visit) == 0:
+            return None
+        next = to_visit.pop(0)
+        while next in already_visited:
+            next = to_visit.pop(0)
+        already_visited.add(next)
+        return next
+
+    def _get_for_loop_ops(self, new_root) -> Dict[Text, dsl.ParallelFor]:
+        to_visit = self._get_all_subgroups_and_ops(new_root)
+        op_name_to_op = {}
+        already_visited = set()
+
+        while len(to_visit):
+            next_op = self._get_next_group_or_op(to_visit, already_visited)
+            if next_op is None:
+                break
+            to_visit.extend(self._get_all_subgroups_and_ops(next_op))
+            if isinstance(next_op, dsl.ParallelFor):
+                op_name_to_op[next_op.name] = next_op
+
+        return op_name_to_op
+
+    def _get_all_subgroups_and_ops(self, op):
+        """Get all ops and groups contained within this group."""
+        subgroups = []
+        if hasattr(op, 'ops'):
+            subgroups.extend(op.ops)
+        if hasattr(op, 'groups'):
+            subgroups.extend(op.groups)
+        return subgroups
+
+    def _get_inputs_outputs(
+        self,
+        pipeline,
+        root_group,
+        op_groups,
+        opsgroup_groups,
+        condition_params,
+        op_name_to_for_loop_op: Dict[Text, dsl.ParallelFor],
+    ):
+        """Get inputs and outputs of each group and op.
+
+        Returns:
+          A tuple (inputs, outputs).
+          inputs and outputs are dicts with key being the group/op names and values being list of
+          tuples (param_name, producing_op_name). producing_op_name is the name of the op that
+          produces the param. If the param is a pipeline param (no producer op), then
+          producing_op_name is None.
+        """
+        inputs = defaultdict(set)
+        outputs = defaultdict(set)
+
+        for op in pipeline.ops.values():
+            # op's inputs and all params used in conditions for that op are both considered.
+            for param in op.inputs + list(condition_params[op.name]):
+                # if the value is already provided (immediate value), then no need to expose
+                # it as input for its parent groups.
+                if param.value:
+                    continue
+                if param.op_name:
+                    upstream_op = pipeline.ops[param.op_name]
+                    upstream_groups, downstream_groups = \
+                      self._get_uncommon_ancestors(op_groups, opsgroup_groups, upstream_op, op)
+                    for i, group_name in enumerate(downstream_groups):
+                        if i == 0:
+                            # If it is the first uncommon downstream group, then the input comes from
+                            # the first uncommon upstream group.
+                            inputs[group_name].add(
+                                (param.full_name, upstream_groups[0]))
+                        else:
+                            # If not the first downstream group, then the input is passed down from
+                            # its ancestor groups so the upstream group is None.
+                            inputs[group_name].add((param.full_name, None))
+                    for i, group_name in enumerate(upstream_groups):
+                        if i == len(upstream_groups) - 1:
+                            # If last upstream group, it is an operator and output comes from container.
+                            outputs[group_name].add((param.full_name, None))
+                        else:
+                            # If not last upstream group, output value comes from one of its child.
+                            outputs[group_name].add(
+                                (param.full_name, upstream_groups[i + 1]))
+                else:
+                    if not op.is_exit_handler:
+                        for group_name in op_groups[op.name][::-1]:
+                            # if group is for loop group and param is that loop's param, then the param
+                            # is created by that for loop ops_group and it shouldn't be an input to
+                            # any of its parent groups.
+                            inputs[group_name].add((param.full_name, None))
+                            if group_name in op_name_to_for_loop_op:
+                                # for example:
+                                #   loop_group.loop_args.name = 'loop-item-param-99ca152e'
+                                #   param.name =                'loop-item-param-99ca152e--a'
+                                loop_group = op_name_to_for_loop_op[group_name]
+                                if loop_group.loop_args.name in param.name:
+                                    break
+
+        # Generate the input/output for recursive opsgroups
+        # It propagates the recursive opsgroups IO to their ancester opsgroups
+        def _get_inputs_outputs_recursive_opsgroup(group):
+            #TODO: refactor the following codes with the above
+            if group.recursive_ref:
+                params = [(param, False) for param in group.inputs]
+                params.extend([(param, True)
+                               for param in list(condition_params[group.name])])
+                for param, is_condition_param in params:
+                    if param.value:
+                        continue
+                    full_name = param.full_name
+                    if param.op_name:
+                        upstream_op = pipeline.ops[param.op_name]
+                        upstream_groups, downstream_groups = \
+                          self._get_uncommon_ancestors(op_groups, opsgroup_groups, upstream_op, group)
+                        for i, g in enumerate(downstream_groups):
+                            if i == 0:
+                                inputs[g].add((full_name, upstream_groups[0]))
+                            # There is no need to pass the condition param as argument to the downstream ops.
+                            #TODO: this might also apply to ops. add a TODO here and think about it.
+                            elif i == len(downstream_groups
+                                         ) - 1 and is_condition_param:
+                                continue
+                            else:
+                                inputs[g].add((full_name, None))
+                        for i, g in enumerate(upstream_groups):
+                            if i == len(upstream_groups) - 1:
+                                outputs[g].add((full_name, None))
+                            else:
+                                outputs[g].add(
+                                    (full_name, upstream_groups[i + 1]))
+                    elif not is_condition_param:
+                        for g in op_groups[group.name]:
+                            inputs[g].add((full_name, None))
+            for subgroup in group.groups:
+                _get_inputs_outputs_recursive_opsgroup(subgroup)
+
+        _get_inputs_outputs_recursive_opsgroup(root_group)
+
+        # Generate the input for SubGraph along with parallelfor
+        for sub_graph in opsgroup_groups:
+            if sub_graph in op_name_to_for_loop_op:
+                # The opsgroup list is sorted with the farthest group as the first and
+                # the opsgroup itself as the last. To get the latest opsgroup which is
+                # not the opsgroup itself -2 is used.
+                parent = opsgroup_groups[sub_graph][-2]
+                if parent and parent.startswith('subgraph'):
+                    # propagate only op's pipeline param from subgraph to parallelfor
+                    loop_op = op_name_to_for_loop_op[sub_graph]
+                    pipeline_param = loop_op.loop_args.items_or_pipeline_param
+                    if loop_op.items_is_pipeline_param and pipeline_param.op_name:
+                        param_name = '%s-%s' % (sanitize_k8s_name(
+                            pipeline_param.op_name), pipeline_param.name)
+                        inputs[parent].add((param_name, pipeline_param.op_name))
+
+        return inputs, outputs
+
+    def _get_dependencies(self, pipeline, root_group, op_groups,
+                          opsgroups_groups, opsgroups, condition_params):
+        """Get dependent groups and ops for all ops and groups.
+
+        Returns:
+          A dict. Key is group/op name, value is a list of dependent groups/ops.
+          The dependencies are calculated in the following way: if op2 depends on op1,
+          and their ancestors are [root, G1, G2, op1] and [root, G1, G3, G4, op2],
+          then G3 is dependent on G2. Basically dependency only exists in the first uncommon
+          ancesters in their ancesters chain. Only sibling groups/ops can have dependencies.
+        """
+        dependencies = defaultdict(set)
+        for op in pipeline.ops.values():
+            upstream_op_names = set()
+            for param in op.inputs + list(condition_params[op.name]):
+                if param.op_name:
+                    upstream_op_names.add(param.op_name)
+            upstream_op_names |= set(op.dependent_names)
+
+            for upstream_op_name in upstream_op_names:
+                # the dependent op could be either a BaseOp or an opsgroup
+                if upstream_op_name in pipeline.ops:
+                    upstream_op = pipeline.ops[upstream_op_name]
+                elif upstream_op_name in opsgroups:
+                    upstream_op = opsgroups[upstream_op_name]
+                else:
+                    raise ValueError('compiler cannot find the ' +
+                                     upstream_op_name)
+
+                upstream_groups, downstream_groups = self._get_uncommon_ancestors(
+                    op_groups, opsgroups_groups, upstream_op, op)
+                dependencies[downstream_groups[0]].add(upstream_groups[0])
+
+        # Generate dependencies based on the recursive opsgroups
+        #TODO: refactor the following codes with the above
+        def _get_dependency_opsgroup(group, dependencies):
+            upstream_op_names = set(
+                [dependency.name for dependency in group.dependencies])
+            if group.recursive_ref:
+                for param in group.inputs + list(condition_params[group.name]):
+                    if param.op_name:
+                        upstream_op_names.add(param.op_name)
+
+            for op_name in upstream_op_names:
+                if op_name in pipeline.ops:
+                    upstream_op = pipeline.ops[op_name]
+                elif op_name in opsgroups:
+                    upstream_op = opsgroups[op_name]
+                else:
+                    raise ValueError('compiler cannot find the ' + op_name)
+                upstream_groups, downstream_groups = \
+                  self._get_uncommon_ancestors(op_groups, opsgroups_groups, upstream_op, group)
+                dependencies[downstream_groups[0]].add(upstream_groups[0])
+
+            for subgroup in group.groups:
+                _get_dependency_opsgroup(subgroup, dependencies)
+
+        _get_dependency_opsgroup(root_group, dependencies)
+
+        return dependencies
+
+    def _resolve_value_or_reference(self, value_or_reference,
+                                    potential_references):
+        """_resolve_value_or_reference resolves values and PipelineParams,
+        which could be task parameters or input parameters.
+
+        Args:
+          value_or_reference: value or reference to be resolved. It could be basic python types or PipelineParam
+          potential_references(dict{str->str}): a dictionary of parameter names to task names
+        """
+        if isinstance(value_or_reference, dsl.PipelineParam):
+            parameter_name = value_or_reference.full_name
+            task_names = [
+                task_name for param_name, task_name in potential_references
+                if param_name == parameter_name
+            ]
+            if task_names:
+                task_name = task_names[0]
+                # When the task_name is None, the parameter comes directly from ancient ancesters
+                # instead of parents. Thus, it is resolved as the input parameter in the current group.
+                if task_name is None:
+                    return '{{inputs.parameters.%s}}' % parameter_name
+                else:
+                    return '{{tasks.%s.outputs.parameters.%s}}' % (
+                        task_name, parameter_name)
+            else:
+                return '{{inputs.parameters.%s}}' % parameter_name
+        else:
+            return str(value_or_reference)
+
+    @staticmethod
+    def _resolve_task_pipeline_param(pipeline_param: PipelineParam,
+                                     group_type) -> str:
+        if pipeline_param.op_name is None:
+            return '{{workflow.parameters.%s}}' % pipeline_param.name
+        param_name = '%s-%s' % (sanitize_k8s_name(
+            pipeline_param.op_name), pipeline_param.name)
+        if group_type == 'subgraph':
+            return '{{inputs.parameters.%s}}' % (param_name)
+        return '{{tasks.%s.outputs.parameters.%s}}' % (sanitize_k8s_name(
+            pipeline_param.op_name), param_name)
+
+    def _group_to_dag_template(self, group, inputs, outputs, dependencies):
+        """Generate template given an OpsGroup.
+
+        inputs, outputs, dependencies are all helper dicts.
+        """
+        template = {'name': group.name}
+        if group.parallelism != None:
+            template["parallelism"] = group.parallelism
+
+        # Generate inputs section.
+        if inputs.get(group.name, None):
+            template_inputs = [{'name': x[0]} for x in inputs[group.name]]
+            template_inputs.sort(key=lambda x: x['name'])
+            template['inputs'] = {'parameters': template_inputs}
+
+        # Generate outputs section.
+        if outputs.get(group.name, None):
+            template_outputs = []
+            for param_name, dependent_name in outputs[group.name]:
+                template_outputs.append({
+                    'name': param_name,
+                    'valueFrom': {
+                        'parameter':
+                            '{{tasks.%s.outputs.parameters.%s}}' %
+                            (dependent_name, param_name)
+                    }
+                })
+            template_outputs.sort(key=lambda x: x['name'])
+            template['outputs'] = {'parameters': template_outputs}
+
+        # Generate tasks section.
+        tasks = []
+        sub_groups = group.groups + group.ops
+        for sub_group in sub_groups:
+            is_recursive_subgroup = (
+                isinstance(sub_group, OpsGroup) and sub_group.recursive_ref)
+            # Special handling for recursive subgroup: use the existing opsgroup name
+            if is_recursive_subgroup:
+                task = {
+                    'name': sub_group.recursive_ref.name,
+                    'template': sub_group.recursive_ref.name,
+                }
+            else:
+                task = {
+                    'name': sub_group.name,
+                    'template': sub_group.name,
+                }
+            if isinstance(sub_group,
+                          dsl.OpsGroup) and sub_group.type == 'condition':
+                subgroup_inputs = inputs.get(sub_group.name, [])
+                condition = sub_group.condition
+                operand1_value = self._resolve_value_or_reference(
+                    condition.operand1, subgroup_inputs)
+                operand2_value = self._resolve_value_or_reference(
+                    condition.operand2, subgroup_inputs)
+                if condition.operator in ['==', '!=']:
+                    operand1_value = '"' + operand1_value + '"'
+                    operand2_value = '"' + operand2_value + '"'
+                task['when'] = '{} {} {}'.format(operand1_value,
+                                                 condition.operator,
+                                                 operand2_value)
+
+            # Generate dependencies section for this task.
+            if dependencies.get(sub_group.name, None):
+                group_dependencies = list(dependencies[sub_group.name])
+                group_dependencies.sort()
+                task['dependencies'] = group_dependencies
+
+            # Generate arguments section for this task.
+            if inputs.get(sub_group.name, None):
+                task['arguments'] = {
+                    'parameters':
+                        self.get_arguments_for_sub_group(
+                            sub_group, is_recursive_subgroup, inputs)
+                }
+
+            # additional task modifications for withItems and withParam
+            if isinstance(sub_group, dsl.ParallelFor):
+                if sub_group.items_is_pipeline_param:
+                    # these loop args are a 'withParam' rather than 'withItems'.
+                    # i.e., rather than a static list, they are either the output of another task or were input
+                    # as global pipeline parameters
+
+                    pipeline_param = sub_group.loop_args.items_or_pipeline_param
+                    withparam_value = self._resolve_task_pipeline_param(
+                        pipeline_param, group.type)
+                    if pipeline_param.op_name:
+                        # these loop args are the output of another task
+                        if 'dependencies' not in task or task[
+                                'dependencies'] is None:
+                            task['dependencies'] = []
+                        if sanitize_k8s_name(
+                                pipeline_param.op_name
+                        ) not in task[
+                                'dependencies'] and group.type != 'subgraph':
+                            task['dependencies'].append(
+                                sanitize_k8s_name(pipeline_param.op_name))
+
+                    task['withParam'] = withparam_value
+                else:
+                    # Need to sanitize the dict keys for consistency.
+                    loop_tasks = sub_group.loop_args.to_list_for_task_yaml()
+                    nested_pipeline_params = extract_pipelineparams_from_any(
+                        loop_tasks)
+
+                    # Set dependencies in case of nested pipeline_params
+                    map_to_tmpl_var = {
+                        str(p):
+                        self._resolve_task_pipeline_param(p, group.type)
+                        for p in nested_pipeline_params
+                    }
+                    for pipeline_param in nested_pipeline_params:
+                        if pipeline_param.op_name:
+                            # these pipeline_param are the output of another task
+                            if 'dependencies' not in task or task[
+                                    'dependencies'] is None:
+                                task['dependencies'] = []
+                            if sanitize_k8s_name(pipeline_param.op_name
+                                                ) not in task['dependencies']:
+                                task['dependencies'].append(
+                                    sanitize_k8s_name(pipeline_param.op_name))
+
+                    sanitized_tasks = []
+                    if isinstance(loop_tasks[0], dict):
+                        for argument_set in loop_tasks:
+                            c_dict = {}
+                            for k, v in argument_set.items():
+                                c_dict[sanitize_k8s_name(k, True)] = v
+                            sanitized_tasks.append(c_dict)
+                    else:
+                        sanitized_tasks = loop_tasks
+                    # Replace pipeline param if map_to_tmpl_var not empty
+                    task['withItems'] = _process_obj(
+                        sanitized_tasks,
+                        map_to_tmpl_var) if map_to_tmpl_var else sanitized_tasks
+
+                # We will sort dependencies to have determinitc yaml and thus stable tests
+                if task.get('dependencies'):
+                    task['dependencies'].sort()
+
+            tasks.append(task)
+        tasks.sort(key=lambda x: x['name'])
+        template['dag'] = {'tasks': tasks}
+        return template
+
+    def get_arguments_for_sub_group(
+        self,
+        sub_group: Union[OpsGroup, dsl._container_op.BaseOp],
+        is_recursive_subgroup: Optional[bool],
+        inputs: Dict[Text, Tuple[Text, Text]],
+    ):
+        arguments = []
+        for param_name, dependent_name in inputs[sub_group.name]:
+            if is_recursive_subgroup:
+                for input_name, input in sub_group.arguments.items():
+                    if param_name == input.full_name:
+                        break
+                referenced_input = sub_group.recursive_ref.arguments[input_name]
+                argument_name = referenced_input.full_name
+            else:
+                argument_name = param_name
+
+            # Preparing argument. It can be pipeline input reference, task output reference or loop item (or loop item attribute
+            sanitized_loop_arg_full_name = '---'
+            if isinstance(sub_group, dsl.ParallelFor):
+                sanitized_loop_arg_full_name = sanitize_k8s_name(
+                    sub_group.loop_args.full_name)
+            arg_ref_full_name = sanitize_k8s_name(param_name)
+            # We only care about the reference to the current loop item, not the outer loops
+            if isinstance(sub_group,
+                          dsl.ParallelFor) and arg_ref_full_name.startswith(
+                              sanitized_loop_arg_full_name):
+                if arg_ref_full_name == sanitized_loop_arg_full_name:
+                    argument_value = '{{item}}'
+                elif _for_loop.LoopArgumentVariable.name_is_loop_arguments_variable(
+                        param_name):
+                    subvar_name = _for_loop.LoopArgumentVariable.get_subvar_name(
+                        param_name)
+                    argument_value = '{{item.%s}}' % subvar_name
+                else:
+                    raise ValueError(
+                        "Argument seems to reference the loop item, but not the item itself and not some attribute of the item. param_name: {}, "
+                        .format(param_name))
+            else:
+                if dependent_name:
+                    argument_value = '{{tasks.%s.outputs.parameters.%s}}' % (
+                        dependent_name, param_name)
+                else:
+                    argument_value = '{{inputs.parameters.%s}}' % param_name
+
+            arguments.append({
+                'name': argument_name,
+                'value': argument_value,
+            })
+
+        arguments.sort(key=lambda x: x['name'])
+
+        return arguments
+
+    def _create_dag_templates(self,
+                              pipeline,
+                              op_transformers=None,
+                              op_to_templates_handler=None):
+        """Create all groups and ops templates in the pipeline.
+
+        Args:
+          pipeline: Pipeline context object to get all the pipeline data from.
+          op_transformers: A list of functions that are applied to all ContainerOp instances that are being processed.
+          op_to_templates_handler: Handler which converts a base op into a list of argo templates.
+        """
+        op_to_templates_handler = op_to_templates_handler or (
+            lambda op: [_op_to_template(op)])
+        root_group = pipeline.groups[0]
+
+        # Call the transformation functions before determining the inputs/outputs, otherwise
+        # the user would not be able to use pipeline parameters in the container definition
+        # (for example as pod labels) - the generated template is invalid.
+        for op in pipeline.ops.values():
+            for transformer in op_transformers or []:
+                transformer(op)
+
+        # Generate core data structures to prepare for argo yaml generation
+        #   op_name_to_parent_groups: op name -> list of ancestor groups including the current op
+        #   opsgroups: a dictionary of ospgroup.name -> opsgroup
+        #   inputs, outputs: group/op names -> list of tuples (full_param_name, producing_op_name)
+        #   condition_params: recursive_group/op names -> list of pipelineparam
+        #   dependencies: group/op name -> list of dependent groups/ops.
+        # Special Handling for the recursive opsgroup
+        #   op_name_to_parent_groups also contains the recursive opsgroups
+        #   condition_params from _get_condition_params_for_ops also contains the recursive opsgroups
+        #   groups does not include the recursive opsgroups
+        opsgroups = self._get_groups(root_group)
+        op_name_to_parent_groups = self._get_groups_for_ops(root_group)
+        opgroup_name_to_parent_groups = self._get_groups_for_opsgroups(
+            root_group)
+        condition_params = self._get_condition_params_for_ops(root_group)
+        op_name_to_for_loop_op = self._get_for_loop_ops(root_group)
+        inputs, outputs = self._get_inputs_outputs(
+            pipeline,
+            root_group,
+            op_name_to_parent_groups,
+            opgroup_name_to_parent_groups,
+            condition_params,
+            op_name_to_for_loop_op,
+        )
+        dependencies = self._get_dependencies(
+            pipeline,
+            root_group,
+            op_name_to_parent_groups,
+            opgroup_name_to_parent_groups,
+            opsgroups,
+            condition_params,
+        )
+
+        templates = []
+        for opsgroup in opsgroups.keys():
+            template = self._group_to_dag_template(opsgroups[opsgroup], inputs,
+                                                   outputs, dependencies)
+            templates.append(template)
+
+        for op in pipeline.ops.values():
+            if hasattr(op, 'importer_spec'):
+                raise ValueError(
+                    'dsl.importer is not supported with v1 compiler.'
+                )
+
+            templates.extend(op_to_templates_handler(op))
+
+            if hasattr(op, 'custom_job_spec'):
+                warnings.warn(
+                    'CustomJob spec is not supported yet when running on KFP.'
+                    ' The component will execute within the KFP cluster.')
+
+        return templates
+
+    def _create_pipeline_workflow(self,
+                                  parameter_defaults,
+                                  pipeline,
+                                  op_transformers=None,
+                                  pipeline_conf=None):
+        """Create workflow for the pipeline."""
+
+        # Input Parameters
+        input_params = []
+        for name, value in parameter_defaults.items():
+            param = {'name': name}
+            if value is not None:
+                param['value'] = value
+            input_params.append(param)
+
+        # Making the pipeline group name unique to prevent name clashes with templates
+        pipeline_group = pipeline.groups[0]
+        temp_pipeline_group_name = uuid.uuid4().hex
+        pipeline_group.name = temp_pipeline_group_name
+
+        # Templates
+        templates = self._create_dag_templates(pipeline, op_transformers)
+
+        # Exit Handler
+        exit_handler = None
+        if pipeline.groups[0].groups:
+            first_group = pipeline.groups[0].groups[0]
+            if first_group.type == 'exit_handler':
+                exit_handler = first_group.exit_op
+
+        # The whole pipeline workflow
+        # It must valid as a subdomain
+        pipeline_name = pipeline.name or 'pipeline'
+
+        # Workaround for pipeline name clashing with container template names
+        # TODO: Make sure template names cannot clash at all (container, DAG, workflow)
+        template_map = {
+            template['name'].lower(): template for template in templates
+        }
+        from ..components._naming import _make_name_unique_by_adding_index
+        pipeline_template_name = _make_name_unique_by_adding_index(
+            pipeline_name, template_map, '-')
+
+        # Restoring the name of the pipeline template
+        pipeline_template = template_map[temp_pipeline_group_name]
+        pipeline_template['name'] = pipeline_template_name
+
+        templates.sort(key=lambda x: x['name'])
+        workflow = {
+            'apiVersion': 'argoproj.io/v1alpha1',
+            'kind': 'Workflow',
+            'metadata': {
+                'generateName': pipeline_template_name + '-'
+            },
+            'spec': {
+                'entrypoint': pipeline_template_name,
+                'templates': templates,
+                'arguments': {
+                    'parameters': input_params
+                },
+                'serviceAccountName': 'pipeline-runner',
+            }
+        }
+        # set parallelism limits at pipeline level
+        if pipeline_conf.parallelism:
+            workflow['spec']['parallelism'] = pipeline_conf.parallelism
+
+        # set ttl after workflow finishes
+        if pipeline_conf.ttl_seconds_after_finished >= 0:
+            workflow['spec']['ttlStrategy'] = {'secondsAfterCompletion': pipeline_conf.ttl_seconds_after_finished}
+
+        if pipeline_conf._pod_disruption_budget_min_available:
+            pod_disruption_budget = {
+                "minAvailable":
+                    pipeline_conf._pod_disruption_budget_min_available
+            }
+            workflow['spec']['podDisruptionBudget'] = pod_disruption_budget
+
+        if len(pipeline_conf.image_pull_secrets) > 0:
+            image_pull_secrets = []
+            for image_pull_secret in pipeline_conf.image_pull_secrets:
+                image_pull_secrets.append(
+                    convert_k8s_obj_to_json(image_pull_secret))
+            workflow['spec']['imagePullSecrets'] = image_pull_secrets
+
+        if pipeline_conf.timeout:
+            workflow['spec']['activeDeadlineSeconds'] = pipeline_conf.timeout
+
+        if exit_handler:
+            workflow['spec']['onExit'] = exit_handler.name
+
+        # This can be overwritten by the task specific
+        # nodeselection, specified in the template.
+        if pipeline_conf.default_pod_node_selector:
+            workflow['spec'][
+                'nodeSelector'] = pipeline_conf.default_pod_node_selector
+
+        if pipeline_conf.dns_config:
+            workflow['spec']['dnsConfig'] = convert_k8s_obj_to_json(
+                pipeline_conf.dns_config)
+
+        if pipeline_conf.image_pull_policy != None:
+            if pipeline_conf.image_pull_policy in [
+                    "Always", "Never", "IfNotPresent"
+            ]:
+                for template in workflow["spec"]["templates"]:
+                    container = template.get('container', None)
+                    if container and "imagePullPolicy" not in container:
+                        container[
+                            "imagePullPolicy"] = pipeline_conf.image_pull_policy
+            else:
+                raise ValueError(
+                    'Invalid imagePullPolicy. Must be one of `Always`, `Never`, `IfNotPresent`.'
+                )
+        return workflow
+
+    def _validate_exit_handler(self, pipeline):
+        """Makes sure there is only one global exit handler.
+
+        Note this is a temporary workaround until argo supports local
+        exit handler.
+        """
+
+        def _validate_exit_handler_helper(group, exiting_op_names,
+                                          handler_exists):
+            if group.type == 'exit_handler':
+                if handler_exists or len(exiting_op_names) > 1:
+                    raise ValueError(
+                        'Only one global exit_handler is allowed and all ops need to be included.'
+                    )
+                handler_exists = True
+
+            if group.ops:
+                exiting_op_names.extend([x.name for x in group.ops])
+
+            for g in group.groups:
+                _validate_exit_handler_helper(g, exiting_op_names,
+                                              handler_exists)
+
+        return _validate_exit_handler_helper(pipeline.groups[0], [], False)
+
+    def _sanitize_and_inject_artifact(self,
+                                      pipeline: dsl.Pipeline,
+                                      pipeline_conf=None):
+        """Sanitize operator/param names and inject pipeline artifact
+        location."""
+
+        # Sanitize operator names and param names
+        sanitized_ops = {}
+
+        for op in pipeline.ops.values():
+            sanitized_name = sanitize_k8s_name(op.name)
+            op.name = sanitized_name
+            for param in op.outputs.values():
+                param.name = sanitize_k8s_name(param.name, True)
+                if param.op_name:
+                    param.op_name = sanitize_k8s_name(param.op_name)
+            if op.output is not None and not isinstance(
+                    op.output, dsl._container_op._MultipleOutputsError):
+                op.output.name = sanitize_k8s_name(op.output.name, True)
+                op.output.op_name = sanitize_k8s_name(op.output.op_name)
+            if op.dependent_names:
+                op.dependent_names = [
+                    sanitize_k8s_name(name) for name in op.dependent_names
+                ]
+            if isinstance(op, dsl.ContainerOp) and op.file_outputs is not None:
+                sanitized_file_outputs = {}
+                for key in op.file_outputs.keys():
+                    sanitized_file_outputs[sanitize_k8s_name(
+                        key, True)] = op.file_outputs[key]
+                op.file_outputs = sanitized_file_outputs
+            elif isinstance(
+                    op, dsl.ResourceOp) and op.attribute_outputs is not None:
+                sanitized_attribute_outputs = {}
+                for key in op.attribute_outputs.keys():
+                    sanitized_attribute_outputs[sanitize_k8s_name(key, True)] = \
+                      op.attribute_outputs[key]
+                op.attribute_outputs = sanitized_attribute_outputs
+            if isinstance(op, dsl.ContainerOp):
+                if op.input_artifact_paths:
+                    op.input_artifact_paths = {
+                        sanitize_k8s_name(key, True): value
+                        for key, value in op.input_artifact_paths.items()
+                    }
+                if op.artifact_arguments:
+                    op.artifact_arguments = {
+                        sanitize_k8s_name(key, True): value
+                        for key, value in op.artifact_arguments.items()
+                    }
+            sanitized_ops[sanitized_name] = op
+        pipeline.ops = sanitized_ops
+
+    def _create_workflow(
+        self,
+        pipeline_func: Callable,
+        pipeline_name: Optional[Text] = None,
+        pipeline_description: Optional[Text] = None,
+        params_list: Optional[List[dsl.PipelineParam]] = None,
+        pipeline_conf: Optional[dsl.PipelineConf] = None,
+    ) -> Dict[Text, Any]:
+        """Internal implementation of create_workflow."""
+        params_list = params_list or []
+
+        # Create the arg list with no default values and call pipeline function.
+        # Assign type information to the PipelineParam
+        pipeline_meta = _extract_pipeline_metadata(pipeline_func)
+        pipeline_meta.name = pipeline_name or pipeline_meta.name
+        pipeline_meta.description = pipeline_description or pipeline_meta.description
+        pipeline_name = sanitize_k8s_name(pipeline_meta.name)
+
+        # Need to first clear the default value of dsl.PipelineParams. Otherwise, it
+        # will be resolved immediately in place when being to each component.
+        default_param_values = OrderedDict()
+
+        if self._pipeline_root_param:
+            params_list.append(self._pipeline_root_param)
+        if self._pipeline_name_param:
+            params_list.append(self._pipeline_name_param)
+
+        for param in params_list:
+            default_param_values[param.name] = param.value
+            param.value = None
+
+        args_list = []
+        kwargs_dict = dict()
+        signature = inspect.signature(pipeline_func)
+        for arg_name, arg in signature.parameters.items():
+            arg_type = None
+            for input in pipeline_meta.inputs or []:
+                if arg_name == input.name:
+                    arg_type = input.type
+                    break
+            param = dsl.PipelineParam(
+                sanitize_k8s_name(arg_name, True), param_type=arg_type)
+            if arg.kind == inspect.Parameter.KEYWORD_ONLY:
+                kwargs_dict[arg_name] = param
+            else:
+                args_list.append(param)
+
+        with dsl.Pipeline(pipeline_name) as dsl_pipeline:
+            pipeline_func(*args_list, **kwargs_dict)
+
+        pipeline_conf = pipeline_conf or dsl_pipeline.conf  # Configuration passed to the compiler is overriding. Unfortunately, it's not trivial to detect whether the dsl_pipeline.conf was ever modified.
+
+        self._validate_exit_handler(dsl_pipeline)
+        self._sanitize_and_inject_artifact(dsl_pipeline, pipeline_conf)
+
+        # Fill in the default values by merging two param lists.
+        args_list_with_defaults = OrderedDict()
+        if pipeline_meta.inputs:
+            args_list_with_defaults = OrderedDict([
+                (sanitize_k8s_name(input_spec.name, True), input_spec.default)
+                for input_spec in pipeline_meta.inputs
+            ])
+
+        if params_list:
+            # Or, if args are provided by params_list, fill in pipeline_meta.
+            for k, v in default_param_values.items():
+                args_list_with_defaults[k] = v
+
+            pipeline_meta.inputs = pipeline_meta.inputs or []
+            for param in params_list:
+                pipeline_meta.inputs.append(
+                    InputSpec(
+                        name=param.name,
+                        type=param.param_type,
+                        default=default_param_values[param.name]))
+
+        op_transformers = [add_pod_env]
+        pod_labels = {
+            _SDK_VERSION_LABEL: kfp.__version__,
+            _SDK_ENV_LABEL: _SDK_ENV_DEFAULT
+        }
+        op_transformers.append(add_pod_labels(pod_labels))
+        op_transformers.extend(pipeline_conf.op_transformers)
+
+        workflow = self._create_pipeline_workflow(
+            args_list_with_defaults,
+            dsl_pipeline,
+            op_transformers,
+            pipeline_conf,
+        )
+
+        from ._data_passing_rewriter import fix_big_data_passing
+        workflow = fix_big_data_passing(workflow)
+
+        if pipeline_conf and pipeline_conf.data_passing_method != None:
+            workflow = pipeline_conf.data_passing_method(workflow)
+
+        metadata = workflow.setdefault('metadata', {})
+        annotations = metadata.setdefault('annotations', {})
+        labels = metadata.setdefault('labels', {})
+
+        annotations[_SDK_VERSION_LABEL] = kfp.__version__
+        annotations[
+            'pipelines.kubeflow.org/pipeline_compilation_time'] = datetime.datetime.now(
+            ).isoformat()
+        annotations['pipelines.kubeflow.org/pipeline_spec'] = json.dumps(
+            pipeline_meta.to_dict(), sort_keys=True)
+
+        # Labels might be logged better than annotations so adding some information here as well
+        labels[_SDK_VERSION_LABEL] = kfp.__version__
+
+        return workflow
+
+    # For now (0.1.31) this function is only used by TFX's KubeflowDagRunner.
+    # See https://github.com/tensorflow/tfx/blob/811e4c1cc0f7903d73d151b9d4f21f79f6013d4a/tfx/orchestration/kubeflow/kubeflow_dag_runner.py#L238
+    @deprecated(
+        version='0.1.32',
+        reason='Workflow spec is not intended to be handled by user, please '
+        'switch to _create_workflow')
+    def create_workflow(
+            self,
+            pipeline_func: Callable,
+            pipeline_name: Text = None,
+            pipeline_description: Text = None,
+            params_list: List[dsl.PipelineParam] = None,
+            pipeline_conf: dsl.PipelineConf = None) -> Dict[Text, Any]:
+        """Create workflow spec from pipeline function and specified pipeline
+        params/metadata. Currently, the pipeline params are either specified in
+        the signature of the pipeline function or by passing a list of
+        dsl.PipelineParam. Conflict will cause ValueError.
+
+        Args:
+          pipeline_func: Pipeline function where ContainerOps are invoked.
+          pipeline_name: The name of the pipeline to compile.
+          pipeline_description: The description of the pipeline.
+          params_list: List of pipeline params to append to the pipeline.
+          pipeline_conf: PipelineConf instance. Can specify op transforms, image pull secrets and other pipeline-level configuration options. Overrides any configuration that may be set by the pipeline.
+
+        Returns:
+          The created workflow dictionary.
+        """
+        return self._create_workflow(pipeline_func, pipeline_name,
+                                     pipeline_description, params_list,
+                                     pipeline_conf)
+
+    @deprecated(version='0.1.32', reason='Switch to _create_workflow.')
+    def _compile(self, pipeline_func, pipeline_conf: dsl.PipelineConf = None):
+        """Compile the given pipeline function into workflow."""
+        return self._create_workflow(
+            pipeline_func=pipeline_func, pipeline_conf=pipeline_conf)
+
+    def compile(self,
+                pipeline_func,
+                package_path,
+                type_check: bool = True,
+                pipeline_conf: Optional[dsl.PipelineConf] = None):
+        """Compile the given pipeline function into workflow yaml.
+
+        Args:
+          pipeline_func: Pipeline functions with @dsl.pipeline decorator.
+          package_path: The output workflow tar.gz file path. for example,
+            "~/a.tar.gz"
+          type_check: Whether to enable the type check or not, default: True.
+          pipeline_conf: PipelineConf instance. Can specify op transforms, image
+            pull secrets and other pipeline-level configuration options. Overrides
+            any configuration that may be set by the pipeline.
+        """
+        pipeline_root_dir = getattr(pipeline_func, 'pipeline_root', None)
+        if pipeline_root_dir is not None:
+            self._pipeline_root_param = dsl.PipelineParam(
+                name=dsl.ROOT_PARAMETER_NAME, value=pipeline_root_dir or '')
+
+        import kfp
+        type_check_old_value = kfp.TYPE_CHECK
+        compiling_for_v2_old_value = kfp.COMPILING_FOR_V2
+        kfp.COMPILING_FOR_V2 = False
+
+        try:
+            kfp.TYPE_CHECK = type_check
+            self._create_and_write_workflow(
+                pipeline_func=pipeline_func,
+                pipeline_conf=pipeline_conf,
+                package_path=package_path)
+        finally:
+            kfp.TYPE_CHECK = type_check_old_value
+            kfp.COMPILING_FOR_V2 = compiling_for_v2_old_value
+
+    @staticmethod
+    def _write_workflow(workflow: Dict[Text, Any], package_path: Text = None):
+        """Dump pipeline workflow into yaml spec and write out in the format
+        specified by the user.
+
+        Args:
+          workflow: Workflow spec of the pipline, dict.
+          package_path: file path to be written. If not specified, a yaml_text string will be returned.
+        """
+        yaml_text = dump_yaml(workflow)
+
+        if package_path is None:
+            return yaml_text
+
+        if package_path.endswith('.tar.gz') or package_path.endswith('.tgz'):
+            from contextlib import closing
+            from io import BytesIO
+            with tarfile.open(package_path, "w:gz") as tar:
+                with closing(BytesIO(yaml_text.encode())) as yaml_file:
+                    tarinfo = tarfile.TarInfo('pipeline.yaml')
+                    tarinfo.size = len(yaml_file.getvalue())
+                    tar.addfile(tarinfo, fileobj=yaml_file)
+        elif package_path.endswith('.zip'):
+            with zipfile.ZipFile(package_path, "w") as zip:
+                zipinfo = zipfile.ZipInfo('pipeline.yaml')
+                zipinfo.compress_type = zipfile.ZIP_DEFLATED
+                zip.writestr(zipinfo, yaml_text)
+        elif package_path.endswith('.yaml') or package_path.endswith('.yml'):
+            with open(package_path, 'w') as yaml_file:
+                yaml_file.write(yaml_text)
+        else:
+            raise ValueError('The output path ' + package_path +
+                             ' should ends with one of the following formats: '
+                             '[.tar.gz, .tgz, .zip, .yaml, .yml]')
+
+    def _create_and_write_workflow(self,
+                                   pipeline_func: Callable,
+                                   pipeline_name: Text = None,
+                                   pipeline_description: Text = None,
+                                   params_list: List[dsl.PipelineParam] = None,
+                                   pipeline_conf: dsl.PipelineConf = None,
+                                   package_path: Text = None) -> None:
+        """Compile the given pipeline function and dump it to specified file
+        format."""
+        workflow = self._create_workflow(pipeline_func, pipeline_name,
+                                         pipeline_description, params_list,
+                                         pipeline_conf)
+        self._write_workflow(workflow, package_path)
+        _validate_workflow(workflow)
+
+
+def _validate_workflow(workflow: dict):
+    workflow = workflow.copy()
+    # Working around Argo lint issue
+    for argument in workflow['spec'].get('arguments', {}).get('parameters', []):
+        if 'value' not in argument:
+            argument['value'] = ''
+
+    yaml_text = dump_yaml(workflow)
+    if '{{pipelineparam' in yaml_text:
+        raise RuntimeError(
+            '''Internal compiler error: Found unresolved PipelineParam.
+Please create a new issue at https://github.com/kubeflow/pipelines/issues attaching the pipeline code and the pipeline package.'''
+        )
+
+    # Running Argo lint if available
+    import shutil
+    import subprocess
+    argo_path = shutil.which('argo')
+    if argo_path:
+        has_working_argo_lint = False
+        try:
+            has_working_argo_lint = _run_argo_lint("""
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          generateName: hello-world-
+        spec:
+          entrypoint: whalesay
+          templates:
+          - name: whalesay
+            container:
+              image: docker/whalesay:latest""")
+        except:
+            warnings.warn(
+                "Cannot validate the compiled workflow. Found the argo program in PATH, but it's not usable. argo CLI v3.1.1+ should work."
+            )
+
+        if has_working_argo_lint:
+            _run_argo_lint(yaml_text)
+
+
+def _run_argo_lint(yaml_text: str):
+    # Running Argo lint if available
+    import shutil
+    import subprocess
+    argo_path = shutil.which('argo')
+    if argo_path:
+        result = subprocess.run([
+            argo_path, '--offline=true', '--kinds=workflows', 'lint',
+            '/dev/stdin'
+        ],
+                                input=yaml_text.encode('utf-8'),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        if result.returncode:
+            if re.match(
+                    pattern=r'.+failed to resolve {{tasks\..+\.outputs\.artifacts\..+}}.+',
+                    string=result.stderr.decode('utf-8')):
+                raise RuntimeError(
+                    'Compiler has produced Argo-incompatible workflow due to '
+                    'unresolvable input artifact(s). Please check whether inputPath has'
+                    ' been connected to outputUri placeholder, which is not supported '
+                    'yet. Otherwise, please create a new issue at '
+                    'https://github.com/kubeflow/pipelines/issues attaching the '
+                    'pipeline code and the pipeline package. Error: {}'.format(
+                        result.stderr.decode('utf-8')))
+            raise RuntimeError(
+                '''Internal compiler error: Compiler has produced Argo-incompatible workflow.
+Please create a new issue at https://github.com/kubeflow/pipelines/issues attaching the pipeline code and the pipeline package.
+Error: {}'''.format(result.stderr.decode('utf-8')))
+
+        return True
+    return False

--- a/kfp/compiler/main.py
+++ b/kfp/compiler/main.py
@@ -1,0 +1,135 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import Optional
+from kfp import dsl
+import kfp.compiler
+import os
+import sys
+from deprecated.sphinx import deprecated
+
+_KF_PIPELINES_COMPILER_MODE_ENV = 'KF_PIPELINES_COMPILER_MODE'
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--py', type=str, help='local absolute path to a py file.')
+    parser.add_argument(
+        '--function',
+        type=str,
+        help='The name of the function to compile if there are multiple.')
+    parser.add_argument(
+        '--namespace', type=str, help='The namespace for the pipeline function')
+    parser.add_argument(
+        '--output',
+        type=str,
+        required=True,
+        help='local path to the output workflow yaml file.')
+    parser.add_argument(
+        '--disable-type-check',
+        action='store_true',
+        help='disable the type check, default is enabled.')
+    parser.add_argument(
+        '--mode',
+        type=str,
+        help='(Deprecated) compiler mode, only V1_LEGACY is supported. You can override the default using env var KF_PIPELINES_COMPILER_MODE.'
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def _compile_pipeline_function(pipeline_funcs, function_name, output_path,
+                               type_check,
+                               mode: Optional[dsl.PipelineExecutionMode]):
+    if len(pipeline_funcs) == 0:
+        raise ValueError(
+            'A function with @dsl.pipeline decorator is required in the py file.'
+        )
+
+    if len(pipeline_funcs) > 1 and not function_name:
+        func_names = [x.__name__ for x in pipeline_funcs]
+        raise ValueError(
+            'There are multiple pipelines: %s. Please specify --function.' %
+            func_names)
+
+    if function_name:
+        pipeline_func = next(
+            (x for x in pipeline_funcs if x.__name__ == function_name), None)
+        if not pipeline_func:
+            raise ValueError('The function "%s" does not exist. '
+                             'Did you forget @dsl.pipeline decoration?' %
+                             function_name)
+    else:
+        pipeline_func = pipeline_funcs[0]
+
+    kfp.compiler.Compiler(mode=mode).compile(pipeline_func, output_path,
+                                             type_check)
+
+
+class PipelineCollectorContext():
+
+    def __enter__(self):
+        pipeline_funcs = []
+
+        def add_pipeline(func):
+            pipeline_funcs.append(func)
+            return func
+
+        self.old_handler = dsl._pipeline._pipeline_decorator_handler
+        dsl._pipeline._pipeline_decorator_handler = add_pipeline
+        return pipeline_funcs
+
+    def __exit__(self, *args):
+        dsl._pipeline._pipeline_decorator_handler = self.old_handler
+
+
+def compile_pyfile(pyfile, function_name, output_path, type_check,
+                   mode: Optional[dsl.PipelineExecutionMode]):
+    sys.path.insert(0, os.path.dirname(pyfile))
+    try:
+        filename = os.path.basename(pyfile)
+        with PipelineCollectorContext() as pipeline_funcs:
+            __import__(os.path.splitext(filename)[0])
+        _compile_pipeline_function(pipeline_funcs, function_name, output_path,
+                                   type_check, mode)
+    finally:
+        del sys.path[0]
+
+
+def main():
+    args = parse_arguments()
+    if args.py is None:
+        raise ValueError('The --py option must be specified.')
+    mode_str = args.mode
+    if not mode_str:
+        mode_str = os.environ.get(_KF_PIPELINES_COMPILER_MODE_ENV, 'V1')
+    mode = None
+    if mode_str == 'V1_LEGACY' or mode_str == 'V1':
+        mode = kfp.dsl.PipelineExecutionMode.V1_LEGACY
+    else:
+        raise ValueError(
+            f'Got unexpected --mode option "{mode_str}", it must be V1 or V1_LEGACY. V2 modes are not supported in this SDK version.'
+        )
+    compile_pyfile(
+        args.py,
+        args.function,
+        args.output,
+        not args.disable_type_check,
+        mode,
+    )

--- a/kfp/components/__init__.py
+++ b/kfp/components/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._airflow_op import *
+from ._components import *
+from ._python_op import *
+from ._python_to_graph_component import *
+from ._component_store import *

--- a/kfp/components/_airflow_op.py
+++ b/kfp/components/_airflow_op.py
@@ -1,0 +1,145 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'create_component_from_airflow_op',
+]
+
+from typing import List
+
+from ._python_op import _func_to_component_spec, _create_task_factory_from_component_spec
+
+_default_airflow_base_image = 'apache/airflow:master-python3.6-ci'  #TODO: Update a production release image once they become available: https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-10+Multi-layered+and+multi-stage+official+Airflow+CI+image#AIP-10Multi-layeredandmulti-stageofficialAirflowCIimage-ProposedsetupoftheDockerHubandTravisCI . See https://issues.apache.org/jira/browse/AIRFLOW-5093
+
+
+def create_component_from_airflow_op(
+        op_class: type,
+        base_image: str = _default_airflow_base_image,
+        variable_output_names: List[str] = None,
+        xcom_output_names: List[str] = None,
+        modules_to_capture: List[str] = None):
+    """Creates component function from an Airflow operator class. The inputs of
+    the component are the same as the operator constructor parameters. By
+    default the component has the following outputs: "Result", "Variables" and
+    "XComs". "Variables" and "XComs" are serialized JSON maps of all variables
+    and xcoms produced by the operator during the execution. Use the
+    variable_output_names and xcom_output_names parameters to output individual
+    variables/xcoms as separate outputs.
+
+    Args:
+        op_class: Reference to the Airflow operator class (e.g. EmailOperator or BashOperator) to convert to componenent.
+        base_image: Optional. The container image to use for the component. Default is apache/airflow. The container image must have the same python version as the environment used to run create_component_from_airflow_op. The image should have python 3.5+ with airflow package installed.
+        variable_output_names: Optional. A list of Airflow "variables" produced by the operator that should be returned as separate outputs.
+        xcom_output_names: Optional. A list of Airflow "XComs" produced by the operator that should be returned as separate outputs.
+        modules_to_capture: Optional. A list of names of additional modules that the operator depends on. By default only the module containing the operator class is captured. If the operator class uses the code from another module, the name of that module can be specified in this list.
+    """
+    component_spec = _create_component_spec_from_airflow_op(
+        op_class=op_class,
+        base_image=base_image,
+        variables_to_output=variable_output_names,
+        xcoms_to_output=xcom_output_names,
+        modules_to_capture=modules_to_capture,
+    )
+    task_factory = _create_task_factory_from_component_spec(component_spec)
+    return task_factory
+
+
+def _create_component_spec_from_airflow_op(
+    op_class: type,
+    base_image: str = _default_airflow_base_image,
+    result_output_name: str = 'Result',
+    variables_dict_output_name: str = 'Variables',
+    xcoms_dict_output_name: str = 'XComs',
+    variables_to_output: List[str] = None,
+    xcoms_to_output: List[str] = None,
+    modules_to_capture: List[str] = None,
+):
+    variables_output_names = variables_to_output or []
+    xcoms_output_names = xcoms_to_output or []
+    modules_to_capture = modules_to_capture or [op_class.__module__]
+    modules_to_capture.append(_run_airflow_op.__module__)
+
+    output_names = []
+    if result_output_name is not None:
+        output_names.append(result_output_name)
+    if variables_dict_output_name is not None:
+        output_names.append(variables_dict_output_name)
+    if xcoms_dict_output_name is not None:
+        output_names.append(xcoms_dict_output_name)
+    output_names.extend(variables_output_names)
+    output_names.extend(xcoms_output_names)
+
+    from collections import namedtuple
+    returnType = namedtuple('AirflowOpOutputs', output_names)
+
+    def _run_airflow_op_closure(*op_args, **op_kwargs) -> returnType:
+        (result, variables, xcoms) = _run_airflow_op(op_class, *op_args,
+                                                     **op_kwargs)
+
+        output_values = {}
+
+        import json
+        if result_output_name is not None:
+            output_values[result_output_name] = str(result)
+        if variables_dict_output_name is not None:
+            output_values[variables_dict_output_name] = json.dumps(variables)
+        if xcoms_dict_output_name is not None:
+            output_values[xcoms_dict_output_name] = json.dumps(xcoms)
+        for name in variables_output_names:
+            output_values[name] = variables[name]
+        for name in xcoms_output_names:
+            output_values[name] = xcoms[name]
+
+        return returnType(**output_values)
+
+    # Hacking the function signature so that correct component interface is generated
+    import inspect
+    parameters = inspect.signature(op_class).parameters.values()
+    #Filtering out `*args` and `**kwargs` parameters that some operators have
+    parameters = [
+        param for param in parameters
+        if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+    sig = inspect.Signature(
+        parameters=parameters,
+        return_annotation=returnType,
+    )
+    _run_airflow_op_closure.__signature__ = sig
+    _run_airflow_op_closure.__name__ = op_class.__name__
+
+    return _func_to_component_spec(
+        _run_airflow_op_closure,
+        base_image=base_image,
+        use_code_pickling=True,
+        modules_to_capture=modules_to_capture)
+
+
+def _run_airflow_op(Op, *op_args, **op_kwargs):
+    from airflow.utils import db
+    db.initdb()
+
+    from datetime import datetime
+    from airflow import DAG, settings
+    from airflow.models import TaskInstance, Variable, XCom
+
+    dag = DAG(dag_id='anydag', start_date=datetime.now())
+    task = Op(*op_args, **op_kwargs, dag=dag, task_id='anytask')
+    ti = TaskInstance(task=task, execution_date=datetime.now())
+    result = task.execute(ti.get_template_context())
+
+    variables = {
+        var.id: var.val for var in settings.Session().query(Variable).all()
+    }
+    xcoms = {msg.key: msg.value for msg in settings.Session().query(XCom).all()}
+    return (result, variables, xcoms)

--- a/kfp/components/_component_store.py
+++ b/kfp/components/_component_store.py
@@ -1,0 +1,394 @@
+__all__ = [
+    'ComponentStore',
+]
+
+from pathlib import Path
+import copy
+import hashlib
+import json
+import logging
+import requests
+import tempfile
+from typing import Callable, Iterable
+from uritemplate import URITemplate
+from . import _components as comp
+from .structures import ComponentReference
+from ._key_value_store import KeyValueStore
+
+_COMPONENT_FILENAME = 'component.yaml'
+
+
+class ComponentStore:
+    """Component store.
+    
+    Enables external components to be loaded by name and digest/tag.
+    
+    Attributes:
+
+        local_search_paths: A list of local directories to include in the search.
+        url_seach_prefixes: A list of URL prefixes to include in the search.
+        uri_search_template: A URI template for components, which may include {name}, {digest} and {tag} variables.
+    """
+
+    def __init__(self,
+                 local_search_paths=None,
+                 url_search_prefixes=None,
+                 auth=None,
+                 uri_search_template=None):
+        """Instantiates a ComponentStore including the specified locations.
+        
+        Args:
+
+            local_search_paths: A list of local directories to include in the search.
+            url_seach_prefixes: A list of URL prefixes to include in the search.
+            auth: Auth object for the requests library. See https://requests.readthedocs.io/en/master/user/authentication/
+            uri_search_template: A URI template for components, which may include {name}, {digest} and {tag} variables.
+        """
+        self.local_search_paths = local_search_paths or ['.']
+        self.uri_search_template = URITemplate(uri_search_template) if uri_search_template else None
+        self.url_search_prefixes = url_search_prefixes or []
+        self._auth = auth
+
+        self._component_file_name = 'component.yaml'
+        self._digests_subpath = 'versions/sha256'
+        self._tags_subpath = 'versions/tags'
+
+        cache_base_dir = Path(tempfile.gettempdir()) / '.kfp_components'
+        self._git_blob_hash_to_data_db = KeyValueStore(
+            cache_dir=cache_base_dir / 'git_blob_hash_to_data')
+        self._url_to_info_db = KeyValueStore(cache_dir=cache_base_dir /
+                                             'url_to_info')
+
+    def load_component_from_url(self, url):
+        """Loads a component from a URL.
+
+        Args:
+            url: The url of the component specification.
+
+        Returns:
+            A factory function with a strongly-typed signature.
+        """
+        return comp.load_component_from_url(url=url, auth=self._auth)
+
+    def load_component_from_file(self, path):
+        """Loads a component from a path.
+
+        Args:
+            path: The path of the component specification.
+
+        Returns:
+            A factory function with a strongly-typed signature.
+        """
+        return comp.load_component_from_file(path)
+
+    def load_component(self, name, digest=None, tag=None):
+        """Loads component local file or URL and creates a task factory
+        function.
+
+        Search locations:
+
+        * :code:`<local-search-path>/<name>/component.yaml`
+        * :code:`<url-search-prefix>/<name>/component.yaml`
+
+        If the digest is specified, then the search locations are:
+
+        * :code:`<local-search-path>/<name>/versions/sha256/<digest>`
+        * :code:`<url-search-prefix>/<name>/versions/sha256/<digest>`
+
+        If the tag is specified, then the search locations are:
+
+        * :code:`<local-search-path>/<name>/versions/tags/<digest>`
+        * :code:`<url-search-prefix>/<name>/versions/tags/<digest>`
+
+        Args:
+            name:   Component name used to search and load the component artifact containing the component definition.
+                    Component name usually has the following form: group/subgroup/component
+            digest: Strict component version. SHA256 hash digest of the component artifact file. Can be used to load a specific component version so that the pipeline is reproducible.
+            tag:    Version tag. Can be used to load component version from a specific branch. The version of the component referenced by a tag can change in future.
+
+        Returns:
+            A factory function with a strongly-typed signature.
+            Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+        """
+        #This function should be called load_task_factory since it returns a factory function.
+        #The real load_component function should produce an object with component properties (e.g. name, description, inputs/outputs).
+        #TODO: Change this function to return component spec object but it should be callable to construct tasks.
+        component_ref = ComponentReference(name=name, digest=digest, tag=tag)
+        component_ref = self._load_component_spec_in_component_ref(
+            component_ref)
+        return comp._create_task_factory_from_component_spec(
+            component_spec=component_ref.spec,
+            component_ref=component_ref,
+        )
+
+    def _load_component_spec_in_component_ref(
+        self,
+        component_ref: ComponentReference,
+    ) -> ComponentReference:
+        """Takes component_ref, finds the component spec and returns
+        component_ref with .spec set to the component spec.
+
+        See ComponentStore.load_component for the details of the search
+        logic.
+        """
+        if component_ref.spec:
+            return component_ref
+
+        component_ref = copy.copy(component_ref)
+        if component_ref.url:
+            component_ref.spec = comp._load_component_spec_from_url(
+                url=component_ref.url, auth=self._auth)
+            return component_ref
+
+        name = component_ref.name
+        if not name:
+            raise TypeError("name is required")
+        if name.startswith('/') or name.endswith('/'):
+            raise ValueError(
+                'Component name should not start or end with slash: "{}"'
+                .format(name))
+
+        digest = component_ref.digest
+        tag = component_ref.tag
+
+        tried_locations = []
+
+        if digest is not None and tag is not None:
+            raise ValueError('Cannot specify both tag and digest')
+
+        if digest is not None:
+            path_suffix = name + '/' + self._digests_subpath + '/' + digest
+        elif tag is not None:
+            path_suffix = name + '/' + self._tags_subpath + '/' + tag
+            #TODO: Handle symlinks in GIT URLs
+        else:
+            path_suffix = name + '/' + self._component_file_name
+
+        #Trying local search paths
+        for local_search_path in self.local_search_paths:
+            component_path = Path(local_search_path, path_suffix)
+            tried_locations.append(str(component_path))
+            if component_path.is_file():
+                # TODO: Verify that the content matches the digest (if specified).
+                component_ref._local_path = str(component_path)
+                component_ref.spec = comp._load_component_spec_from_file(
+                    str(component_path))
+                return component_ref
+
+        #Trying URI template
+        if self.uri_search_template:
+            url = self.uri_search_template.expand(
+                name=name, digest=digest, tag=tag)
+            tried_locations.append(url)
+            if self._load_component_spec_from_url(component_ref, url):
+                return component_ref
+
+        #Trying URL prefixes
+        for url_search_prefix in self.url_search_prefixes:
+            url = url_search_prefix + path_suffix
+            tried_locations.append(url)
+            if self._load_component_spec_from_url(component_ref, url):
+                return component_ref
+
+        raise RuntimeError(
+            'Component {} was not found. Tried the following locations:\n{}'
+            .format(name, '\n'.join(tried_locations)))
+
+    def _load_component_spec_from_url(self, component_ref, url) -> bool:
+        """Loads component spec from a URL.
+
+        On success, the url and spec attributes of the component_ref arg will be populated.
+
+        Args:
+            component_ref: the component whose spec to load.
+            url: the location from which to obtain the component spec.
+
+        Returns:
+            True if the component was retrieved and non-empty; otherwise False.
+        """
+
+        try:
+            response = requests.get(
+                url, auth=self._auth
+            )  #Does not throw exceptions on bad status, but throws on dead domains and malformed URLs. Should we log those cases?
+            response.raise_for_status()
+        except:
+            return False
+
+        if response.content:
+            # TODO: Verify that the content matches the digest (if specified).
+            component_ref.url = url
+            component_ref.spec = comp._load_component_spec_from_yaml_or_zip_bytes(
+                response.content)
+            return True
+
+        return False
+
+    def _load_component_from_ref(self,
+                                 component_ref: ComponentReference) -> Callable:
+        component_ref = self._load_component_spec_in_component_ref(
+            component_ref)
+        return comp._create_task_factory_from_component_spec(
+            component_spec=component_ref.spec, component_ref=component_ref)
+
+    def search(self, name: str):
+        """Searches for components by name in the configured component store.
+
+        Prints the component name and URL for components that match the given name.
+        Only components on GitHub are currently supported.
+
+        Example::
+
+            kfp.components.ComponentStore.default_store.search('xgboost')
+
+            # Returns results:
+            #     Xgboost train   https://raw.githubusercontent.com/.../components/XGBoost/Train/component.yaml
+            #     Xgboost predict https://raw.githubusercontent.com/.../components/XGBoost/Predict/component.yaml
+        """
+        self._refresh_component_cache()
+        for url in self._url_to_info_db.keys():
+            component_info = json.loads(
+                self._url_to_info_db.try_get_value_bytes(url))
+            component_name = component_info['name']
+            if name.casefold() in component_name.casefold():
+                print('\t'.join([
+                    component_name,
+                    url,
+                ]))
+
+    def list(self):
+        self.search('')
+
+    def _refresh_component_cache(self):
+        for url_search_prefix in self.url_search_prefixes:
+            if url_search_prefix.startswith(
+                    'https://raw.githubusercontent.com/'):
+                logging.info('Searching for components in "{}"'.format(
+                    url_search_prefix))
+                for candidate in _list_candidate_component_uris_from_github_repo(
+                        url_search_prefix, auth=self._auth):
+                    component_url = candidate['url']
+                    if self._url_to_info_db.exists(component_url):
+                        continue
+
+                    logging.debug(
+                        'Found new component URL: "{}"'.format(component_url))
+
+                    blob_hash = candidate['git_blob_hash']
+                    if not self._git_blob_hash_to_data_db.exists(blob_hash):
+                        logging.debug(
+                            'Downloading component spec from "{}"'.format(
+                                component_url))
+                        response = _get_request_session().get(
+                            component_url, auth=self._auth)
+                        response.raise_for_status()
+                        component_data = response.content
+
+                        # Verifying the hash
+                        received_data_hash = _calculate_git_blob_hash(
+                            component_data)
+                        if received_data_hash.lower() != blob_hash.lower():
+                            raise RuntimeError(
+                                'The downloaded component ({}) has incorrect hash: "{}" != "{}"'
+                                .format(
+                                    component_url,
+                                    received_data_hash,
+                                    blob_hash,
+                                ))
+
+                        # Verifying that the component is loadable
+                        try:
+                            component_spec = comp._load_component_spec_from_component_text(
+                                component_data)
+                        except:
+                            continue
+                        self._git_blob_hash_to_data_db.store_value_bytes(
+                            blob_hash, component_data)
+                    else:
+                        component_data = self._git_blob_hash_to_data_db.try_get_value_bytes(
+                            blob_hash)
+                        component_spec = comp._load_component_spec_from_component_text(
+                            component_data)
+
+                    component_name = component_spec.name
+                    self._url_to_info_db.store_value_text(
+                        component_url,
+                        json.dumps(
+                            dict(
+                                name=component_name,
+                                url=component_url,
+                                git_blob_hash=blob_hash,
+                                digest=_calculate_component_digest(
+                                    component_data),
+                            )))
+
+
+def _get_request_session(max_retries: int = 3):
+    session = requests.Session()
+
+    retry_strategy = requests.packages.urllib3.util.retry.Retry(
+        total=max_retries,
+        backoff_factor=0.1,
+        status_forcelist=[413, 429, 500, 502, 503, 504],
+        method_whitelist=frozenset(['GET', 'POST']),
+    )
+
+    session.mount('https://',
+                  requests.adapters.HTTPAdapter(max_retries=retry_strategy))
+    session.mount('http://',
+                  requests.adapters.HTTPAdapter(max_retries=retry_strategy))
+
+    return session
+
+
+def _calculate_git_blob_hash(data: bytes) -> str:
+    return hashlib.sha1(b'blob ' + str(len(data)).encode('utf-8') + b'\x00' +
+                        data).hexdigest()
+
+
+def _calculate_component_digest(data: bytes) -> str:
+    return hashlib.sha256(data.replace(b'\r\n', b'\n')).hexdigest()
+
+
+def _list_candidate_component_uris_from_github_repo(url_search_prefix: str,
+                                                    auth=None) -> Iterable[str]:
+    (schema, _, host, org, repo, ref,
+     path_prefix) = url_search_prefix.split('/', 6)
+    for page in range(1, 999):
+        search_url = (
+            'https://api.github.com/search/code?q=filename:{}+repo:{}/{}&page={}&per_page=1000'
+        ).format(_COMPONENT_FILENAME, org, repo, page)
+        response = _get_request_session().get(search_url, auth=auth)
+        response.raise_for_status()
+        result = response.json()
+        items = result['items']
+        if not items:
+            break
+        for item in items:
+            html_url = item['html_url']
+            # Constructing direct content URL
+            # There is an API (/repos/:owner/:repo/git/blobs/:file_sha) for
+            # getting the blob content, but it requires decoding the content.
+            raw_url = html_url.replace(
+                'https://github.com/',
+                'https://raw.githubusercontent.com/').replace('/blob/', '/', 1)
+            if not raw_url.endswith(_COMPONENT_FILENAME):
+                # GitHub matches component_test.yaml when searching for filename:"component.yaml"
+                continue
+            result_item = dict(
+                url=raw_url,
+                path=item['path'],
+                git_blob_hash=item['sha'],
+            )
+            yield result_item
+
+
+ComponentStore.default_store = ComponentStore(
+    local_search_paths=[
+        '.',
+    ],
+    uri_search_template='https://raw.githubusercontent.com/kubeflow/pipelines/{tag}/components/{name}/component.yaml',
+    url_search_prefixes=[
+        'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/'
+    ],
+)

--- a/kfp/components/_components.py
+++ b/kfp/components/_components.py
@@ -1,0 +1,677 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'load_component',
+    'load_component_from_text',
+    'load_component_from_url',
+    'load_component_from_file',
+]
+
+import copy
+from collections import OrderedDict
+import pathlib
+from typing import Any, Callable, List, Mapping, NamedTuple, Sequence, Union
+import warnings
+
+from ._naming import _sanitize_file_name, _sanitize_python_function_name, generate_unique_name_conversion_table
+from ._yaml_utils import load_yaml
+from .structures import *
+from ._data_passing import serialize_value, get_canonical_type_for_type_name
+
+_default_component_name = 'Component'
+
+
+def load_component(filename=None, url=None, text=None, component_spec=None):
+    """Loads component from text, file or URL and creates a task factory
+    function.
+
+    Only one argument should be specified.
+
+    Args:
+        filename: Path of local file containing the component definition.
+        url: The URL of the component file data.
+        text: A string containing the component file data.
+        component_spec: A ComponentSpec containing the component definition.
+
+    Returns:
+        A factory function with a strongly-typed signature.
+        Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+    """
+    #This function should be called load_task_factory since it returns a factory function.
+    #The real load_component function should produce an object with component properties (e.g. name, description, inputs/outputs).
+    #TODO: Change this function to return component spec object but it should be callable to construct tasks.
+    non_null_args_count = len(
+        [name for name, value in locals().items() if value != None])
+    if non_null_args_count != 1:
+        raise ValueError('Need to specify exactly one source')
+    if filename:
+        return load_component_from_file(filename)
+    elif url:
+        return load_component_from_url(url)
+    elif text:
+        return load_component_from_text(text)
+    elif component_spec:
+        return load_component_from_spec(component_spec)
+    else:
+        raise ValueError('Need to specify a source')
+
+
+def load_component_from_url(url: str, auth=None):
+    """Loads component from URL and creates a task factory function.
+
+    Args:
+        url: The URL of the component file data
+        auth: Auth object for the requests library. See https://requests.readthedocs.io/en/master/user/authentication/
+
+    Returns:
+        A factory function with a strongly-typed signature.
+        Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+    """
+    component_spec = _load_component_spec_from_url(url, auth)
+    url = _fix_component_uri(url)
+    component_ref = ComponentReference(url=url)
+    return _create_task_factory_from_component_spec(
+        component_spec=component_spec,
+        component_filename=url,
+        component_ref=component_ref,
+    )
+
+
+def load_component_from_file(filename):
+    """Loads component from file and creates a task factory function.
+
+    Args:
+        filename: Path of local file containing the component definition.
+
+    Returns:
+        A factory function with a strongly-typed signature.
+        Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+    """
+    component_spec = _load_component_spec_from_file(path=filename)
+    return _create_task_factory_from_component_spec(
+        component_spec=component_spec,
+        component_filename=filename,
+    )
+
+
+def load_component_from_text(text):
+    """Loads component from text and creates a task factory function.
+
+    Args:
+        text: A string containing the component file data.
+
+    Returns:
+        A factory function with a strongly-typed signature.
+        Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+    """
+    if text is None:
+        raise TypeError
+    component_spec = _load_component_spec_from_component_text(text)
+    return _create_task_factory_from_component_spec(
+        component_spec=component_spec)
+
+
+def load_component_from_spec(component_spec):
+    """Loads component from a ComponentSpec and creates a task factory
+    function.
+
+    Args:
+        component_spec: A ComponentSpec containing the component definition.
+
+    Returns:
+        A factory function with a strongly-typed signature.
+        Once called with the required arguments, the factory constructs a pipeline task instance (ContainerOp).
+    """
+    if component_spec is None:
+        raise TypeError
+    return _create_task_factory_from_component_spec(
+        component_spec=component_spec)
+
+
+def _fix_component_uri(uri: str) -> str:
+    #Handling Google Cloud Storage URIs
+    if uri.startswith('gs://'):
+        #Replacing the gs:// URI with https:// URI (works for public objects)
+        uri = 'https://storage.googleapis.com/' + uri[len('gs://'):]
+    return uri
+
+
+def _load_component_spec_from_file(path) -> ComponentSpec:
+    with open(path, 'rb') as component_stream:
+        return _load_component_spec_from_yaml_or_zip_bytes(
+            component_stream.read())
+
+
+def _load_component_spec_from_url(url: str, auth=None):
+    if url is None:
+        raise TypeError
+
+    url = _fix_component_uri(url)
+
+    import requests
+    resp = requests.get(url, auth=auth)
+    resp.raise_for_status()
+    return _load_component_spec_from_yaml_or_zip_bytes(resp.content)
+
+
+_COMPONENT_FILE_NAME_IN_ARCHIVE = 'component.yaml'
+
+
+def _load_component_spec_from_yaml_or_zip_bytes(data: bytes):
+    """Loads component spec from binary data.
+
+    The data can be a YAML file or a zip file with a component.yaml file
+    inside.
+    """
+    import zipfile
+    import io
+    stream = io.BytesIO(data)
+    if zipfile.is_zipfile(stream):
+        stream.seek(0)
+        with zipfile.ZipFile(stream) as zip_obj:
+            data = zip_obj.read(_COMPONENT_FILE_NAME_IN_ARCHIVE)
+    return _load_component_spec_from_component_text(data)
+
+
+def _load_component_spec_from_component_text(text) -> ComponentSpec:
+    component_dict = load_yaml(text)
+    component_spec = ComponentSpec.from_dict(component_dict)
+
+    if isinstance(component_spec.implementation, ContainerImplementation) and (
+            component_spec.implementation.container.command is None):
+        warnings.warn(
+            'Container component must specify command to be compatible with KFP '
+            'v2 compatible mode and emissary executor, which will be the default'
+            ' executor for KFP v2.'
+            'https://www.kubeflow.org/docs/components/pipelines/installation/choose-executor/',
+            category=FutureWarning,
+        )
+
+    # Calculating hash digest for the component
+    import hashlib
+    data = text if isinstance(text, bytes) else text.encode('utf-8')
+    data = data.replace(b'\r\n', b'\n')  # Normalizing line endings
+    digest = hashlib.sha256(data).hexdigest()
+    component_spec._digest = digest
+
+    return component_spec
+
+
+_inputs_dir = '/tmp/inputs'
+_outputs_dir = '/tmp/outputs'
+_single_io_file_name = 'data'
+
+
+def _generate_input_file_name(port_name):
+    return str(
+        pathlib.PurePosixPath(_inputs_dir, _sanitize_file_name(port_name),
+                              _single_io_file_name))
+
+
+def _generate_output_file_name(port_name):
+    return str(
+        pathlib.PurePosixPath(_outputs_dir, _sanitize_file_name(port_name),
+                              _single_io_file_name))
+
+
+def _react_to_incompatible_reference_type(
+    input_type,
+    argument_type,
+    input_name: str,
+):
+    """Raises error for the case when the argument type is incompatible with
+    the input type."""
+    message = 'Argument with type "{}" was passed to the input "{}" that has type "{}".'.format(
+        argument_type, input_name, input_type)
+    raise TypeError(message)
+
+
+def _create_task_spec_from_component_and_arguments(
+        component_spec: ComponentSpec,
+        arguments: Mapping[str, Any],
+        component_ref: ComponentReference = None,
+        **kwargs) -> TaskSpec:
+    """Constructs a TaskSpec object from component reference and arguments.
+
+    The function also checks the arguments types and serializes them.
+    """
+    if component_ref is None:
+        component_ref = ComponentReference(spec=component_spec)
+    else:
+        component_ref = copy.copy(component_ref)
+        component_ref.spec = component_spec
+
+    # Not checking for missing or extra arguments since the dynamic factory function checks that
+    task_arguments = {}
+    for input_name, argument_value in arguments.items():
+        input_type = component_spec._inputs_dict[input_name].type
+
+        if isinstance(argument_value, (GraphInputArgument, TaskOutputArgument)):
+            # argument_value is a reference
+            if isinstance(argument_value, GraphInputArgument):
+                reference_type = argument_value.graph_input.type
+            elif isinstance(argument_value, TaskOutputArgument):
+                reference_type = argument_value.task_output.type
+            else:
+                reference_type = None
+
+            if reference_type and input_type and reference_type != input_type:
+                _react_to_incompatible_reference_type(input_type,
+                                                      reference_type,
+                                                      input_name)
+
+            task_arguments[input_name] = argument_value
+        else:
+            # argument_value is a constant value
+            serialized_argument_value = serialize_value(argument_value,
+                                                        input_type)
+            task_arguments[input_name] = serialized_argument_value
+
+    task = TaskSpec(
+        component_ref=component_ref,
+        arguments=task_arguments,
+    )
+    task._init_outputs()
+
+    return task
+
+
+_default_container_task_constructor = _create_task_spec_from_component_and_arguments
+
+# Holds the function that constructs a task object based on ComponentSpec, arguments and ComponentReference.
+# Framework authors can override this constructor function to construct different framework-specific task-like objects.
+# The task object should have the task.outputs dictionary with keys corresponding to the ComponentSpec outputs.
+# The default constructor creates and instance of the TaskSpec class.
+_container_task_constructor = _default_container_task_constructor
+
+_always_expand_graph_components = False
+
+
+def _create_task_object_from_component_and_arguments(
+        component_spec: ComponentSpec,
+        arguments: Mapping[str, Any],
+        component_ref: ComponentReference = None,
+        **kwargs):
+    """Creates a task object from component and argument.
+
+    Unlike _container_task_constructor, handles the graph components as
+    well.
+    """
+    if (isinstance(component_spec.implementation, GraphImplementation) and (
+            # When the container task constructor is not overriden, we just construct TaskSpec for both container and graph tasks.
+            # If the container task constructor is overriden, we should expand the graph components so that the override is called for all sub-tasks.
+            _container_task_constructor != _default_container_task_constructor
+            or _always_expand_graph_components)):
+        return _resolve_graph_task(
+            component_spec=component_spec,
+            arguments=arguments,
+            component_ref=component_ref,
+            **kwargs,
+        )
+
+    task = _container_task_constructor(
+        component_spec=component_spec,
+        arguments=arguments,
+        component_ref=component_ref,
+        **kwargs,
+    )
+
+    return task
+
+
+class _DefaultValue:
+
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return repr(self.value)
+
+
+#TODO: Refactor the function to make it shorter
+def _create_task_factory_from_component_spec(
+        component_spec: ComponentSpec,
+        component_filename=None,
+        component_ref: ComponentReference = None):
+    name = component_spec.name or _default_component_name
+
+    func_docstring_lines = []
+    if component_spec.name:
+        func_docstring_lines.append(component_spec.name)
+    if component_spec.description:
+        func_docstring_lines.append(component_spec.description)
+
+    inputs_list = component_spec.inputs or []  #List[InputSpec]
+    input_names = [input.name for input in inputs_list]
+
+    #Creating the name translation tables : Original <-> Pythonic
+    input_name_to_pythonic = generate_unique_name_conversion_table(
+        input_names, _sanitize_python_function_name)
+    pythonic_name_to_input_name = {
+        v: k for k, v in input_name_to_pythonic.items()
+    }
+
+    if component_ref is None:
+        component_ref = ComponentReference(
+            spec=component_spec, url=component_filename)
+    else:
+        component_ref.spec = component_spec
+
+    digest = getattr(component_spec, '_digest', None)
+    # TODO: Calculate the digest if missing
+    if digest:
+        # TODO: Report possible digest conflicts
+        component_ref.digest = digest
+
+    def create_task_object_from_component_and_pythonic_arguments(
+            pythonic_arguments):
+        arguments = {
+            pythonic_name_to_input_name[argument_name]: argument_value
+            for argument_name, argument_value in pythonic_arguments.items()
+            if not isinstance(
+                argument_value, _DefaultValue
+            )  # Skipping passing arguments for optional values that have not been overridden.
+        }
+        return _create_task_object_from_component_and_arguments(
+            component_spec=component_spec,
+            arguments=arguments,
+            component_ref=component_ref,
+        )
+
+    import inspect
+    from . import _dynamic
+
+    #Reordering the inputs since in Python optional parameters must come after required parameters
+    reordered_input_list = [
+        input for input in inputs_list
+        if input.default is None and not input.optional
+    ] + [
+        input for input in inputs_list
+        if not (input.default is None and not input.optional)
+    ]
+
+    def component_default_to_func_default(component_default: str,
+                                          is_optional: bool):
+        if is_optional:
+            return _DefaultValue(component_default)
+        if component_default is not None:
+            return component_default
+        return inspect.Parameter.empty
+
+    input_parameters = [
+        _dynamic.KwParameter(
+            input_name_to_pythonic[port.name],
+            annotation=(get_canonical_type_for_type_name(str(port.type)) or str(
+                port.type) if port.type else inspect.Parameter.empty),
+            default=component_default_to_func_default(port.default,
+                                                      port.optional),
+        )
+        for port in reordered_input_list
+    ]
+    factory_function_parameters = input_parameters  #Outputs are no longer part of the task factory function signature. The paths are always generated by the system.
+
+    task_factory = _dynamic.create_function_from_parameters(
+        create_task_object_from_component_and_pythonic_arguments,
+        factory_function_parameters,
+        documentation='\n'.join(func_docstring_lines),
+        func_name=name,
+        func_filename=component_filename if
+        (component_filename and
+         (component_filename.endswith('.yaml') or
+          component_filename.endswith('.yml'))) else None,
+    )
+    task_factory.component_spec = component_spec
+    return task_factory
+
+
+_ResolvedCommandLineAndPaths = NamedTuple(
+    '_ResolvedCommandLineAndPaths',
+    [
+        ('command', Sequence[str]),
+        ('args', Sequence[str]),
+        ('input_paths', Mapping[str, str]),
+        ('output_paths', Mapping[str, str]),
+        ('inputs_consumed_by_value', Mapping[str, str]),
+    ],
+)
+
+
+def _resolve_command_line_and_paths(
+    component_spec: ComponentSpec,
+    arguments: Mapping[str, str],
+    input_path_generator: Callable[[str], str] = _generate_input_file_name,
+    output_path_generator: Callable[[str], str] = _generate_output_file_name,
+    argument_serializer: Callable[[str], str] = serialize_value,
+    placeholder_resolver: Callable[[Any, ComponentSpec, Mapping[str, str]],
+                                   str] = None,
+) -> _ResolvedCommandLineAndPaths:
+    """Resolves the command line argument placeholders.
+
+    Also produces the maps of the generated inpuit/output paths.
+    """
+    argument_values = arguments
+
+    if not isinstance(component_spec.implementation, ContainerImplementation):
+        raise TypeError(
+            'Only container components have command line to resolve')
+
+    inputs_dict = {
+        input_spec.name: input_spec
+        for input_spec in component_spec.inputs or []
+    }
+    container_spec = component_spec.implementation.container
+
+    output_paths = OrderedDict(
+    )  #Preserving the order to make the kubernetes output names deterministic
+    unconfigurable_output_paths = container_spec.file_outputs or {}
+    for output in component_spec.outputs or []:
+        if output.name in unconfigurable_output_paths:
+            output_paths[output.name] = unconfigurable_output_paths[output.name]
+
+    input_paths = OrderedDict()
+    inputs_consumed_by_value = {}
+
+    def expand_command_part(arg) -> Union[str, List[str], None]:
+        if arg is None:
+            return None
+        if placeholder_resolver:
+            resolved_arg = placeholder_resolver(
+                arg=arg,
+                component_spec=component_spec,
+                arguments=arguments,
+            )
+            if resolved_arg is not None:
+                return resolved_arg
+        if isinstance(arg, (str, int, float, bool)):
+            return str(arg)
+        if isinstance(arg, InputValuePlaceholder):
+            input_name = arg.input_name
+            input_spec = inputs_dict[input_name]
+            input_value = argument_values.get(input_name, None)
+            if input_value is not None:
+                serialized_argument = argument_serializer(
+                    input_value, input_spec.type)
+                inputs_consumed_by_value[input_name] = serialized_argument
+                return serialized_argument
+            else:
+                if input_spec.optional:
+                    return None
+                else:
+                    raise ValueError(
+                        'No value provided for input {}'.format(input_name))
+
+        if isinstance(arg, InputPathPlaceholder):
+            input_name = arg.input_name
+            input_value = argument_values.get(input_name, None)
+            if input_value is not None:
+                input_path = input_path_generator(input_name)
+                input_paths[input_name] = input_path
+                return input_path
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    #Even when we support default values there is no need to check for a default here.
+                    #In current execution flow (called by python task factory), the missing argument would be replaced with the default value by python itself.
+                    return None
+                else:
+                    raise ValueError(
+                        'No value provided for input {}'.format(input_name))
+
+        elif isinstance(arg, OutputPathPlaceholder):
+            output_name = arg.output_name
+            output_filename = output_path_generator(output_name)
+            if arg.output_name in output_paths:
+                if output_paths[output_name] != output_filename:
+                    raise ValueError(
+                        'Conflicting output files specified for port {}: {} and {}'
+                        .format(output_name, output_paths[output_name],
+                                output_filename))
+            else:
+                output_paths[output_name] = output_filename
+
+            return output_filename
+        elif isinstance(arg, ConcatPlaceholder):
+            expanded_argument_strings = expand_argument_list(arg.items)
+            return ''.join(expanded_argument_strings)
+
+        elif isinstance(arg, IfPlaceholder):
+            arg = arg.if_structure
+            condition_result = expand_command_part(arg.condition)
+            from distutils.util import strtobool
+            condition_result_bool = condition_result and strtobool(
+                condition_result
+            )  #Python gotcha: bool('False') == True; Need to use strtobool; Also need to handle None and []
+            result_node = arg.then_value if condition_result_bool else arg.else_value
+            if result_node is None:
+                return []
+            if isinstance(result_node, list):
+                expanded_result = expand_argument_list(result_node)
+            else:
+                expanded_result = expand_command_part(result_node)
+            return expanded_result
+
+        elif isinstance(arg, IsPresentPlaceholder):
+            argument_is_present = argument_values.get(arg.input_name,
+                                                      None) is not None
+            return str(argument_is_present)
+        else:
+            raise TypeError('Unrecognized argument type: {}'.format(arg))
+
+    def expand_argument_list(argument_list):
+        expanded_list = []
+        if argument_list is not None:
+            for part in argument_list:
+                expanded_part = expand_command_part(part)
+                if expanded_part is not None:
+                    if isinstance(expanded_part, list):
+                        expanded_list.extend(expanded_part)
+                    else:
+                        expanded_list.append(str(expanded_part))
+        return expanded_list
+
+    expanded_command = expand_argument_list(container_spec.command)
+    expanded_args = expand_argument_list(container_spec.args)
+
+    return _ResolvedCommandLineAndPaths(
+        command=expanded_command,
+        args=expanded_args,
+        input_paths=input_paths,
+        output_paths=output_paths,
+        inputs_consumed_by_value=inputs_consumed_by_value,
+    )
+
+
+_ResolvedGraphTask = NamedTuple(
+    '_ResolvedGraphTask',
+    [
+        ('component_spec', ComponentSpec),
+        ('component_ref', ComponentReference),
+        ('outputs', Mapping[str, Any]),
+        ('task_arguments', Mapping[str, Any]),
+    ],
+)
+
+
+def _resolve_graph_task(
+    component_spec: ComponentSpec,
+    arguments: Mapping[str, Any],
+    component_ref: ComponentReference = None,
+) -> TaskSpec:
+    from ..components import ComponentStore
+    component_store = ComponentStore.default_store
+
+    graph = component_spec.implementation.graph
+
+    graph_input_arguments = {
+        input.name: input.default
+        for input in component_spec.inputs or []
+        if input.default is not None
+    }
+    graph_input_arguments.update(arguments)
+
+    outputs_of_tasks = {}
+
+    def resolve_argument(argument):
+        if isinstance(argument, (str, int, float, bool)):
+            return argument
+        elif isinstance(argument, GraphInputArgument):
+            return graph_input_arguments[argument.graph_input.input_name]
+        elif isinstance(argument, TaskOutputArgument):
+            upstream_task_output_ref = argument.task_output
+            upstream_task_outputs = outputs_of_tasks[
+                upstream_task_output_ref.task_id]
+            upstream_task_output = upstream_task_outputs[
+                upstream_task_output_ref.output_name]
+            return upstream_task_output
+        else:
+            raise TypeError(
+                'Argument for input has unexpected type "{}".'.format(
+                    type(argument)))
+
+    for task_id, task_spec in graph._toposorted_tasks.items(
+    ):  # Cannot use graph.tasks here since they might be listed not in dependency order. Especially on python <3.6 where the dicts do not preserve ordering
+        resolved_task_component_ref = component_store._load_component_spec_in_component_ref(
+            task_spec.component_ref)
+        # TODO: Handle the case when optional graph component input is passed to optional task component input
+        task_arguments = {
+            input_name: resolve_argument(argument)
+            for input_name, argument in task_spec.arguments.items()
+        }
+        task_component_spec = resolved_task_component_ref.spec
+
+        task_obj = _create_task_object_from_component_and_arguments(
+            component_spec=task_component_spec,
+            arguments=task_arguments,
+            component_ref=task_spec.component_ref,
+        )
+        task_outputs_with_original_names = {
+            output.name: task_obj.outputs[output.name]
+            for output in task_component_spec.outputs or []
+        }
+        outputs_of_tasks[task_id] = task_outputs_with_original_names
+
+    resolved_graph_outputs = OrderedDict([
+        (output_name, resolve_argument(argument))
+        for output_name, argument in graph.output_values.items()
+    ])
+
+    # For resolved graph component tasks task.outputs point to the actual tasks that originally produced the output that is later returned from the graph
+    graph_task = _ResolvedGraphTask(
+        component_ref=component_ref,
+        component_spec=component_spec,
+        outputs=resolved_graph_outputs,
+        task_arguments=arguments,
+    )
+    return graph_task

--- a/kfp/components/_data_passing.py
+++ b/kfp/components/_data_passing.py
@@ -1,0 +1,252 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'get_canonical_type_name_for_type',
+    'get_canonical_type_for_type_name',
+    'get_deserializer_code_for_type_name',
+    'get_serializer_func_for_type_name',
+]
+
+import inspect
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Type
+import warnings
+
+from kfp.components import type_annotation_utils
+
+Converter = NamedTuple('Converter', [
+    ('types', Sequence[Type]),
+    ('type_names', Sequence[str]),
+    ('serializer', Callable[[Any], str]),
+    ('deserializer_code', str),
+    ('definitions', str),
+])
+
+
+def _serialize_str(str_value: str) -> str:
+    if not isinstance(str_value, str):
+        raise TypeError('Value "{}" has type "{}" instead of str.'.format(
+            str(str_value), str(type(str_value))))
+    return str_value
+
+
+def _serialize_int(int_value: int) -> str:
+    if isinstance(int_value, str):
+        return int_value
+    if not isinstance(int_value, int):
+        raise TypeError('Value "{}" has type "{}" instead of int.'.format(
+            str(int_value), str(type(int_value))))
+    return str(int_value)
+
+
+def _serialize_float(float_value: float) -> str:
+    if isinstance(float_value, str):
+        return float_value
+    if not isinstance(float_value, (float, int)):
+        raise TypeError('Value "{}" has type "{}" instead of float.'.format(
+            str(float_value), str(type(float_value))))
+    return str(float_value)
+
+
+def _serialize_bool(bool_value: bool) -> str:
+    if isinstance(bool_value, str):
+        return bool_value
+    if not isinstance(bool_value, bool):
+        raise TypeError('Value "{}" has type "{}" instead of bool.'.format(
+            str(bool_value), str(type(bool_value))))
+    return str(bool_value)
+
+
+def _deserialize_bool(s) -> bool:
+    from distutils.util import strtobool
+    return strtobool(s) == 1
+
+
+_bool_deserializer_definitions = inspect.getsource(_deserialize_bool)
+_bool_deserializer_code = _deserialize_bool.__name__
+
+
+def _serialize_json(obj) -> str:
+    if isinstance(obj, str):
+        return obj
+    import json
+
+    def default_serializer(obj):
+        if hasattr(obj, 'to_struct'):
+            return obj.to_struct()
+        else:
+            raise TypeError(
+                "Object of type '%s' is not JSON serializable and does not have .to_struct() method."
+                % obj.__class__.__name__)
+
+    return json.dumps(obj, default=default_serializer, sort_keys=True)
+
+
+def _serialize_base64_pickle(obj) -> str:
+    if isinstance(obj, str):
+        return obj
+    import base64
+    import pickle
+    return base64.b64encode(pickle.dumps(obj)).decode('ascii')
+
+
+def _deserialize_base64_pickle(s):
+    import base64
+    import pickle
+    return pickle.loads(base64.b64decode(s))
+
+
+_deserialize_base64_pickle_definitions = inspect.getsource(
+    _deserialize_base64_pickle)
+_deserialize_base64_pickle_code = _deserialize_base64_pickle.__name__
+
+_converters = [
+    Converter([str], ['String', 'str'], _serialize_str, 'str', None),
+    Converter([int], ['Integer', 'int'], _serialize_int, 'int', None),
+    Converter([float], ['Float', 'float'], _serialize_float, 'float', None),
+    Converter([bool], ['Boolean', 'Bool', 'bool'], _serialize_bool,
+              _bool_deserializer_code, _bool_deserializer_definitions),
+    Converter(
+        [list], ['JsonArray', 'List', 'list'], _serialize_json, 'json.loads',
+        'import json'
+    ),  # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+    Converter(
+        [dict], ['JsonObject', 'Dictionary', 'Dict', 'dict'], _serialize_json,
+        'json.loads', 'import json'
+    ),  # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+    Converter([], ['Json'], _serialize_json, 'json.loads', 'import json'),
+    Converter([], ['Base64Pickle'], _serialize_base64_pickle,
+              _deserialize_base64_pickle_code,
+              _deserialize_base64_pickle_definitions),
+]
+
+type_to_type_name = {
+    typ: converter.type_names[0] for converter in _converters
+    for typ in converter.types
+}
+type_name_to_type = {
+    type_name: converter.types[0] for converter in _converters
+    for type_name in converter.type_names
+    if converter.types
+}
+type_to_deserializer = {
+    typ: (converter.deserializer_code, converter.definitions)
+    for converter in _converters for typ in converter.types
+}
+type_name_to_deserializer = {
+    type_name: (converter.deserializer_code, converter.definitions)
+    for converter in _converters for type_name in converter.type_names
+}
+type_name_to_serializer = {
+    type_name: converter.serializer for converter in _converters
+    for type_name in converter.type_names
+}
+
+
+def get_canonical_type_name_for_type(typ: Type) -> str:
+    """Find the canonical type name for a given type.
+
+    Args:
+        typ: The type to search for.
+
+    Returns:
+        The canonical name of the type found.
+    """
+    try:
+        return type_to_type_name.get(typ, None)
+    except:
+        return None
+
+
+def get_canonical_type_for_type_name(type_name: str) -> Optional[Type]:
+    """Find the canonical type for a given type name.
+
+    Args:
+        type_name: The type name to search for.
+
+    Returns:
+        The canonical type found.
+    """
+    try:
+        return type_name_to_type.get(type_name, None)
+    except:
+        return None
+
+
+def get_deserializer_code_for_type_name(type_name: str) -> Optional[str]:
+    """Find the deserializer code for the given type name.
+
+    Args:
+        type_name: The type name to search for.
+
+    Returns:
+        The deserializer code needed to deserialize the type.
+    """
+    try:
+        return type_name_to_deserializer.get(
+            type_annotation_utils.get_short_type_name(type_name), None)
+    except:
+        return None
+
+
+def get_serializer_func_for_type_name(type_name: str) -> Optional[Callable]:
+    """Find the serializer code for the given type name.
+
+    Args:
+        type_name: The type name to search for.
+
+    Returns:
+        The serializer func needed to serialize the type.
+    """
+    try:
+        return type_name_to_serializer.get(
+            type_annotation_utils.get_short_type_name(type_name), None)
+    except:
+        return None
+
+
+def serialize_value(value, type_name: str) -> str:
+    """serialize_value converts the passed value to string based on the
+    serializer associated with the passed type_name."""
+    if isinstance(value, str):
+        return value  # The value is supposedly already serialized
+
+    if type_name is None:
+        type_name = type_to_type_name.get(type(value), type(value).__name__)
+        warnings.warn(
+            'Missing type name was inferred as "{}" based on the value "{}".'
+            .format(type_name, str(value)))
+
+    serializer = type_name_to_serializer.get(
+        type_annotation_utils.get_short_type_name(type_name))
+    if serializer:
+        try:
+            serialized_value = serializer(value)
+            if not isinstance(serialized_value, str):
+                raise TypeError(
+                    'Serializer {} returned result of type "{}" instead of string.'
+                    .format(serializer, type(serialized_value)))
+            return serialized_value
+        except Exception as e:
+            raise ValueError(
+                'Failed to serialize the value "{}" of type "{}" to type "{}". Exception: {}'
+                .format(
+                    str(value),
+                    str(type(value).__name__),
+                    str(type_name),
+                    str(e),
+                ))
+
+    raise TypeError('There are no registered serializers for type "{}".'.format(
+        str(type_name),))

--- a/kfp/components/_dynamic.py
+++ b/kfp/components/_dynamic.py
@@ -1,0 +1,96 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+from typing import Any, Callable, Mapping, Sequence
+from inspect import Parameter, Signature
+
+
+class KwParameter(Parameter):
+
+    def __init__(self,
+                 name,
+                 default=Parameter.empty,
+                 annotation=Parameter.empty):
+        super().__init__(
+            name,
+            Parameter.POSITIONAL_OR_KEYWORD,
+            default=default,
+            annotation=annotation)
+
+
+def create_function_from_parameter_names(func: Callable[[Mapping[str, Any]],
+                                                        Any],
+                                         parameter_names: Sequence[str],
+                                         documentation=None,
+                                         func_name=None,
+                                         func_filename=None):
+    return create_function_from_parameters(
+        func, [KwParameter(name) for name in parameter_names], documentation,
+        func_name, func_filename)
+
+
+def create_function_from_parameters(func: Callable[[Mapping[str, Any]], Any],
+                                    parameters: Sequence[Parameter],
+                                    documentation=None,
+                                    func_name=None,
+                                    func_filename=None):
+    new_signature = Signature(parameters)  # Checks the parameter consistency
+
+    def pass_locals():
+        return dict_func(locals())  # noqa: F821 TODO
+
+    code = pass_locals.__code__
+    mod_co_argcount = len(parameters)
+    mod_co_nlocals = len(parameters)
+    mod_co_varnames = tuple(param.name for param in parameters)
+    mod_co_name = func_name or code.co_name
+    if func_filename:
+        mod_co_filename = func_filename
+        mod_co_firstlineno = 1
+    else:
+        mod_co_filename = code.co_filename
+        mod_co_firstlineno = code.co_firstlineno
+
+    if sys.version_info >= (3, 8):
+        modified_code = code.replace(
+            co_argcount=mod_co_argcount,
+            co_nlocals=mod_co_nlocals,
+            co_varnames=mod_co_varnames,
+            co_filename=mod_co_filename,
+            co_name=mod_co_name,
+            co_firstlineno=mod_co_firstlineno,
+        )
+    else:
+        modified_code = types.CodeType(
+            mod_co_argcount, code.co_kwonlyargcount, mod_co_nlocals,
+            code.co_stacksize, code.co_flags, code.co_code, code.co_consts,
+            code.co_names, mod_co_varnames, mod_co_filename, mod_co_name,
+            mod_co_firstlineno, code.co_lnotab)
+
+    default_arg_values = tuple(
+        p.default for p in parameters if p.default != Parameter.empty
+    )  #!argdefs "starts from the right"/"is right-aligned"
+    modified_func = types.FunctionType(
+        modified_code, {
+            'dict_func': func,
+            'locals': locals
+        },
+        name=func_name,
+        argdefs=default_arg_values)
+    modified_func.__doc__ = documentation
+    modified_func.__signature__ = new_signature
+
+    return modified_func

--- a/kfp/components/_key_value_store.py
+++ b/kfp/components/_key_value_store.py
@@ -1,0 +1,68 @@
+import hashlib
+from pathlib import Path
+
+
+class KeyValueStore:
+    KEY_FILE_SUFFIX = '.key'
+    VALUE_FILE_SUFFIX = '.value'
+
+    def __init__(
+        self,
+        cache_dir: str,
+    ):
+        cache_dir = Path(cache_dir)
+        hash_func = (
+            lambda text: hashlib.sha256(text.encode('utf-8')).hexdigest())
+        self.cache_dir = cache_dir
+        self.hash_func = hash_func
+
+    def store_value_text(self, key: str, text: str) -> str:
+        return self.store_value_bytes(key, text.encode('utf-8'))
+
+    def store_value_bytes(self, key: str, data: bytes) -> str:
+        cache_id = self.hash_func(key)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_key_file_path = self.cache_dir / (
+            cache_id + KeyValueStore.KEY_FILE_SUFFIX)
+        cache_value_file_path = self.cache_dir / (
+            cache_id + KeyValueStore.VALUE_FILE_SUFFIX)
+        if cache_key_file_path.exists():
+            old_key = cache_key_file_path.read_text()
+            if key != old_key:
+                raise RuntimeError(
+                    'Cache is corrupted: File "{}" contains existing key '
+                    '"{}" != new key "{}"'.format(cache_key_file_path, old_key,
+                                                  key))
+            if cache_value_file_path.exists():
+                old_data = cache_value_file_path.read_bytes()
+                if data != old_data:
+                    # TODO: Add options to raise error when overwriting the value.
+                    pass
+        cache_value_file_path.write_bytes(data)
+        cache_key_file_path.write_text(key)
+        return cache_id
+
+    def try_get_value_text(self, key: str) -> str:
+        result = self.try_get_value_bytes(key)
+        if result is None:
+            return None
+        return result.decode('utf-8')
+
+    def try_get_value_bytes(self, key: str) -> bytes:
+        cache_id = self.hash_func(key)
+        cache_value_file_path = self.cache_dir / (
+            cache_id + KeyValueStore.VALUE_FILE_SUFFIX)
+        if cache_value_file_path.exists():
+            return cache_value_file_path.read_bytes()
+        return None
+
+    def exists(self, key: str) -> bool:
+        cache_id = self.hash_func(key)
+        cache_key_file_path = self.cache_dir / (
+            cache_id + KeyValueStore.KEY_FILE_SUFFIX)
+        return cache_key_file_path.exists()
+
+    def keys(self):
+        for cache_key_file_path in self.cache_dir.glob(
+                '*' + KeyValueStore.KEY_FILE_SUFFIX):
+            yield Path(cache_key_file_path).read_text()

--- a/kfp/components/_naming.py
+++ b/kfp/components/_naming.py
@@ -1,0 +1,122 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    '_normalize_identifier_name',
+    '_sanitize_kubernetes_resource_name',
+    '_sanitize_python_function_name',
+    '_sanitize_file_name',
+    '_convert_to_human_name',
+    '_generate_unique_suffix',
+    '_make_name_unique_by_adding_index',
+    '_convert_name_and_make_it_unique_by_adding_number',
+    'generate_unique_name_conversion_table',
+]
+
+import re
+import sys
+from typing import Callable, Sequence, Mapping
+
+
+def _normalize_identifier_name(name):
+    import re
+    normalized_name = name.lower()
+    normalized_name = re.sub(r'[\W_]', ' ',
+                             normalized_name)  #No non-word characters
+    normalized_name = re.sub(
+        ' +', ' ',
+        normalized_name).strip()  #No double spaces, leading or trailing spaces
+    if re.match(r'\d', normalized_name):
+        normalized_name = 'n' + normalized_name  #No leading digits
+    return normalized_name
+
+
+def _sanitize_kubernetes_resource_name(name):
+    return _normalize_identifier_name(name).replace(' ', '-')
+
+
+def _sanitize_python_function_name(name):
+    return _normalize_identifier_name(name).replace(' ', '_')
+
+
+def _sanitize_file_name(name):
+    import re
+    return re.sub('[^-_.0-9a-zA-Z]+', '_', name)
+
+
+def _convert_to_human_name(name: str):
+    """Converts underscore or dash delimited name to space-delimited name that
+    starts with a capital letter.
+
+    Does not handle "camelCase" names.
+    """
+    return name.replace('_', ' ').replace('-', ' ').strip().capitalize()
+
+
+def _generate_unique_suffix(data):
+    import time
+    import hashlib
+    string_data = str((data, time.time()))
+    return hashlib.sha256(string_data.encode()).hexdigest()[0:8]
+
+
+def _make_name_unique_by_adding_index(name: str, collection, delimiter: str):
+    unique_name = name
+    if unique_name in collection:
+        for i in range(2, sys.maxsize**10):
+            unique_name = name + delimiter + str(i)
+            if unique_name not in collection:
+                break
+    return unique_name
+
+
+def _convert_name_and_make_it_unique_by_adding_number(
+        name: str, used_converted_names, conversion_func: Callable[[str], str]):
+    converted_name = conversion_func(name)
+    if converted_name in used_converted_names:
+        for i in range(
+                2, sys.maxsize**
+                10):  #Starting indices from 2: "Something", "Something_2", ...
+            converted_name = conversion_func(name + ' ' + str(i))
+            if converted_name not in used_converted_names:
+                break
+    return converted_name
+
+
+def generate_unique_name_conversion_table(
+        names: Sequence[str],
+        conversion_func: Callable[[str], str]) -> Mapping[str, str]:
+    """Given a list of names and conversion_func, this function generates a map
+    from original names to converted names that are made unique by adding
+    numbers."""
+    forward_map = {}
+    reverse_map = {}
+
+    # Names that do not change when applying the conversion_func should remain unchanged in the table
+    names_that_need_conversion = []
+    for name in names:
+        if conversion_func(name) == name:
+            forward_map[name] = name
+            reverse_map[name] = name
+        else:
+            names_that_need_conversion.append(name)
+
+    for name in names_that_need_conversion:
+        if name in forward_map:
+            raise ValueError('Original name {} is not unique.'.format(name))
+        converted_name = _convert_name_and_make_it_unique_by_adding_number(
+            name, reverse_map, conversion_func)
+        forward_map[name] = converted_name
+        reverse_map[converted_name] = name
+    return forward_map

--- a/kfp/components/_python_op.py
+++ b/kfp/components/_python_op.py
@@ -1,0 +1,1072 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'create_component_from_func',
+    'func_to_container_op',
+    'func_to_component_text',
+    'default_base_image_or_builder',
+    'InputArtifact',
+    'InputPath',
+    'InputTextFile',
+    'InputBinaryFile',
+    'OutputArtifact',
+    'OutputPath',
+    'OutputTextFile',
+    'OutputBinaryFile',
+]
+
+from ._yaml_utils import dump_yaml
+from ._components import _create_task_factory_from_component_spec
+from ._data_passing import serialize_value, get_deserializer_code_for_type_name, get_serializer_func_for_type_name, get_canonical_type_name_for_type
+from ._naming import _make_name_unique_by_adding_index
+from .structures import *
+from . import _structures as structures
+from kfp.components import type_annotation_utils
+
+import inspect
+import itertools
+from pathlib import Path
+import textwrap
+from typing import Callable, Dict, List, Mapping, Optional, TypeVar
+import warnings
+
+import docstring_parser
+
+T = TypeVar('T')
+
+# InputPath(list) or InputPath('JsonObject')
+
+
+class InputPath:
+    """When creating component from function, :class:`.InputPath` should be
+    used as function parameter annotation to tell the system to pass the *data
+    file path* to the function instead of passing the actual data."""
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class InputTextFile:
+    """When creating component from function, :class:`.InputTextFile` should be
+    used as function parameter annotation to tell the system to pass the *text
+    data stream* object (`io.TextIOWrapper`) to the function instead of passing
+    the actual data."""
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class InputBinaryFile:
+    """When creating component from function, :class:`.InputBinaryFile` should
+    be used as function parameter annotation to tell the system to pass the.
+
+    *binary data stream* object (`io.BytesIO`) to the function instead of
+    passing the actual data.
+    """
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class InputArtifact:
+    """InputArtifact function parameter annotation.
+
+    When creating a component from a Python function, indicates to the
+    system that function parameter with this annotation should be passed
+    as a RuntimeArtifact.
+    """
+
+    def __init__(self, type: Optional[str] = None):
+        self.type = type
+
+
+class OutputPath:
+    """When creating component from function, :class:`.OutputPath` should be
+    used as function parameter annotation to tell the system that the function
+    wants to output data by writing it into a file with the given path instead
+    of returning the data from the function."""
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class OutputTextFile:
+    """When creating component from function, :class:`.OutputTextFile` should
+    be used as function parameter annotation to tell the system that the
+    function wants to output data by writing it into a given text file stream
+    (`io.TextIOWrapper`) instead of returning the data from the function."""
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class OutputBinaryFile:
+    """When creating component from function, :class:`.OutputBinaryFile` should
+    be used as function parameter annotation to tell the system that the
+    function wants to output data by writing it into a given binary file stream
+    (:code:`io.BytesIO`) instead of returning the data from the function."""
+
+    def __init__(self, type=None):
+        self.type = type
+
+
+class OutputArtifact:
+    """OutputArtifact function parameter annotation.
+
+    When creating component from function. OutputArtifact indicates that
+    the associated input parameter should be treated as an MLMD
+    artifact, whose underlying content, together with metadata will be
+    updated by this component
+    """
+
+    def __init__(self, type: Optional[str] = None):
+        self.type = type
+
+
+def _make_parent_dirs_and_return_path(file_path: str):
+    import os
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    return file_path
+
+
+def _parent_dirs_maker_that_returns_open_file(mode: str, encoding: str = None):
+
+    def make_parent_dirs_and_return_path(file_path: str):
+        import os
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        return open(file_path, mode=mode, encoding=encoding)
+
+    return make_parent_dirs_and_return_path
+
+
+default_base_image_or_builder = 'python:3.7'
+
+
+def _python_function_name_to_component_name(name):
+    import re
+    name_with_spaces = re.sub(' +', ' ', name.replace('_', ' ')).strip(' ')
+    return name_with_spaces[0].upper() + name_with_spaces[1:]
+
+
+def _capture_function_code_using_cloudpickle(
+        func, modules_to_capture: List[str] = None) -> str:
+    import base64
+    import sys
+    import cloudpickle
+    import pickle
+
+    if modules_to_capture is None:
+        modules_to_capture = [func.__module__]
+
+    # Hack to force cloudpickle to capture the whole function instead of just referencing the code file. See https://github.com/cloudpipe/cloudpickle/blob/74d69d759185edaeeac7bdcb7015cfc0c652f204/cloudpickle/cloudpickle.py#L490
+    old_modules = {}
+    old_sig = getattr(func, '__signature__', None)
+    try:  # Try is needed to restore the state if something goes wrong
+        for module_name in modules_to_capture:
+            if module_name in sys.modules:
+                old_modules[module_name] = sys.modules.pop(module_name)
+        # Hack to prevent cloudpickle from trying to pickle generic types that might be present in the signature. See https://github.com/cloudpipe/cloudpickle/issues/196
+        # Currently the __signature__ is only set by Airflow components as a means to spoof/pass the function signature to _func_to_component_spec
+        if hasattr(func, '__signature__'):
+            del func.__signature__
+        func_pickle = base64.b64encode(
+            cloudpickle.dumps(func, pickle.DEFAULT_PROTOCOL))
+    finally:
+        sys.modules.update(old_modules)
+        if old_sig:
+            func.__signature__ = old_sig
+
+    function_loading_code = '''\
+import sys
+try:
+    import cloudpickle as _cloudpickle
+except ImportError:
+    import subprocess
+    try:
+        print("cloudpickle is not installed. Installing it globally", file=sys.stderr)
+        subprocess.run([sys.executable, "-m", "pip", "install", "cloudpickle==1.1.1", "--quiet"], env={"PIP_DISABLE_PIP_VERSION_CHECK": "1"}, check=True)
+        print("Installed cloudpickle globally", file=sys.stderr)
+    except:
+        print("Failed to install cloudpickle globally. Installing for the current user.", file=sys.stderr)
+        subprocess.run([sys.executable, "-m", "pip", "install", "cloudpickle==1.1.1", "--user", "--quiet"], env={"PIP_DISABLE_PIP_VERSION_CHECK": "1"}, check=True)
+        print("Installed cloudpickle for the current user", file=sys.stderr)
+        # Enable loading from user-installed package directory. Python does not add it to sys.path if it was empty at start. Running pip does not refresh `sys.path`.
+        import site
+        sys.path.append(site.getusersitepackages())
+    import cloudpickle as _cloudpickle
+    print("cloudpickle loaded successfully after installing.", file=sys.stderr)
+''' + '''
+pickler_python_version = {pickler_python_version}
+current_python_version = tuple(sys.version_info)
+if (
+    current_python_version[0] != pickler_python_version[0] or
+    current_python_version[1] < pickler_python_version[1] or
+    current_python_version[0] == 3 and ((pickler_python_version[1] < 6) != (current_python_version[1] < 6))
+    ):
+    raise RuntimeError("Incompatible python versions: " + str(current_python_version) + " instead of " + str(pickler_python_version))
+
+if current_python_version != pickler_python_version:
+    print("Warning!: Different python versions. The code may crash! Current environment python version: " + str(current_python_version) + ". Component code python version: " + str(pickler_python_version), file=sys.stderr)
+
+import base64
+import pickle
+
+{func_name} = pickle.loads(base64.b64decode({func_pickle}))
+'''.format(
+        func_name=func.__name__,
+        func_pickle=repr(func_pickle),
+        pickler_python_version=repr(tuple(sys.version_info)),
+    )
+
+    return function_loading_code
+
+
+def strip_type_hints(source_code: str) -> str:
+    try:
+        return _strip_type_hints_using_lib2to3(source_code)
+    except Exception as ex:
+        print('Error when stripping type annotations: ' + str(ex))
+
+    try:
+        return _strip_type_hints_using_strip_hints(source_code)
+    except Exception as ex:
+        print('Error when stripping type annotations: ' + str(ex))
+
+    return source_code
+
+
+def _strip_type_hints_using_strip_hints(source_code: str) -> str:
+    from strip_hints import strip_string_to_string
+
+    # Workaround for https://github.com/abarker/strip-hints/issues/4 , https://bugs.python.org/issue35107
+    # I could not repro it though
+    if source_code[-1] != '\n':
+        source_code += '\n'
+
+    return strip_string_to_string(source_code, to_empty=True)
+
+
+def _strip_type_hints_using_lib2to3(source_code: str) -> str:
+    """Strips type annotations from the function definitions in the provided
+    source code."""
+
+    # Using the standard lib2to3 library to strip type annotations.
+    # Switch to another library like strip-hints if issues are found.
+    from lib2to3 import fixer_base, refactor, fixer_util
+
+    class StripAnnotations(fixer_base.BaseFix):
+        PATTERN = r'''
+            typed_func_parameter=tname
+            |
+            typed_func_return_value=funcdef< any+ '->' any+ >
+        '''
+
+        def transform(self, node, results):
+            if 'typed_func_parameter' in results:
+                # Delete the annotation part of the function parameter declaration
+                del node.children[1:]
+            elif 'typed_func_return_value' in results:
+                # Delete the return annotation part of the function declaration
+                del node.children[-4:-2]
+            return node
+
+    class Refactor(refactor.RefactoringTool):
+
+        def __init__(self, fixers):
+            self._fixers = [cls(None, None) for cls in fixers]
+            super().__init__(None, {'print_function': True})
+
+        def get_fixers(self):
+            return self._fixers, []
+
+    stripped_code = str(
+        Refactor([StripAnnotations]).refactor_string(source_code, ''))
+    return stripped_code
+
+
+def _get_function_source_definition(func: Callable) -> str:
+    func_code = inspect.getsource(func)
+
+    # Function might be defined in some indented scope (e.g. in another
+    # function). We need to handle this and properly dedent the function source
+    # code
+    func_code = textwrap.dedent(func_code)
+    func_code_lines = func_code.split('\n')
+
+    # Removing possible decorators (can be multiline) until the function
+    # definition is found
+    func_code_lines = itertools.dropwhile(lambda x: not x.startswith('def'),
+                                          func_code_lines)
+
+    if not func_code_lines:
+        raise ValueError(
+            'Failed to dedent and clean up the source of function "{}". '
+            'It is probably not properly indented.'.format(func.__name__))
+
+    return '\n'.join(func_code_lines)
+
+
+def _capture_function_code_using_source_copy(func: Callable) -> str:
+    func_code = _get_function_source_definition(func)
+
+    # Stripping type annotations to prevent import errors.
+    # The most common cases are InputPath/OutputPath and typing.NamedTuple annotations
+    return strip_type_hints(func_code)
+
+
+def _extract_component_interface(func: Callable) -> ComponentSpec:
+    single_output_name_const = 'Output'
+
+    signature = inspect.signature(func)
+    parameters = list(signature.parameters.values())
+
+    parsed_docstring = docstring_parser.parse(inspect.getdoc(func))
+    doc_dict = {p.arg_name: p.description for p in parsed_docstring.params}
+
+    inputs = []
+    outputs = []
+
+    def annotation_to_type_struct(annotation):
+        if not annotation or annotation == inspect.Parameter.empty:
+            return None
+        if hasattr(annotation, 'to_dict'):
+            annotation = annotation.to_dict()
+        if isinstance(annotation, dict):
+            return annotation
+        if isinstance(annotation, type):
+            type_struct = get_canonical_type_name_for_type(annotation)
+            if type_struct:
+                return type_struct
+            type_name = str(annotation.__name__)
+        elif hasattr(
+                annotation, '__forward_arg__'
+        ):  # Handling typing.ForwardRef('Type_name') (the name was _ForwardRef in python 3.5-3.6)
+            type_name = str(annotation.__forward_arg__)
+        else:
+            type_name = str(annotation)
+
+        # It's also possible to get the converter by type name
+        type_struct = get_canonical_type_name_for_type(type_name)
+        if type_struct:
+            return type_struct
+        return type_name
+
+    input_names = set()
+    output_names = set()
+    for parameter in parameters:
+        parameter_type = type_annotation_utils.maybe_strip_optional_from_annotation(
+            parameter.annotation)
+        passing_style = None
+        io_name = parameter.name
+
+        if isinstance(
+                parameter_type,
+            (InputArtifact, InputPath, InputTextFile, InputBinaryFile,
+             OutputArtifact, OutputPath, OutputTextFile, OutputBinaryFile)):
+
+            # Removing the "_path" and "_file" suffixes from the input/output names as the argument passed to the component needs to be the data itself, not local file path.
+            # Problem: When accepting file inputs (outputs), the function inside the component receives file paths (or file streams), so it's natural to call the function parameter "something_file_path" (e.g. model_file_path or number_file_path).
+            # But from the outside perspective, there are no files or paths - the actual data objects (or references to them) are passed in.
+            # It looks very strange when argument passing code looks like this: `component(number_file_path=42)`. This looks like an error since 42 is not a path. It's not even a string.
+            # It's much more natural to strip the names of file inputs and outputs of "_file" or "_path" suffixes. Then the argument passing code will look natural: "component(number=42)".
+            if isinstance(
+                    parameter_type,
+                (InputPath, OutputPath)) and io_name.endswith('_path'):
+                io_name = io_name[0:-len('_path')]
+            if io_name.endswith('_file'):
+                io_name = io_name[0:-len('_file')]
+
+            passing_style = type(parameter_type)
+            parameter_type = parameter_type.type
+            if parameter.default is not inspect.Parameter.empty and not (
+                    passing_style == InputPath and parameter.default is None):
+                raise ValueError(
+                    'Path inputs only support default values of None. Default values for outputs are not supported.'
+                )
+
+        type_struct = annotation_to_type_struct(parameter_type)
+
+        if passing_style in [
+                OutputArtifact, OutputPath, OutputTextFile, OutputBinaryFile
+        ]:
+            io_name = _make_name_unique_by_adding_index(io_name, output_names,
+                                                        '_')
+            output_names.add(io_name)
+            output_spec = OutputSpec(
+                name=io_name,
+                type=type_struct,
+                description=doc_dict.get(parameter.name))
+            output_spec._passing_style = passing_style
+            output_spec._parameter_name = parameter.name
+            outputs.append(output_spec)
+        else:
+            io_name = _make_name_unique_by_adding_index(io_name, input_names,
+                                                        '_')
+            input_names.add(io_name)
+            input_spec = InputSpec(
+                name=io_name,
+                type=type_struct,
+                description=doc_dict.get(parameter.name))
+            if parameter.default is not inspect.Parameter.empty:
+                input_spec.optional = True
+                if parameter.default is not None:
+                    outer_type_name = list(type_struct.keys())[0] if isinstance(
+                        type_struct, dict) else type_struct
+                    try:
+                        input_spec.default = serialize_value(
+                            parameter.default, outer_type_name)
+                    except Exception as ex:
+                        warnings.warn(
+                            'Could not serialize the default value of the parameter "{}". {}'
+                            .format(parameter.name, ex))
+            input_spec._passing_style = passing_style
+            input_spec._parameter_name = parameter.name
+            inputs.append(input_spec)
+
+    #Analyzing the return type annotations.
+    return_ann = signature.return_annotation
+    if hasattr(return_ann, '_fields'):  #NamedTuple
+        # Getting field type annotations.
+        # __annotations__ does not exist in python 3.5 and earlier
+        # _field_types does not exist in python 3.9 and later
+        field_annotations = getattr(return_ann,
+                                    '__annotations__', None) or getattr(
+                                        return_ann, '_field_types', None)
+        for field_name in return_ann._fields:
+            type_struct = None
+            if field_annotations:
+                type_struct = annotation_to_type_struct(
+                    field_annotations.get(field_name, None))
+
+            output_name = _make_name_unique_by_adding_index(
+                field_name, output_names, '_')
+            output_names.add(output_name)
+            output_spec = OutputSpec(
+                name=output_name,
+                type=type_struct,
+            )
+            output_spec._passing_style = None
+            output_spec._return_tuple_field_name = field_name
+            outputs.append(output_spec)
+    # Deprecated dict-based way of declaring multiple outputs. Was only used by the @component decorator
+    elif isinstance(return_ann, dict):
+        warnings.warn(
+            "The ability to specify multiple outputs using the dict syntax has been deprecated."
+            "It will be removed soon after release 0.1.32."
+            "Please use typing.NamedTuple to declare multiple outputs.")
+        for output_name, output_type_annotation in return_ann.items():
+            output_type_struct = annotation_to_type_struct(
+                output_type_annotation)
+            output_spec = OutputSpec(
+                name=output_name,
+                type=output_type_struct,
+            )
+            outputs.append(output_spec)
+    elif signature.return_annotation is not None and signature.return_annotation != inspect.Parameter.empty:
+        output_name = _make_name_unique_by_adding_index(
+            single_output_name_const, output_names, '_'
+        )  # Fixes exotic, but possible collision: `def func(output_path: OutputPath()) -> str: ...`
+        output_names.add(output_name)
+        type_struct = annotation_to_type_struct(signature.return_annotation)
+        output_spec = OutputSpec(
+            name=output_name,
+            type=type_struct,
+        )
+        output_spec._passing_style = None
+        outputs.append(output_spec)
+
+    # Component name and description are derived from the function's name and docstring.
+    # The name can be overridden by setting setting func.__name__ attribute (of the legacy func._component_human_name attribute).
+    # The description can be overridden by setting the func.__doc__ attribute (or the legacy func._component_description attribute).
+    component_name = getattr(func, '_component_human_name',
+                             None) or _python_function_name_to_component_name(
+                                 func.__name__)
+    description = getattr(func, '_component_description',
+                          None) or parsed_docstring.short_description
+    if description:
+        description = description.strip()
+
+    component_spec = ComponentSpec(
+        name=component_name,
+        description=description,
+        inputs=inputs if inputs else None,
+        outputs=outputs if outputs else None,
+    )
+    return component_spec
+
+
+def _func_to_component_spec(func,
+                            extra_code='',
+                            base_image: str = None,
+                            packages_to_install: List[str] = None,
+                            modules_to_capture: List[str] = None,
+                            use_code_pickling=False) -> ComponentSpec:
+    """Takes a self-contained python function and converts it to component.
+
+    Args:
+        func: Required. The function to be converted
+        base_image: Optional. Docker image to be used as a base image for the python component. Must have python 3.5+ installed. Default is python:3.7
+                    Note: The image can also be specified by decorating the function with the @python_component decorator. If different base images are explicitly specified in both places, an error is raised.
+        extra_code: Optional. Python source code that gets placed before the function code. Can be used as workaround to define types used in function signature.
+        packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        modules_to_capture: Optional. List of module names that will be captured (instead of just referencing) during the dependency scan. By default the :code:`func.__module__` is captured.
+        use_code_pickling: Specifies whether the function code should be captured using pickling as opposed to source code manipulation. Pickling has better support for capturing dependencies, but is sensitive to version mismatch between python in component creation environment and runtime image.
+
+    Returns:
+        A :py:class:`kfp.components.structures.ComponentSpec` instance.
+    """
+    decorator_base_image = getattr(func, '_component_base_image', None)
+    if decorator_base_image is not None:
+        if base_image is not None and decorator_base_image != base_image:
+            raise ValueError(
+                'base_image ({}) conflicts with the decorator-specified base image metadata ({})'
+                .format(base_image, decorator_base_image))
+        else:
+            base_image = decorator_base_image
+    else:
+        if base_image is None:
+            base_image = default_base_image_or_builder
+            if isinstance(base_image, Callable):
+                base_image = base_image()
+
+    packages_to_install = packages_to_install or []
+
+    component_spec = _extract_component_interface(func)
+
+    component_inputs = component_spec.inputs or []
+    component_outputs = component_spec.outputs or []
+
+    arguments = []
+    arguments.extend(
+        InputValuePlaceholder(input.name) for input in component_inputs)
+    arguments.extend(
+        OutputPathPlaceholder(output.name) for output in component_outputs)
+
+    if use_code_pickling:
+        func_code = _capture_function_code_using_cloudpickle(
+            func, modules_to_capture)
+        # pip startup is quite slow. TODO: Remove the special cloudpickle installation code in favor of the the following line once a way to speed up pip startup is discovered.
+        #packages_to_install.append('cloudpickle==1.1.1')
+    else:
+        func_code = _capture_function_code_using_source_copy(func)
+
+    definitions = set()
+
+    def get_deserializer_and_register_definitions(type_name):
+        deserializer_code = get_deserializer_code_for_type_name(type_name)
+        if deserializer_code:
+            (deserializer_code_str, definition_str) = deserializer_code
+            if definition_str:
+                definitions.add(definition_str)
+            return deserializer_code_str
+        return 'str'
+
+    pre_func_definitions = set()
+
+    def get_argparse_type_for_input_file(passing_style):
+        # Bypass InputArtifact and OutputArtifact.
+        if passing_style in (None, InputArtifact, OutputArtifact):
+            return None
+
+        if passing_style is InputPath:
+            return 'str'
+        elif passing_style is InputTextFile:
+            return "argparse.FileType('rt')"
+        elif passing_style is InputBinaryFile:
+            return "argparse.FileType('rb')"
+        # For Output* we cannot use the build-in argparse.FileType objects since they do not create parent directories.
+        elif passing_style is OutputPath:
+            # ~= return 'str'
+            pre_func_definitions.add(
+                inspect.getsource(_make_parent_dirs_and_return_path))
+            return _make_parent_dirs_and_return_path.__name__
+        elif passing_style is OutputTextFile:
+            # ~= return "argparse.FileType('wt')"
+            pre_func_definitions.add(
+                inspect.getsource(_parent_dirs_maker_that_returns_open_file))
+            return _parent_dirs_maker_that_returns_open_file.__name__ + "('wt')"
+        elif passing_style is OutputBinaryFile:
+            # ~= return "argparse.FileType('wb')"
+            pre_func_definitions.add(
+                inspect.getsource(_parent_dirs_maker_that_returns_open_file))
+            return _parent_dirs_maker_that_returns_open_file.__name__ + "('wb')"
+        raise NotImplementedError('Unexpected data passing style: "{}".'.format(
+            str(passing_style)))
+
+    def get_serializer_and_register_definitions(type_name) -> str:
+        serializer_func = get_serializer_func_for_type_name(type_name)
+        if serializer_func:
+            # If serializer is not part of the standard python library, then include its code in the generated program
+            if hasattr(serializer_func,
+                       '__module__') and not _module_is_builtin_or_standard(
+                           serializer_func.__module__):
+                import inspect
+                serializer_code_str = inspect.getsource(serializer_func)
+                definitions.add(serializer_code_str)
+            return serializer_func.__name__
+        return 'str'
+
+    arg_parse_code_lines = [
+        'import argparse',
+        '_parser = argparse.ArgumentParser(prog={prog_repr}, description={description_repr})'
+        .format(
+            prog_repr=repr(component_spec.name or ''),
+            description_repr=repr(component_spec.description or ''),
+        ),
+    ]
+    outputs_passed_through_func_return_tuple = [
+        output for output in component_outputs if output._passing_style is None
+    ]
+    file_outputs_passed_using_func_parameters = [
+        output for output in component_outputs
+        if output._passing_style is not None
+    ]
+    arguments = []
+    for input in component_inputs + file_outputs_passed_using_func_parameters:
+        param_flag = "--" + input.name.replace("_", "-")
+        is_required = isinstance(input, OutputSpec) or not input.optional
+        line = '_parser.add_argument("{param_flag}", dest="{param_var}", type={param_type}, required={is_required}, default=argparse.SUPPRESS)'.format(
+            param_flag=param_flag,
+            param_var=input.
+            _parameter_name,  # Not input.name, since the inputs could have been renamed
+            param_type=get_argparse_type_for_input_file(input._passing_style) or
+            get_deserializer_and_register_definitions(input.type),
+            is_required=str(is_required),
+        )
+        arg_parse_code_lines.append(line)
+
+        if input._passing_style in [
+                InputPath, InputTextFile, InputBinaryFile, InputArtifact
+        ]:
+            arguments_for_input = [param_flag, InputPathPlaceholder(input.name)]
+        elif input._passing_style in [
+                OutputPath, OutputTextFile, OutputBinaryFile, OutputArtifact
+        ]:
+            arguments_for_input = [
+                param_flag, OutputPathPlaceholder(input.name)
+            ]
+        else:
+            arguments_for_input = [
+                param_flag, InputValuePlaceholder(input.name)
+            ]
+
+        if is_required:
+            arguments.extend(arguments_for_input)
+        else:
+            arguments.append(
+                IfPlaceholder(
+                    IfPlaceholderStructure(
+                        condition=IsPresentPlaceholder(input.name),
+                        then_value=arguments_for_input,
+                    )))
+
+    if outputs_passed_through_func_return_tuple:
+        param_flag = "----output-paths"
+        output_param_var = "_output_paths"
+        line = '_parser.add_argument("{param_flag}", dest="{param_var}", type=str, nargs={nargs})'.format(
+            param_flag=param_flag,
+            param_var=output_param_var,
+            nargs=len(outputs_passed_through_func_return_tuple),
+        )
+        arg_parse_code_lines.append(line)
+        arguments.append(param_flag)
+        arguments.extend(
+            OutputPathPlaceholder(output.name)
+            for output in outputs_passed_through_func_return_tuple)
+
+    output_serialization_expression_strings = []
+    for output in outputs_passed_through_func_return_tuple:
+        serializer_call_str = get_serializer_and_register_definitions(
+            output.type)
+        output_serialization_expression_strings.append(serializer_call_str)
+
+    pre_func_code = '\n'.join(list(pre_func_definitions))
+
+    arg_parse_code_lines = sorted(list(definitions)) + arg_parse_code_lines
+
+    arg_parse_code_lines.append('_parsed_args = vars(_parser.parse_args())',)
+    if outputs_passed_through_func_return_tuple:
+        arg_parse_code_lines.append(
+            '_output_files = _parsed_args.pop("_output_paths", [])',)
+
+    # Putting singular return values in a list to be "zipped" with the serializers and output paths
+    outputs_to_list_code = ''
+    return_ann = inspect.signature(func).return_annotation
+    if (  # The return type is singular, not sequence
+            return_ann is not None and return_ann != inspect.Parameter.empty and
+            not isinstance(return_ann, dict) and
+            not hasattr(return_ann, '_fields')  # namedtuple
+    ):
+        outputs_to_list_code = '_outputs = [_outputs]'
+
+    output_serialization_code = ''.join(
+        '    {},\n'.format(s) for s in output_serialization_expression_strings)
+
+    full_output_handling_code = '''
+
+{outputs_to_list_code}
+
+_output_serializers = [
+{output_serialization_code}
+]
+
+import os
+for idx, output_file in enumerate(_output_files):
+    try:
+        os.makedirs(os.path.dirname(output_file))
+    except OSError:
+        pass
+    with open(output_file, 'w') as f:
+        f.write(_output_serializers[idx](_outputs[idx]))
+'''.format(
+        output_serialization_code=output_serialization_code,
+        outputs_to_list_code=outputs_to_list_code,
+    )
+
+    full_source = \
+'''\
+{pre_func_code}
+
+{extra_code}
+
+{func_code}
+
+{arg_parse_code}
+
+_outputs = {func_name}(**_parsed_args)
+'''.format(
+        func_name=func.__name__,
+        func_code=func_code,
+        pre_func_code=pre_func_code,
+        extra_code=extra_code,
+        arg_parse_code='\n'.join(arg_parse_code_lines),
+    )
+
+    if outputs_passed_through_func_return_tuple:
+        full_source += full_output_handling_code
+
+    #Removing consecutive blank lines
+    import re
+    full_source = re.sub('\n\n\n+', '\n\n', full_source).strip('\n') + '\n'
+
+    package_preinstallation_command = []
+    if packages_to_install:
+        package_install_command_line = 'PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location {}'.format(
+            ' '.join([repr(str(package)) for package in packages_to_install]))
+        package_preinstallation_command = [
+            'sh', '-c',
+            '({pip_install} || {pip_install} --user) && "$0" "$@"'.format(
+                pip_install=package_install_command_line)
+        ]
+
+    component_spec.implementation = ContainerImplementation(
+        container=ContainerSpec(
+            image=base_image,
+            command=package_preinstallation_command + [
+                'sh',
+                '-ec',
+                # Writing the program code to a file.
+                # This is needed for Python to show stack traces and for `inspect.getsource` to work (used by PyTorch JIT and this module for example).
+                textwrap.dedent('''\
+                    program_path=$(mktemp)
+                    printf "%s" "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                '''),
+                full_source,
+            ],
+            args=arguments,
+        ))
+
+    return component_spec
+
+
+def _func_to_component_dict(func,
+                            extra_code='',
+                            base_image: str = None,
+                            packages_to_install: List[str] = None,
+                            modules_to_capture: List[str] = None,
+                            use_code_pickling=False):
+    return _func_to_component_spec(
+        func=func,
+        extra_code=extra_code,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+        modules_to_capture=modules_to_capture,
+        use_code_pickling=use_code_pickling,
+    ).to_dict()
+
+
+def func_to_component_text(func,
+                           extra_code='',
+                           base_image: str = None,
+                           packages_to_install: List[str] = None,
+                           modules_to_capture: List[str] = None,
+                           use_code_pickling=False):
+    '''Converts a Python function to a component definition and returns its textual representation.
+
+    Function docstring is used as component description. Argument and return annotations are used as component input/output types.
+
+    To declare a function with multiple return values, use the NamedTuple return annotation syntax::
+
+        from typing import NamedTuple
+        def add_multiply_two_numbers(a: float, b: float) -> NamedTuple('DummyName', [('sum', float), ('product', float)]):
+            """Returns sum and product of two arguments"""
+            return (a + b, a * b)
+
+    Args:
+        func: The python function to convert
+        base_image: Optional. Specify a custom Docker container image to use in the component. For lightweight components, the image needs to have python 3.5+. Default is python:3.7
+        extra_code: Optional. Extra code to add before the function code. Can be used as workaround to define types used in function signature.
+        packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        modules_to_capture: Optional. List of module names that will be captured (instead of just referencing) during the dependency scan. By default the :code:`func.__module__` is captured. The actual algorithm: Starting with the initial function, start traversing dependencies. If the dependency.__module__ is in the modules_to_capture list then it's captured and it's dependencies are traversed. Otherwise the dependency is only referenced instead of capturing and its dependencies are not traversed.
+        use_code_pickling: Specifies whether the function code should be captured using pickling as opposed to source code manipulation. Pickling has better support for capturing dependencies, but is sensitive to version mismatch between python in component creation environment and runtime image.
+
+    Returns:
+        Textual representation of a component definition
+    '''
+    component_dict = _func_to_component_dict(
+        func=func,
+        extra_code=extra_code,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+        modules_to_capture=modules_to_capture,
+        use_code_pickling=use_code_pickling,
+    )
+    return dump_yaml(component_dict)
+
+
+def func_to_component_file(func,
+                           output_component_file,
+                           base_image: str = None,
+                           extra_code='',
+                           packages_to_install: List[str] = None,
+                           modules_to_capture: List[str] = None,
+                           use_code_pickling=False) -> None:
+    '''Converts a Python function to a component definition and writes it to a file.
+
+    Function docstring is used as component description. Argument and return annotations are used as component input/output types.
+
+    To declare a function with multiple return values, use the NamedTuple return annotation syntax::
+
+        from typing import NamedTuple
+        def add_multiply_two_numbers(a: float, b: float) -> NamedTuple('DummyName', [('sum', float), ('product', float)]):
+            """Returns sum and product of two arguments"""
+            return (a + b, a * b)
+
+    Args:
+        func: The python function to convert
+        output_component_file: Write a component definition to a local file. Can be used for sharing.
+        base_image: Optional. Specify a custom Docker container image to use in the component. For lightweight components, the image needs to have python 3.5+. Default is tensorflow/tensorflow:1.13.2-py3
+        extra_code: Optional. Extra code to add before the function code. Can be used as workaround to define types used in function signature.
+        packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        modules_to_capture: Optional. List of module names that will be captured (instead of just referencing) during the dependency scan. By default the :code:`func.__module__` is captured. The actual algorithm: Starting with the initial function, start traversing dependencies. If the :code:`dependency.__module__` is in the :code:`modules_to_capture` list then it's captured and it's dependencies are traversed. Otherwise the dependency is only referenced instead of capturing and its dependencies are not traversed.
+        use_code_pickling: Specifies whether the function code should be captured using pickling as opposed to source code manipulation. Pickling has better support for capturing dependencies, but is sensitive to version mismatch between python in component creation environment and runtime image.
+    '''
+
+    component_yaml = func_to_component_text(
+        func=func,
+        extra_code=extra_code,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+        modules_to_capture=modules_to_capture,
+        use_code_pickling=use_code_pickling,
+    )
+
+    Path(output_component_file).write_text(component_yaml)
+
+
+def func_to_container_op(
+    func: Callable,
+    output_component_file: Optional[str] = None,
+    base_image: Optional[str] = None,
+    extra_code: Optional[str] = '',
+    packages_to_install: List[str] = None,
+    modules_to_capture: List[str] = None,
+    use_code_pickling: bool = False,
+    annotations: Optional[Mapping[str, str]] = None,
+):
+    '''Converts a Python function to a component and returns a task
+      (:class:`kfp.dsl.ContainerOp`) factory.
+
+    Function docstring is used as component description. Argument and return annotations are used as component input/output types.
+
+    To declare a function with multiple return values, use the :code:`NamedTuple` return annotation syntax::
+
+        from typing import NamedTuple
+        def add_multiply_two_numbers(a: float, b: float) -> NamedTuple('DummyName', [('sum', float), ('product', float)]):
+            """Returns sum and product of two arguments"""
+            return (a + b, a * b)
+
+    Args:
+        func: The python function to convert
+        base_image: Optional. Specify a custom Docker container image to use in the component. For lightweight components, the image needs to have python 3.5+. Default is tensorflow/tensorflow:1.13.2-py3
+        output_component_file: Optional. Write a component definition to a local file. Can be used for sharing.
+        extra_code: Optional. Extra code to add before the function code. Can be used as workaround to define types used in function signature.
+        packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        modules_to_capture: Optional. List of module names that will be captured (instead of just referencing) during the dependency scan. By default the :code:`func.__module__` is captured. The actual algorithm: Starting with the initial function, start traversing dependencies. If the :code:`dependency.__module__` is in the :code:`modules_to_capture` list then it's captured and it's dependencies are traversed. Otherwise the dependency is only referenced instead of capturing and its dependencies are not traversed.
+        use_code_pickling: Specifies whether the function code should be captured using pickling as opposed to source code manipulation. Pickling has better support for capturing dependencies, but is sensitive to version mismatch between python in component creation environment and runtime image.
+        annotations: Optional. Allows adding arbitrary key-value data to the component specification.
+
+    Returns:
+        A factory function with a strongly-typed signature taken from the python function.
+        Once called with the required arguments, the factory constructs a pipeline task instance (:class:`kfp.dsl.ContainerOp`) that can run the original function in a container.
+    '''
+
+    component_spec = _func_to_component_spec(
+        func=func,
+        extra_code=extra_code,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+        modules_to_capture=modules_to_capture,
+        use_code_pickling=use_code_pickling,
+    )
+    if annotations:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,)
+
+    output_component_file = output_component_file or getattr(
+        func, '_component_target_component_file', None)
+    if output_component_file:
+        component_spec.save(output_component_file)
+        #TODO: assert ComponentSpec.from_dict(load_yaml(output_component_file)) == component_spec
+
+    return _create_task_factory_from_component_spec(component_spec)
+
+def create_component_from_func(
+    func: Callable,
+    output_component_file: Optional[str] = None,
+    base_image: Optional[str] = None,
+    packages_to_install: List[str] = None,
+    annotations: Optional[Mapping[str, str]] = None,
+):
+    '''Converts a Python function to a component and returns a task factory
+    (a function that accepts arguments and returns a task object).
+
+    Args:
+        func: The python function to convert
+        base_image: Optional. Specify a custom Docker container image to use in the component. For lightweight components, the image needs to have python 3.5+. Default is the python image corresponding to the current python environment.
+        output_component_file: Optional. Write a component definition to a local file. The produced component file can be loaded back by calling :code:`load_component_from_file` or :code:`load_component_from_uri`.
+        packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        annotations: Optional. Allows adding arbitrary key-value data to the component specification.
+
+    Returns:
+        A factory function with a strongly-typed signature taken from the python function.
+        Once called with the required arguments, the factory constructs a task instance that can run the original function in a container.
+
+    Examples:
+        The function name and docstring are used as component name and description. Argument and return annotations are used as component input/output types::
+
+            def add(a: float, b: float) -> float:
+                """Returns sum of two arguments"""
+                return a + b
+
+            # add_op is a task factory function that creates a task object when given arguments
+            add_op = create_component_from_func(
+                func=add,
+                base_image='python:3.7', # Optional
+                output_component_file='add.component.yaml', # Optional
+                packages_to_install=['pandas==0.24'], # Optional
+            )
+
+            # The component spec can be accessed through the .component_spec attribute:
+            add_op.component_spec.save('add.component.yaml')
+
+            # The component function can be called with arguments to create a task:
+            add_task = add_op(1, 3)
+
+            # The resulting task has output references, corresponding to the component outputs.
+            # When the function only has a single anonymous return value, the output name is "Output":
+            sum_output_ref = add_task.outputs['Output']
+
+            # These task output references can be passed to other component functions, constructing a computation graph:
+            task2 = add_op(sum_output_ref, 5)
+
+
+        :code:`create_component_from_func` function can also be used as decorator::
+
+            @create_component_from_func
+            def add_op(a: float, b: float) -> float:
+                """Returns sum of two arguments"""
+                return a + b
+
+        To declare a function with multiple return values, use the :code:`NamedTuple` return annotation syntax::
+
+            from typing import NamedTuple
+
+            def add_multiply_two_numbers(a: float, b: float) -> NamedTuple('Outputs', [('sum', float), ('product', float)]):
+                """Returns sum and product of two arguments"""
+                return (a + b, a * b)
+
+            add_multiply_op = create_component_from_func(add_multiply_two_numbers)
+
+            # The component function can be called with arguments to create a task:
+            add_multiply_task = add_multiply_op(1, 3)
+
+            # The resulting task has output references, corresponding to the component outputs:
+            sum_output_ref = add_multiply_task.outputs['sum']
+
+            # These task output references can be passed to other component functions, constructing a computation graph:
+            task2 = add_multiply_op(sum_output_ref, 5)
+
+        Bigger data should be read from files and written to files.
+        Use the :py:class:`kfp.components.InputPath` parameter annotation to tell the system that the function wants to consume the corresponding input data as a file. The system will download the data, write it to a local file and then pass the **path** of that file to the function.
+        Use the :py:class:`kfp.components.OutputPath` parameter annotation to tell the system that the function wants to produce the corresponding output data as a file. The system will prepare and pass the **path** of a file where the function should write the output data. After the function exits, the system will upload the data to the storage system so that it can be passed to downstream components.
+
+        You can specify the type of the consumed/produced data by specifying the type argument to :py:class:`kfp.components.InputPath` and :py:class:`kfp.components.OutputPath`. The type can be a python type or an arbitrary type name string. :code:`OutputPath('CatBoostModel')` means that the function states that the data it has written to a file has type :code:`CatBoostModel`. :code:`InputPath('CatBoostModel')` means that the function states that it expect the data it reads from a file to have type 'CatBoostModel'. When the pipeline author connects inputs to outputs the system checks whether the types match.
+        Every kind of data can be consumed as a file input. Conversely, bigger data should not be consumed by value as all value inputs pass through the command line.
+
+        Example of a component function declaring file input and output::
+
+            def catboost_train_classifier(
+                training_data_path: InputPath('CSV'),            # Path to input data file of type "CSV"
+                trained_model_path: OutputPath('CatBoostModel'), # Path to output data file of type "CatBoostModel"
+                number_of_trees: int = 100,                      # Small output of type "Integer"
+            ) -> NamedTuple('Outputs', [
+                ('Accuracy', float),  # Small output of type "Float"
+                ('Precision', float), # Small output of type "Float"
+                ('JobUri', 'URI'),    # Small output of type "URI"
+            ]):
+                """Trains CatBoost classification model"""
+                ...
+
+                return (accuracy, precision, recall)
+    '''
+
+    component_spec = _func_to_component_spec(
+        func=func,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+    )
+    if annotations:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,)
+
+    if output_component_file:
+        component_spec.save(output_component_file)
+
+    return _create_task_factory_from_component_spec(component_spec)
+
+
+def _module_is_builtin_or_standard(module_name: str) -> bool:
+    import sys
+    if module_name in sys.builtin_module_names:
+        return True
+    import distutils.sysconfig as sysconfig
+    import os
+    std_lib_dir = sysconfig.get_python_lib(standard_lib=True)
+    module_name_parts = module_name.split('.')
+    expected_module_path = os.path.join(std_lib_dir, *module_name_parts)
+    return os.path.exists(expected_module_path) or os.path.exists(
+        expected_module_path + '.py')

--- a/kfp/components/_python_to_graph_component.py
+++ b/kfp/components/_python_to_graph_component.py
@@ -1,0 +1,214 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'create_graph_component_from_pipeline_func',
+]
+
+import inspect
+from collections import OrderedDict
+from typing import Callable, Mapping, Optional
+
+from . import _components
+from . import structures
+from ._structures import TaskSpec, ComponentSpec, OutputSpec, GraphInputReference, TaskOutputArgument, GraphImplementation, GraphSpec
+from ._naming import _make_name_unique_by_adding_index
+from ._python_op import _extract_component_interface
+from ._components import _create_task_factory_from_component_spec
+
+
+def create_graph_component_from_pipeline_func(
+    pipeline_func: Callable,
+    output_component_file: str = None,
+    embed_component_specs: bool = False,
+    annotations: Optional[Mapping[str, str]] = None,
+) -> Callable:
+    """Creates graph component definition from a python pipeline function. The
+    component file can be published for sharing.
+
+    Pipeline function is a function that only calls component functions and passes outputs to inputs.
+    This feature is experimental and lacks support for some of the DSL features like conditions and loops.
+    Only pipelines consisting of loaded components or python components are currently supported (no manually created ContainerOps or ResourceOps).
+
+    .. warning::
+
+        Please note this feature is considered experimental!
+
+    Args:
+        pipeline_func: Python function to convert
+        output_component_file: Path of the file where the component definition will be written. The `component.yaml` file can then be published for sharing.
+        embed_component_specs: Whether to embed component definitions or just reference them. Embedding makes the graph component self-contained. Default is False.
+        annotations: Optional. Allows adding arbitrary key-value data to the component specification.
+
+    Returns:
+        A function representing the graph component. The component spec can be accessed using the .component_spec attribute.
+        The function will have the same parameters as the original function.
+        When called, the function will return a task object, corresponding to the graph component.
+        To reference the outputs of the task, use task.outputs["Output name"].
+
+    Example::
+
+        producer_op = load_component_from_file('producer/component.yaml')
+        processor_op = load_component_from_file('processor/component.yaml')
+
+        def pipeline1(pipeline_param_1: int):
+            producer_task = producer_op()
+            processor_task = processor_op(pipeline_param_1, producer_task.outputs['Output 2'])
+
+            return OrderedDict([
+                ('Pipeline output 1', producer_task.outputs['Output 1']),
+                ('Pipeline output 2', processor_task.outputs['Output 2']),
+            ])
+
+        create_graph_component_from_pipeline_func(pipeline1, output_component_file='pipeline.component.yaml')
+    """
+    component_spec = create_graph_component_spec_from_pipeline_func(
+        pipeline_func, embed_component_specs)
+    if annotations:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,)
+    if output_component_file:
+        from pathlib import Path
+        from ._yaml_utils import dump_yaml
+        component_dict = component_spec.to_dict()
+        component_yaml = dump_yaml(component_dict)
+        Path(output_component_file).write_text(component_yaml)
+
+    return _create_task_factory_from_component_spec(component_spec)
+
+
+def create_graph_component_spec_from_pipeline_func(
+        pipeline_func: Callable,
+        embed_component_specs: bool = False) -> ComponentSpec:
+
+    component_spec = _extract_component_interface(pipeline_func)
+    # Checking the function parameters - they should not have file passing annotations.
+    input_specs = component_spec.inputs or []
+    for input in input_specs:
+        if input._passing_style:
+            raise TypeError(
+                'Graph component function parameter "{}" cannot have file-passing annotation "{}".'
+                .format(input.name, input._passing_style))
+
+    task_map = OrderedDict()  #Preserving task order
+
+    from ._components import _create_task_spec_from_component_and_arguments
+
+    def task_construction_handler(
+        component_spec,
+        arguments,
+        component_ref,
+    ):
+        task = _create_task_spec_from_component_and_arguments(
+            component_spec=component_spec,
+            arguments=arguments,
+            component_ref=component_ref,
+        )
+
+        #Rewriting task ids so that they're same every time
+        task_id = task.component_ref.spec.name or "Task"
+        task_id = _make_name_unique_by_adding_index(task_id, task_map.keys(),
+                                                    ' ')
+        for output_ref in task.outputs.values():
+            output_ref.task_output.task_id = task_id
+            output_ref.task_output.task = None
+        task_map[task_id] = task
+        # Remove the component spec from component reference unless it will make the reference empty or unless explicitly asked by the user
+        if not embed_component_specs and any([
+                task.component_ref.name, task.component_ref.url,
+                task.component_ref.digest
+        ]):
+            task.component_ref.spec = None
+
+        return task  #The handler is a transformation function, so it must pass the task through.
+
+    # Preparing the pipeline_func arguments
+    # TODO: The key should be original parameter name if different
+    pipeline_func_args = {
+        input.name: GraphInputReference(input_name=input.name).as_argument()
+        for input in input_specs
+    }
+
+    try:
+        #Setting the handler to fix and catch the tasks.
+        # FIX: The handler only hooks container component creation
+        old_handler = _components._container_task_constructor
+        _components._container_task_constructor = task_construction_handler
+
+        #Calling the pipeline_func with GraphInputArgument instances as arguments
+        pipeline_func_result = pipeline_func(**pipeline_func_args)
+    finally:
+        _components._container_task_constructor = old_handler
+
+    # Getting graph outputs
+    output_names = [output.name for output in (component_spec.outputs or [])]
+
+    if len(output_names) == 1 and output_names[
+            0] == 'Output':  # TODO: Check whether the NamedTuple syntax was used
+        pipeline_func_result = [pipeline_func_result]
+
+    if isinstance(pipeline_func_result, tuple) and hasattr(
+            pipeline_func_result,
+            '_asdict'):  # collections.namedtuple and typing.NamedTuple
+        pipeline_func_result = pipeline_func_result._asdict()
+
+    if isinstance(pipeline_func_result, dict):
+        if output_names:
+            if set(output_names) != set(pipeline_func_result.keys()):
+                raise ValueError(
+                    'Returned outputs do not match outputs specified in the function signature: {} = {}'
+                    .format(
+                        str(set(pipeline_func_result.keys())),
+                        str(set(output_names))))
+
+    if pipeline_func_result is None:
+        graph_output_value_map = {}
+    elif isinstance(pipeline_func_result, dict):
+        graph_output_value_map = OrderedDict(pipeline_func_result)
+    elif isinstance(pipeline_func_result, (list, tuple)):
+        if output_names:
+            if len(pipeline_func_result) != len(output_names):
+                raise ValueError(
+                    'Expected {} values from pipeline function, but got {}.'
+                    .format(len(output_names), len(pipeline_func_result)))
+            graph_output_value_map = OrderedDict(
+                (name_value[0], name_value[1])
+                for name_value in zip(output_names, pipeline_func_result))
+        else:
+            graph_output_value_map = OrderedDict(
+                (output_value.task_output.output_name, output_value)
+                for output_value in pipeline_func_result
+            )  # TODO: Fix possible name non-uniqueness (e.g. use task id as prefix or add index to non-unique names)
+    else:
+        raise TypeError('Pipeline must return outputs as tuple or OrderedDict.')
+
+    #Checking the pipeline_func output object types
+    for output_name, output_value in graph_output_value_map.items():
+        if not isinstance(output_value, TaskOutputArgument):
+            raise TypeError(
+                'Only TaskOutputArgument instances should be returned from graph component, but got "{}" = "{}".'
+                .format(output_name, str(output_value)))
+
+    if not component_spec.outputs and graph_output_value_map:
+        component_spec.outputs = [
+            OutputSpec(name=output_name, type=output_value.task_output.type)
+            for output_name, output_value in graph_output_value_map.items()
+        ]
+
+    component_spec.implementation = GraphImplementation(
+        graph=GraphSpec(
+            tasks=task_map,
+            output_values=graph_output_value_map,
+        ))
+    return component_spec

--- a/kfp/components/_structures.py
+++ b/kfp/components/_structures.py
@@ -1,0 +1,896 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'InputSpec',
+    'OutputSpec',
+    'InputValuePlaceholder',
+    'InputPathPlaceholder',
+    'OutputPathPlaceholder',
+    'InputUriPlaceholder',
+    'OutputUriPlaceholder',
+    'InputMetadataPlaceholder',
+    'InputOutputPortNamePlaceholder',
+    'OutputMetadataPlaceholder',
+    'ExecutorInputPlaceholder',
+    'ConcatPlaceholder',
+    'IsPresentPlaceholder',
+    'IfPlaceholderStructure',
+    'IfPlaceholder',
+    'ContainerSpec',
+    'ContainerImplementation',
+    'ComponentSpec',
+    'ComponentReference',
+    'GraphInputReference',
+    'GraphInputArgument',
+    'TaskOutputReference',
+    'TaskOutputArgument',
+    'EqualsPredicate',
+    'NotEqualsPredicate',
+    'GreaterThanPredicate',
+    'GreaterThanOrEqualPredicate',
+    'LessThenPredicate',
+    'LessThenOrEqualPredicate',
+    'NotPredicate',
+    'AndPredicate',
+    'OrPredicate',
+    'RetryStrategySpec',
+    'CachingStrategySpec',
+    'ExecutionOptionsSpec',
+    'TaskSpec',
+    'GraphSpec',
+    'GraphImplementation',
+    'PipelineRunSpec',
+]
+
+from collections import OrderedDict
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+from .modelbase import ModelBase
+
+PrimitiveTypes = Union[str, int, float, bool]
+PrimitiveTypesIncludingNone = Optional[PrimitiveTypes]
+
+TypeSpecType = Union[str, Dict, List]
+
+
+class InputSpec(ModelBase):
+    """Describes the component input specification."""
+
+    def __init__(
+        self,
+        name: str,
+        type: Optional[TypeSpecType] = None,
+        description: Optional[str] = None,
+        default: Optional[PrimitiveTypes] = None,
+        optional: Optional[bool] = False,
+        annotations: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(locals())
+
+
+class OutputSpec(ModelBase):
+    """Describes the component output specification."""
+
+    def __init__(
+        self,
+        name: str,
+        type: Optional[TypeSpecType] = None,
+        description: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(locals())
+
+
+class InputValuePlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by the input argument value."""
+    _serialized_names = {
+        'input_name': 'inputValue',
+    }
+
+    def __init__(
+        self,
+        input_name: str,
+    ):
+        super().__init__(locals())
+
+
+class InputPathPlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by a local file path pointing to a file containing the input
+    argument value."""
+    _serialized_names = {
+        'input_name': 'inputPath',
+    }
+
+    def __init__(
+        self,
+        input_name: str,
+    ):
+        super().__init__(locals())
+
+
+class OutputPathPlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by a local file path pointing to a file where the program
+    should write its output data."""
+    _serialized_names = {
+        'output_name': 'outputPath',
+    }
+
+    def __init__(
+        self,
+        output_name: str,
+    ):
+        super().__init__(locals())
+
+
+class InputUriPlaceholder(ModelBase):  # Non-standard attr names
+    """Represents a placeholder for the URI of an input artifact.
+
+    Represents the command-line argument placeholder that will be
+    replaced at run-time by the URI of the input artifact argument.
+    """
+    _serialized_names = {
+        'input_name': 'inputUri',
+    }
+
+    def __init__(
+        self,
+        input_name: str,
+    ):
+        super().__init__(locals())
+
+
+class OutputUriPlaceholder(ModelBase):  # Non-standard attr names
+    """Represents a placeholder for the URI of an output artifact.
+
+    Represents the command-line argument placeholder that will be
+    replaced at run-time by a URI of the output artifac where the
+    program should write its output data.
+    """
+    _serialized_names = {
+        'output_name': 'outputUri',
+    }
+
+    def __init__(
+        self,
+        output_name: str,
+    ):
+        super().__init__(locals())
+
+
+class InputMetadataPlaceholder(ModelBase):  # Non-standard attr names
+    """Represents the file path to an input artifact metadata.
+
+    During runtime, this command-line argument placeholder will be
+    replaced by the path where the metadata file associated with this
+    artifact has been written to. Currently only supported in v2
+    components.
+    """
+    _serialized_names = {
+        'input_name': 'inputMetadata',
+    }
+
+    def __init__(self, input_name: str):
+        super().__init__(locals())
+
+
+class InputOutputPortNamePlaceholder(ModelBase):  # Non-standard attr names
+    """Represents the output port name of an input artifact.
+
+    During compile time, this command-line argument placeholder will be
+    replaced by the actual output port name used by the producer task.
+    Currently only supported in v2 components.
+    """
+    _serialized_names = {
+        'input_name': 'inputOutputPortName',
+    }
+
+    def __init__(self, input_name: str):
+        super().__init__(locals())
+
+
+class OutputMetadataPlaceholder(ModelBase):  # Non-standard attr names
+    """Represents the output metadata JSON file location of this task.
+
+    This file will encode the metadata information produced by this task:
+    - Artifacts metadata, but not the content of the artifact, and
+    - output parameters.
+
+    Only supported in v2 components.
+    """
+    _serialized_names = {
+        'output_metadata': 'outputMetadata',
+    }
+
+    def __init__(self, output_metadata: type(None) = None):
+        if output_metadata:
+            raise RuntimeError(
+                'Output metadata placeholder cannot be associated with key')
+        super().__init__(locals())
+
+    def to_dict(self) -> Mapping[str, Any]:
+        # Override parent implementation. Otherwise it always returns {}.
+        return {'outputMetadata': None}
+
+
+class ExecutorInputPlaceholder(ModelBase):  # Non-standard attr names
+    """Represents the serialized ExecutorInput message at runtime.
+
+    This placeholder will be replaced by a serialized
+    [ExecutorInput](https://github.com/kubeflow/pipelines/blob/61f9c2c328d245d89c9d9b8c923f24dbbd08cdc9/api/v2alpha1/pipeline_spec.proto#L730)
+    proto message at runtime, which includes parameters of the task, artifact
+    URIs and metadata.
+    """
+    _serialized_names = {
+        'executor_input': 'executorInput',
+    }
+
+    def __init__(self, executor_input: type(None) = None):
+        if executor_input:
+            raise RuntimeError(
+                'Executor input placeholder cannot be associated with input key'
+                '. Got %s' % executor_input)
+        super().__init__(locals())
+
+    def to_dict(self) -> Mapping[str, Any]:
+        # Override parent implementation. Otherwise it always returns {}.
+        return {'executorInput': None}
+
+
+CommandlineArgumentType = Union[str, InputValuePlaceholder,
+                                InputPathPlaceholder, OutputPathPlaceholder,
+                                InputUriPlaceholder, OutputUriPlaceholder,
+                                InputMetadataPlaceholder,
+                                InputOutputPortNamePlaceholder,
+                                OutputMetadataPlaceholder,
+                                ExecutorInputPlaceholder, 'ConcatPlaceholder',
+                                'IfPlaceholder',]
+
+
+class ConcatPlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by the concatenated values of its items."""
+    _serialized_names = {
+        'items': 'concat',
+    }
+
+    def __init__(
+        self,
+        items: List[CommandlineArgumentType],
+    ):
+        super().__init__(locals())
+
+
+class IsPresentPlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by a boolean value specifying whether the caller has passed an
+    argument for the specified optional input."""
+    _serialized_names = {
+        'input_name': 'isPresent',
+    }
+
+    def __init__(
+        self,
+        input_name: str,
+    ):
+        super().__init__(locals())
+
+
+IfConditionArgumentType = Union[bool, str, IsPresentPlaceholder,
+                                InputValuePlaceholder]
+
+
+class IfPlaceholderStructure(ModelBase):  #Non-standard attr names
+    '''Used in by the IfPlaceholder - the command-line argument placeholder that will be replaced at run-time by the expanded value of either "then_value" or "else_value" depending on the submissio-time resolved value of the "cond" predicate.'''
+    _serialized_names = {
+        'condition': 'cond',
+        'then_value': 'then',
+        'else_value': 'else',
+    }
+
+    def __init__(
+        self,
+        condition: IfConditionArgumentType,
+        then_value: Union[CommandlineArgumentType,
+                          List[CommandlineArgumentType]],
+        else_value: Optional[Union[CommandlineArgumentType,
+                                   List[CommandlineArgumentType]]] = None,
+    ):
+        super().__init__(locals())
+
+
+class IfPlaceholder(ModelBase):  #Non-standard attr names
+    """Represents the command-line argument placeholder that will be replaced
+    at run-time by the expanded value of either "then_value" or "else_value"
+    depending on the submissio-time resolved value of the "cond" predicate."""
+    _serialized_names = {
+        'if_structure': 'if',
+    }
+
+    def __init__(
+        self,
+        if_structure: IfPlaceholderStructure,
+    ):
+        super().__init__(locals())
+
+
+class ContainerSpec(ModelBase):
+    """Describes the container component implementation."""
+    _serialized_names = {
+        'file_outputs':
+            'fileOutputs',  #TODO: rename to something like legacy_unconfigurable_output_paths
+    }
+
+    def __init__(
+            self,
+            image: str,
+            command: Optional[List[CommandlineArgumentType]] = None,
+            args: Optional[List[CommandlineArgumentType]] = None,
+            env: Optional[Mapping[str, str]] = None,
+            file_outputs:
+        Optional[Mapping[
+            str,
+            str]] = None,  #TODO: rename to something like legacy_unconfigurable_output_paths
+    ):
+        super().__init__(locals())
+
+
+class ContainerImplementation(ModelBase):
+    """Represents the container component implementation."""
+
+    def __init__(
+        self,
+        container: ContainerSpec,
+    ):
+        super().__init__(locals())
+
+
+ImplementationType = Union[ContainerImplementation, 'GraphImplementation']
+
+
+class MetadataSpec(ModelBase):
+
+    def __init__(
+        self,
+        annotations: Optional[Dict[str, str]] = None,
+        labels: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__(locals())
+
+
+class ComponentSpec(ModelBase):
+    """Component specification.
+
+    Describes the metadata (name, description, annotations and labels),
+    the interface (inputs and outputs) and the implementation of the
+    component.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,  #? Move to metadata?
+        description: Optional[str] = None,  #? Move to metadata?
+        metadata: Optional[MetadataSpec] = None,
+        inputs: Optional[List[InputSpec]] = None,
+        outputs: Optional[List[OutputSpec]] = None,
+        implementation: Optional[ImplementationType] = None,
+        version: Optional[str] = 'google.com/cloud/pipelines/component/v1',
+        #tags: Optional[Set[str]] = None,
+    ):
+        super().__init__(locals())
+        self._post_init()
+
+    def _post_init(self):
+        #Checking input names for uniqueness
+        self._inputs_dict = {}
+        if self.inputs:
+            for input in self.inputs:
+                if input.name in self._inputs_dict:
+                    raise ValueError('Non-unique input name "{}"'.format(
+                        input.name))
+                self._inputs_dict[input.name] = input
+
+        #Checking output names for uniqueness
+        self._outputs_dict = {}
+        if self.outputs:
+            for output in self.outputs:
+                if output.name in self._outputs_dict:
+                    raise ValueError('Non-unique output name "{}"'.format(
+                        output.name))
+                self._outputs_dict[output.name] = output
+
+        if isinstance(self.implementation, ContainerImplementation):
+            container = self.implementation.container
+
+            if container.file_outputs:
+                for output_name, path in container.file_outputs.items():
+                    if output_name not in self._outputs_dict:
+                        raise TypeError(
+                            'Unconfigurable output entry "{}" references non-existing output.'
+                            .format({output_name: path}))
+
+            def verify_arg(arg):
+                if arg is None:
+                    pass
+                elif isinstance(
+                        arg, (str, int, float, bool, OutputMetadataPlaceholder,
+                              ExecutorInputPlaceholder)):
+                    pass
+                elif isinstance(arg, list):
+                    for arg2 in arg:
+                        verify_arg(arg2)
+                elif isinstance(
+                        arg,
+                    (InputUriPlaceholder, InputValuePlaceholder,
+                     InputPathPlaceholder, IsPresentPlaceholder,
+                     InputMetadataPlaceholder, InputOutputPortNamePlaceholder)):
+                    if arg.input_name not in self._inputs_dict:
+                        raise TypeError(
+                            'Argument "{}" references non-existing input.'
+                            .format(arg))
+                elif isinstance(arg,
+                                (OutputUriPlaceholder, OutputPathPlaceholder)):
+                    if arg.output_name not in self._outputs_dict:
+                        raise TypeError(
+                            'Argument "{}" references non-existing output.'
+                            .format(arg))
+                elif isinstance(arg, ConcatPlaceholder):
+                    for arg2 in arg.items:
+                        verify_arg(arg2)
+                elif isinstance(arg, IfPlaceholder):
+                    verify_arg(arg.if_structure.condition)
+                    verify_arg(arg.if_structure.then_value)
+                    verify_arg(arg.if_structure.else_value)
+                else:
+                    raise TypeError('Unexpected argument "{}"'.format(arg))
+
+            verify_arg(container.command)
+            verify_arg(container.args)
+
+        if isinstance(self.implementation, GraphImplementation):
+            graph = self.implementation.graph
+
+            if graph.output_values is not None:
+                for output_name, argument in graph.output_values.items():
+                    if output_name not in self._outputs_dict:
+                        raise TypeError(
+                            'Graph output argument entry "{}" references non-existing output.'
+                            .format({output_name: argument}))
+
+            if graph.tasks is not None:
+                for task in graph.tasks.values():
+                    if task.arguments is not None:
+                        for argument in task.arguments.values():
+                            if isinstance(
+                                    argument, GraphInputArgument
+                            ) and argument.graph_input.input_name not in self._inputs_dict:
+                                raise TypeError(
+                                    'Argument "{}" references non-existing input.'
+                                    .format(argument))
+
+    def save(self, file_path: str):
+        """Saves the component definition to file.
+
+        It can be shared online and later loaded using the
+        load_component function.
+        """
+        from ._yaml_utils import dump_yaml
+        component_yaml = dump_yaml(self.to_dict())
+        with open(file_path, 'w') as f:
+            f.write(component_yaml)
+
+
+class ComponentReference(ModelBase):
+    """Component reference.
+
+    Contains information that can be used to locate and load a component
+    by name, digest or URL
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
+        tag: Optional[str] = None,
+        url: Optional[str] = None,
+        spec: Optional[ComponentSpec] = None,
+    ):
+        super().__init__(locals())
+        self._post_init()
+
+    def _post_init(self) -> None:
+        if not any([self.name, self.digest, self.tag, self.url, self.spec]):
+            raise TypeError('Need at least one argument.')
+
+
+class GraphInputReference(ModelBase):
+    """References the input of the graph (the scope is a single graph)."""
+    _serialized_names = {
+        'input_name': 'inputName',
+    }
+
+    def __init__(
+            self,
+            input_name: str,
+            type:
+        Optional[
+            TypeSpecType] = None,  # Can be used to override the reference data type
+    ):
+        super().__init__(locals())
+
+    def as_argument(self) -> 'GraphInputArgument':
+        return GraphInputArgument(graph_input=self)
+
+    def with_type(self, type_spec: TypeSpecType) -> 'GraphInputReference':
+        return GraphInputReference(
+            input_name=self.input_name,
+            type=type_spec,
+        )
+
+    def without_type(self) -> 'GraphInputReference':
+        return self.with_type(None)
+
+
+class GraphInputArgument(ModelBase):
+    """Represents the component argument value that comes from the graph
+    component input."""
+    _serialized_names = {
+        'graph_input': 'graphInput',
+    }
+
+    def __init__(
+        self,
+        graph_input: GraphInputReference,
+    ):
+        super().__init__(locals())
+
+
+class TaskOutputReference(ModelBase):
+    """References the output of some task (the scope is a single graph)."""
+    _serialized_names = {
+        'task_id': 'taskId',
+        'output_name': 'outputName',
+    }
+
+    def __init__(
+            self,
+            output_name: str,
+            task_id:
+        Optional[
+            str] = None,  # Used for linking to the upstream task in serialized component file.
+            task:
+        Optional[
+            'TaskSpec'] = None,  # Used for linking to the upstream task in runtime since Task does not have an ID until inserted into a graph.
+            type:
+        Optional[
+            TypeSpecType] = None,  # Can be used to override the reference data type
+    ):
+        super().__init__(locals())
+        if self.task_id is None and self.task is None:
+            raise TypeError('task_id and task cannot be None at the same time.')
+
+    def with_type(self, type_spec: TypeSpecType) -> 'TaskOutputReference':
+        return TaskOutputReference(
+            output_name=self.output_name,
+            task_id=self.task_id,
+            task=self.task,
+            type=type_spec,
+        )
+
+    def without_type(self) -> 'TaskOutputReference':
+        return self.with_type(None)
+
+
+class TaskOutputArgument(ModelBase
+                        ):  #Has additional constructor for convenience
+    """Represents the component argument value that comes from the output of
+    another task."""
+    _serialized_names = {
+        'task_output': 'taskOutput',
+    }
+
+    def __init__(
+        self,
+        task_output: TaskOutputReference,
+    ):
+        super().__init__(locals())
+
+    @staticmethod
+    def construct(
+        task_id: str,
+        output_name: str,
+    ) -> 'TaskOutputArgument':
+        return TaskOutputArgument(
+            TaskOutputReference(
+                task_id=task_id,
+                output_name=output_name,
+            ))
+
+    def with_type(self, type_spec: TypeSpecType) -> 'TaskOutputArgument':
+        return TaskOutputArgument(
+            task_output=self.task_output.with_type(type_spec),)
+
+    def without_type(self) -> 'TaskOutputArgument':
+        return self.with_type(None)
+
+
+ArgumentType = Union[PrimitiveTypes, GraphInputArgument, TaskOutputArgument]
+
+
+class TwoOperands(ModelBase):
+
+    def __init__(
+        self,
+        op1: ArgumentType,
+        op2: ArgumentType,
+    ):
+        super().__init__(locals())
+
+
+class BinaryPredicate(ModelBase):  #abstract base type
+
+    def __init__(self, operands: TwoOperands):
+        super().__init__(locals())
+
+
+class EqualsPredicate(BinaryPredicate):
+    """Represents the "equals" comparison predicate."""
+    _serialized_names = {'operands': '=='}
+
+
+class NotEqualsPredicate(BinaryPredicate):
+    """Represents the "not equals" comparison predicate."""
+    _serialized_names = {'operands': '!='}
+
+
+class GreaterThanPredicate(BinaryPredicate):
+    """Represents the "greater than" comparison predicate."""
+    _serialized_names = {'operands': '>'}
+
+
+class GreaterThanOrEqualPredicate(BinaryPredicate):
+    """Represents the "greater than or equal" comparison predicate."""
+    _serialized_names = {'operands': '>='}
+
+
+class LessThenPredicate(BinaryPredicate):
+    """Represents the "less than" comparison predicate."""
+    _serialized_names = {'operands': '<'}
+
+
+class LessThenOrEqualPredicate(BinaryPredicate):
+    """Represents the "less than or equal" comparison predicate."""
+    _serialized_names = {'operands': '<='}
+
+
+PredicateType = Union[ArgumentType, EqualsPredicate, NotEqualsPredicate,
+                      GreaterThanPredicate, GreaterThanOrEqualPredicate,
+                      LessThenPredicate, LessThenOrEqualPredicate,
+                      'NotPredicate', 'AndPredicate', 'OrPredicate',]
+
+
+class TwoBooleanOperands(ModelBase):
+
+    def __init__(
+        self,
+        op1: PredicateType,
+        op2: PredicateType,
+    ):
+        super().__init__(locals())
+
+
+class NotPredicate(ModelBase):
+    """Represents the "not" logical operation."""
+    _serialized_names = {'operand': 'not'}
+
+    def __init__(self, operand: PredicateType):
+        super().__init__(locals())
+
+
+class AndPredicate(ModelBase):
+    """Represents the "and" logical operation."""
+    _serialized_names = {'operands': 'and'}
+
+    def __init__(self, operands: TwoBooleanOperands):
+        super().__init__(locals())
+
+
+class OrPredicate(ModelBase):
+    """Represents the "or" logical operation."""
+    _serialized_names = {'operands': 'or'}
+
+    def __init__(self, operands: TwoBooleanOperands):
+        super().__init__(locals())
+
+
+class RetryStrategySpec(ModelBase):
+    _serialized_names = {
+        'max_retries': 'maxRetries',
+    }
+
+    def __init__(
+        self,
+        max_retries: int,
+    ):
+        super().__init__(locals())
+
+
+class CachingStrategySpec(ModelBase):
+    _serialized_names = {
+        'max_cache_staleness': 'maxCacheStaleness',
+    }
+
+    def __init__(
+            self,
+            max_cache_staleness: Optional[
+                str] = None,  # RFC3339 compliant duration: P30DT1H22M3S
+    ):
+        super().__init__(locals())
+
+
+class ExecutionOptionsSpec(ModelBase):
+    _serialized_names = {
+        'retry_strategy': 'retryStrategy',
+        'caching_strategy': 'cachingStrategy',
+    }
+
+    def __init__(
+        self,
+        retry_strategy: Optional[RetryStrategySpec] = None,
+        caching_strategy: Optional[CachingStrategySpec] = None,
+    ):
+        super().__init__(locals())
+
+
+class TaskSpec(ModelBase):
+    """Task specification.
+
+    Task is a "configured" component - a component supplied with arguments and other applied configuration changes.
+    """
+    _serialized_names = {
+        'component_ref': 'componentRef',
+        'is_enabled': 'isEnabled',
+        'execution_options': 'executionOptions'
+    }
+
+    def __init__(
+        self,
+        component_ref: ComponentReference,
+        arguments: Optional[Mapping[str, ArgumentType]] = None,
+        is_enabled: Optional[PredicateType] = None,
+        execution_options: Optional[ExecutionOptionsSpec] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(locals())
+        #TODO: If component_ref is resolved to component spec, then check that the arguments correspond to the inputs
+
+    def _init_outputs(self):
+        #Adding output references to the task
+        if self.component_ref.spec is None:
+            return
+        task_outputs = OrderedDict()
+        for output in self.component_ref.spec.outputs or []:
+            task_output_ref = TaskOutputReference(
+                output_name=output.name,
+                task=self,
+                type=output.
+                type,  # TODO: Resolve type expressions. E.g. type: {TypeOf: Input 1}
+            )
+            task_output_arg = TaskOutputArgument(task_output=task_output_ref)
+            task_outputs[output.name] = task_output_arg
+
+        self.outputs = task_outputs
+        if len(task_outputs) == 1:
+            self.output = list(task_outputs.values())[0]
+
+
+class GraphSpec(ModelBase):
+    """Describes the graph component implementation.
+
+    It represents a graph of component tasks connected to the upstream
+    sources of data using the argument specifications. It also describes
+    the sources of graph output values.
+    """
+    _serialized_names = {
+        'output_values': 'outputValues',
+    }
+
+    def __init__(
+        self,
+        tasks: Mapping[str, TaskSpec],
+        output_values: Mapping[str, ArgumentType] = None,
+    ):
+        super().__init__(locals())
+        self._post_init()
+
+    def _post_init(self):
+        #Checking task output references and preparing the dependency table
+        task_dependencies = {}
+        for task_id, task in self.tasks.items():
+            dependencies = set()
+            task_dependencies[task_id] = dependencies
+            if task.arguments is not None:
+                for argument in task.arguments.values():
+                    if isinstance(argument, TaskOutputArgument):
+                        dependencies.add(argument.task_output.task_id)
+                        if argument.task_output.task_id not in self.tasks:
+                            raise TypeError(
+                                'Argument "{}" references non-existing task.'
+                                .format(argument))
+
+        #Topologically sorting tasks to detect cycles
+        task_dependents = {k: set() for k in task_dependencies.keys()}
+        for task_id, dependencies in task_dependencies.items():
+            for dependency in dependencies:
+                task_dependents[dependency].add(task_id)
+        task_number_of_remaining_dependencies = {
+            k: len(v) for k, v in task_dependencies.items()
+        }
+        sorted_tasks = OrderedDict()
+
+        def process_task(task_id):
+            if task_number_of_remaining_dependencies[
+                    task_id] == 0 and task_id not in sorted_tasks:
+                sorted_tasks[task_id] = self.tasks[task_id]
+                for dependent_task in task_dependents[task_id]:
+                    task_number_of_remaining_dependencies[
+                        dependent_task] = task_number_of_remaining_dependencies[
+                            dependent_task] - 1
+                    process_task(dependent_task)
+
+        for task_id in task_dependencies.keys():
+            process_task(task_id)
+        if len(sorted_tasks) != len(task_dependencies):
+            tasks_with_unsatisfied_dependencies = {
+                k: v
+                for k, v in task_number_of_remaining_dependencies.items()
+                if v > 0
+            }
+            task_wth_minimal_number_of_unsatisfied_dependencies = min(
+                tasks_with_unsatisfied_dependencies.keys(),
+                key=lambda task_id: tasks_with_unsatisfied_dependencies[task_id]
+            )
+            raise ValueError('Task "{}" has cyclical dependency.'.format(
+                task_wth_minimal_number_of_unsatisfied_dependencies))
+
+        self._toposorted_tasks = sorted_tasks
+
+
+class GraphImplementation(ModelBase):
+    """Represents the graph component implementation."""
+
+    def __init__(
+        self,
+        graph: GraphSpec,
+    ):
+        super().__init__(locals())
+
+
+class PipelineRunSpec(ModelBase):
+    """The object that can be sent to the backend to start a new Run."""
+    _serialized_names = {
+        'root_task': 'rootTask',
+        #'on_exit_task': 'onExitTask',
+    }
+
+    def __init__(
+        self,
+        root_task: TaskSpec,
+        #on_exit_task: Optional[TaskSpec] = None,
+    ):
+        super().__init__(locals())

--- a/kfp/components/_yaml_utils.py
+++ b/kfp/components/_yaml_utils.py
@@ -1,0 +1,71 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import yaml
+from collections import OrderedDict
+
+
+def load_yaml(stream):
+    #!!! Yaml should only be loaded using this function. Otherwise the dict ordering may be broken in Python versions prior to 3.6
+    #See https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts/21912744#21912744
+
+    def ordered_load(stream,
+                     Loader=yaml.SafeLoader,
+                     object_pairs_hook=OrderedDict):
+
+        class OrderedLoader(Loader):
+            pass
+
+        def construct_mapping(loader, node):
+            loader.flatten_mapping(node)
+            return object_pairs_hook(loader.construct_pairs(node))
+
+        OrderedLoader.add_constructor(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+        return yaml.load(stream, OrderedLoader)
+
+    return ordered_load(stream)
+
+
+def dump_yaml(data):
+    #See https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts/21912744#21912744
+
+    def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+
+        class OrderedDumper(Dumper):
+            pass
+
+        def _dict_representer(dumper, data):
+            return dumper.represent_mapping(
+                yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
+
+        OrderedDumper.add_representer(OrderedDict, _dict_representer)
+        OrderedDumper.add_representer(dict, _dict_representer)
+
+        #Hack to force the code (multi-line string) to be output using the '|' style.
+        def represent_str_or_text(self, data):
+            style = None
+            if data.find('\n') >= 0:  #Multiple lines
+                #print('Switching style for multiline text:' + data)
+                style = '|'
+            if data.lower() in [
+                    'y', 'n', 'yes', 'no', 'true', 'false', 'on', 'off'
+            ]:
+                style = '"'
+            return self.represent_scalar(u'tag:yaml.org,2002:str', data, style)
+
+        OrderedDumper.add_representer(str, represent_str_or_text)
+
+        return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+    return ordered_dump(data, default_flow_style=None)

--- a/kfp/components/modelbase.py
+++ b/kfp/components/modelbase.py
@@ -1,0 +1,396 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'ModelBase',
+]
+
+import inspect
+from collections import abc, OrderedDict
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, TypeVar, Union, cast, get_type_hints
+
+T = TypeVar('T')
+
+
+def verify_object_against_type(x: Any, typ: Type[T]) -> T:
+    """Verifies that the object is compatible to the specified type (types from
+    the typing package can be used)."""
+    #TODO: Merge with parse_object_from_struct_based_on_type which has almost the same code
+    if typ is type(None):
+        if x is None:
+            return x
+        else:
+            raise TypeError('Error: Object "{}" is not None.'.format(x))
+
+    if typ is Any or type(typ) is TypeVar:
+        return x
+
+    try:  #isinstance can fail for generics
+        if isinstance(x, typ):
+            return cast(typ, x)
+    except:
+        pass
+
+    if hasattr(typ, '__origin__'):  #Handling generic types
+        if typ.__origin__ is Union:  #Optional == Union
+            exception_map = {}
+            possible_types = typ.__args__
+            if type(
+                    None
+            ) in possible_types and x is None:  #Shortcut for Optional[] tests. Can be removed, but the exceptions will be more noisy.
+                return x
+            for possible_type in possible_types:
+                try:
+                    verify_object_against_type(x, possible_type)
+                    return x
+                except Exception as ex:
+                    exception_map[possible_type] = ex
+                    pass
+            #exception_lines = ['Exception for type {}: {}.'.format(t, e) for t, e in exception_map.items()]
+            exception_lines = [str(e) for t, e in exception_map.items()]
+            exception_lines.append(
+                'Error: Object "{}" is incompatible with type "{}".'.format(
+                    x, typ))
+            raise TypeError('\n'.join(exception_lines))
+
+        #not Union => not None
+        if x is None:
+            raise TypeError(
+                'Error: None object is incompatible with type {}'.format(typ))
+
+        #assert isinstance(x, typ.__origin__)
+        generic_type = typ.__origin__ or getattr(
+            typ, '__extra__', None
+        )  #In python <3.7 typing.List.__origin__ == None; Python 3.7 has working __origin__, but no __extra__  TODO: Remove the __extra__ once we move to Python 3.7
+        if generic_type in [
+                list, List, abc.Sequence, abc.MutableSequence, Sequence,
+                MutableSequence
+        ] and type(x) is not str:  #! str is also Sequence
+            if not isinstance(x, generic_type):
+                raise TypeError(
+                    'Error: Object "{}" is incompatible with type "{}"'.format(
+                        x, typ))
+            # In Python <3.7 Mapping.__args__ is None.
+            # In Python 3.9 typ.__args__ does not exist when the generic type does not have subscripts
+            type_args = typ.__args__ if getattr(
+                typ, '__args__', None) is not None else (Any, Any)
+            inner_type = type_args[0]
+            for item in x:
+                verify_object_against_type(item, inner_type)
+            return x
+
+        elif generic_type in [
+                dict, Dict, abc.Mapping, abc.MutableMapping, Mapping,
+                MutableMapping, OrderedDict
+        ]:
+            if not isinstance(x, generic_type):
+                raise TypeError(
+                    'Error: Object "{}" is incompatible with type "{}"'.format(
+                        x, typ))
+            # In Python <3.7 Mapping.__args__ is None.
+            # In Python 3.9 typ.__args__ does not exist when the generic type does not have subscripts
+            type_args = typ.__args__ if getattr(
+                typ, '__args__', None) is not None else (Any, Any)
+            inner_key_type = type_args[0]
+            inner_value_type = type_args[1]
+            for k, v in x.items():
+                verify_object_against_type(k, inner_key_type)
+                verify_object_against_type(v, inner_value_type)
+            return x
+
+        else:
+            raise TypeError(
+                'Error: Unsupported generic type "{}". type.__origin__ or type.__extra__ == "{}"'
+                .format(typ, generic_type))
+
+    raise TypeError('Error: Object "{}" is incompatible with type "{}"'.format(
+        x, typ))
+
+
+def parse_object_from_struct_based_on_type(struct: Any, typ: Type[T]) -> T:
+    """Constructs an object from structure (usually dict) based on type.
+
+    Supports list and dict types from the typing package plus Optional[]
+    and Union[] types. If some type is a class that has .from_dict class
+    method, that method is used for object construction.
+    """
+    if typ is type(None):
+        if struct is None:
+            return None
+        else:
+            raise TypeError('Error: Structure "{}" is not None.'.format(struct))
+
+    if typ is Any or type(typ) is TypeVar:
+        return struct
+
+    try:  #isinstance can fail for generics
+        #if (isinstance(struct, typ)
+        #    and not (typ is Sequence and type(struct) is str) #! str is also Sequence
+        #    and not (typ is int and type(struct) is bool) #! bool is int
+        #):
+        if type(struct) is typ:
+            return struct
+    except:
+        pass
+    if hasattr(typ, 'from_dict'):
+        try:  #More informative errors
+            return typ.from_dict(struct)
+        except Exception as ex:
+            raise TypeError(
+                'Error: {}.from_dict(struct={}) failed with exception:\n{}'
+                .format(typ.__name__, struct, str(ex)))
+    if hasattr(typ, '__origin__'):  #Handling generic types
+        if typ.__origin__ is Union:  #Optional == Union
+            results = {}
+            exception_map = {}
+            # In Python 3.9 typ.__args__ does not exist when the generic type does not have subscripts
+            # Union without subscripts seems useless, but semantically it should be the same as Any.
+            possible_types = list(getattr(typ, '__args__', [Any]))
+            #if type(None) in possible_types and struct is None: #Shortcut for Optional[] tests. Can be removed, but the exceptions will be more noisy.
+            #    return None
+            #Hack for Python <3.7 which for some reason "simplifies" Union[bool, int, ...] to just Union[int, ...]
+            if int in possible_types:
+                possible_types = possible_types + [bool]
+            for possible_type in possible_types:
+                try:
+                    obj = parse_object_from_struct_based_on_type(
+                        struct, possible_type)
+                    results[possible_type] = obj
+                except Exception as ex:
+                    if isinstance(ex, TypeError):
+                        exception_map[possible_type] = ex
+                    else:
+                        exception_map[
+                            possible_type] = 'Unexpected exception when trying to convert structure "{}" to type "{}": {}: {}'.format(
+                                struct, typ, type(ex), ex)
+                    pass
+
+            #Single successful parsing.
+            if len(results) == 1:
+                return list(results.values())[0]
+
+            if len(results) > 1:
+                raise TypeError(
+                    'Error: Structure "{}" is ambiguous. It can be parsed to multiple types: {}.'
+                    .format(struct, list(results.keys())))
+
+            exception_lines = [str(e) for t, e in exception_map.items()]
+            exception_lines.append(
+                'Error: Structure "{}" is incompatible with type "{}" - none of the types in Union are compatible.'
+                .format(struct, typ))
+            raise TypeError('\n'.join(exception_lines))
+        #not Union => not None
+        if struct is None:
+            raise TypeError(
+                'Error: None structure is incompatible with type {}'.format(
+                    typ))
+
+        #assert isinstance(x, typ.__origin__)
+        generic_type = typ.__origin__ or getattr(
+            typ, '__extra__', None
+        )  #In python <3.7 typing.List.__origin__ == None; Python 3.7 has working __origin__, but no __extra__  TODO: Remove the __extra__ once we move to Python 3.7
+        if generic_type in [
+                list, List, abc.Sequence, abc.MutableSequence, Sequence,
+                MutableSequence
+        ] and type(struct) is not str:  #! str is also Sequence
+            if not isinstance(struct, generic_type):
+                raise TypeError(
+                    'Error: Structure "{}" is incompatible with type "{}" - it does not have list type.'
+                    .format(struct, typ))
+            # In Python <3.7 Mapping.__args__ is None.
+            # In Python 3.9 typ.__args__ does not exist when the generic type does not have subscripts
+            type_args = typ.__args__ if getattr(
+                typ, '__args__', None) is not None else (Any, Any)
+            inner_type = type_args[0]
+            return [
+                parse_object_from_struct_based_on_type(item, inner_type)
+                for item in struct
+            ]
+
+        elif generic_type in [
+                dict, Dict, abc.Mapping, abc.MutableMapping, Mapping,
+                MutableMapping, OrderedDict
+        ]:  #in Python <3.7 there is a difference between abc.Mapping and typing.Mapping
+            if not isinstance(struct, generic_type):
+                raise TypeError(
+                    'Error: Structure "{}" is incompatible with type "{}" - it does not have dict type.'
+                    .format(struct, typ))
+            # In Python <3.7 Mapping.__args__ is None.
+            # In Python 3.9 typ.__args__ does not exist when the generic type does not have subscripts
+            type_args = typ.__args__ if getattr(
+                typ, '__args__', None) is not None else (Any, Any)
+            inner_key_type = type_args[0]
+            inner_value_type = type_args[1]
+            return {
+                parse_object_from_struct_based_on_type(k, inner_key_type):
+                parse_object_from_struct_based_on_type(v, inner_value_type)
+                for k, v in struct.items()
+            }
+
+        else:
+            raise TypeError(
+                'Error: Unsupported generic type "{}". type.__origin__ or type.__extra__ == "{}"'
+                .format(typ, generic_type))
+
+    raise TypeError(
+        'Error: Structure "{}" is incompatible with type "{}". Structure is not the instance of the type, the type does not have .from_dict method and is not generic.'
+        .format(struct, typ))
+
+
+def convert_object_to_struct(obj, serialized_names: Mapping[str, str] = {}):
+    """Converts an object to structure (usually a dict).
+
+    Serializes all properties that do not start with underscores. If the
+    type of some property is a class that has .to_dict class method,
+    that method is used for conversion. Used by the ModelBase class.
+    """
+    signature = inspect.signature(obj.__init__)  #Needed for default values
+    result = {}
+    for python_name in signature.parameters:  #TODO: Make it possible to specify the field ordering regardless of the presence of default values
+        value = getattr(obj, python_name)
+        if python_name.startswith('_'):
+            continue
+        attr_name = serialized_names.get(python_name, python_name)
+        if hasattr(value, "to_dict"):
+            result[attr_name] = value.to_dict()
+        elif isinstance(value, list):
+            result[attr_name] = [
+                (x.to_dict() if hasattr(x, 'to_dict') else x) for x in value
+            ]
+        elif isinstance(value, dict):
+            result[attr_name] = {
+                k: (v.to_dict() if hasattr(v, 'to_dict') else v)
+                for k, v in value.items()
+            }
+        else:
+            param = signature.parameters.get(python_name, None)
+            if param is None or param.default == inspect.Parameter.empty or value != param.default:
+                result[attr_name] = value
+
+    return result
+
+
+def parse_object_from_struct_based_on_class_init(
+        cls: Type[T],
+        struct: Mapping,
+        serialized_names: Mapping[str, str] = {}) -> T:
+    """Constructs an object of specified class from structure (usually dict)
+    using the class.__init__ method. Converts all constructor arguments to
+    appropriate types based on the __init__ type hints. Used by the ModelBase
+    class.
+
+    Arguments:
+
+    serialized_names: specifies the mapping between __init__ parameter names and the structure key names for cases where these names are different (due to language syntax clashes or style differences).
+    """
+    parameter_types = get_type_hints(
+        cls.__init__)  #Properlty resolves forward references
+
+    serialized_names_to_pythonic = {v: k for k, v in serialized_names.items()}
+    #If a pythonic name has a different original name, we forbid the pythonic name in the structure. Otherwise, this function would accept "python-styled" structures that should be invalid
+    forbidden_struct_keys = set(
+        serialized_names_to_pythonic.values()).difference(
+            serialized_names_to_pythonic.keys())
+    args = {}
+    for original_name, value in struct.items():
+        if original_name in forbidden_struct_keys:
+            raise ValueError(
+                'Use "{}" key instead of pythonic key "{}" in the structure: {}.'
+                .format(serialized_names[original_name], original_name, struct))
+        python_name = serialized_names_to_pythonic.get(original_name,
+                                                       original_name)
+        param_type = parameter_types.get(python_name, None)
+        if param_type is not None:
+            args[python_name] = parse_object_from_struct_based_on_type(
+                value, param_type)
+        else:
+            args[python_name] = value
+
+    return cls(**args)
+
+
+class ModelBase:
+    """Base class for types that can be converted to JSON-like dict structures
+    or constructed from such structures. The object fields, their types and
+    default values are taken from the __init__ method arguments. Override the
+    _serialized_names mapping to control the key names of the serialized
+    structures.
+
+    The derived class objects will have the .from_dict and .to_dict methods for conversion to or from structure. The base class constructor accepts the arguments map, checks the argument types and sets the object field values.
+
+    Example derived class:
+
+    class TaskSpec(ModelBase):
+        _serialized_names = {
+            'component_ref': 'componentRef',
+            'is_enabled': 'isEnabled',
+        }
+
+        def __init__(self,
+            component_ref: ComponentReference,
+            arguments: Optional[Mapping[str, ArgumentType]] = None,
+            is_enabled: Optional[Union[ArgumentType, EqualsPredicate, NotEqualsPredicate]] = None, #Optional property with default value
+        ):
+            super().__init__(locals()) #Calling the ModelBase constructor to check the argument types and set the object field values.
+
+    task_spec = TaskSpec.from_dict("{'componentRef': {...}, 'isEnabled: {'and': {...}}}") # = instance of TaskSpec
+    task_struct = task_spec.to_dict() #= "{'componentRef': {...}, 'isEnabled: {'and': {...}}}"
+    """
+    _serialized_names = {}
+
+    def __init__(self, args):
+        parameter_types = get_type_hints(self.__class__.__init__)
+        field_values = {
+            k: v
+            for k, v in args.items()
+            if k != 'self' and not k.startswith('_')
+        }
+        for k, v in field_values.items():
+            parameter_type = parameter_types.get(k, None)
+            if parameter_type is not None:
+                try:
+                    verify_object_against_type(v, parameter_type)
+                except Exception as e:
+                    raise TypeError(
+                        'Argument for {} is not compatible with type "{}". Exception: {}'
+                        .format(k, parameter_type, e))
+        self.__dict__.update(field_values)
+
+    @classmethod
+    def from_dict(cls: Type[T], struct: Mapping) -> T:
+        return parse_object_from_struct_based_on_class_init(
+            cls, struct, serialized_names=cls._serialized_names)
+
+    def to_dict(self) -> Mapping:
+        return convert_object_to_struct(
+            self, serialized_names=self._serialized_names)
+
+    def _get_field_names(self):
+        return list(inspect.signature(self.__init__).parameters)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(' + ', '.join(
+            param + '=' + repr(getattr(self, param))
+            for param in self._get_field_names()) + ')'
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ and {
+            k: getattr(self, k) for k in self._get_field_names()
+        } == {k: getattr(other, k) for k in other._get_field_names()}
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(repr(self))

--- a/kfp/components/structures/__init__.py
+++ b/kfp/components/structures/__init__.py
@@ -1,0 +1,1 @@
+from .._structures import *

--- a/kfp/components/type_annotation_utils.py
+++ b/kfp/components/type_annotation_utils.py
@@ -1,0 +1,65 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for handling Python type annotation."""
+
+import re
+from typing import TypeVar, Union
+
+T = TypeVar('T')
+
+
+def maybe_strip_optional_from_annotation(annotation: T) -> T:
+    """Strips 'Optional' from 'Optional[<type>]' if applicable.
+
+    For example::
+      Optional[str] -> str
+      str -> str
+      List[int] -> List[int]
+
+    Args:
+      annotation: The original type annotation which may or may not has
+        `Optional`.
+
+    Returns:
+      The type inside Optional[] if Optional exists, otherwise the original type.
+    """
+    if getattr(annotation, '__origin__',
+               None) is Union and annotation.__args__[1] is type(None):
+        return annotation.__args__[0]
+    return annotation
+
+
+def get_short_type_name(type_name: str) -> str:
+    """Extracts the short form type name.
+
+    This method is used for looking up serializer for a given type.
+
+    For example::
+      typing.List -> List
+      typing.List[int] -> List
+      typing.Dict[str, str] -> Dict
+      List -> List
+      str -> str
+
+    Args:
+      type_name: The original type name.
+
+    Returns:
+      The short form type name or the original name if pattern doesn't match.
+    """
+    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    if match:
+        return match.group('type')
+    else:
+        return type_name

--- a/kfp/components/type_annotation_utils_test.py
+++ b/kfp/components/type_annotation_utils_test.py
@@ -1,0 +1,87 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.components.type_annoation_utils."""
+
+import unittest
+from absl.testing import parameterized
+from typing import Any, Dict, List, Optional
+
+from kfp.components import type_annotation_utils
+
+
+class TypeAnnotationUtilsTest(parameterized.TestCase):
+
+    @parameterized.parameters(
+        {
+            'original_annotation': str,
+            'expected_annotation': str,
+        },
+        {
+            'original_annotation': 'MyCustomType',
+            'expected_annotation': 'MyCustomType',
+        },
+        {
+            'original_annotation': List[int],
+            'expected_annotation': List[int],
+        },
+        {
+            'original_annotation': Optional[str],
+            'expected_annotation': str,
+        },
+        {
+            'original_annotation': Optional[Dict[str, float]],
+            'expected_annotation': Dict[str, float],
+        },
+        {
+            'original_annotation': Optional[List[Dict[str, Any]]],
+            'expected_annotation': List[Dict[str, Any]],
+        },
+    )
+    def test_maybe_strip_optional_from_annotation(self, original_annotation,
+                                                  expected_annotation):
+        self.assertEqual(
+            expected_annotation,
+            type_annotation_utils.maybe_strip_optional_from_annotation(
+                original_annotation))
+
+    @parameterized.parameters(
+        {
+            'original_type_name': 'str',
+            'expected_type_name': 'str',
+        },
+        {
+            'original_type_name': 'typing.List[int]',
+            'expected_type_name': 'List',
+        },
+        {
+            'original_type_name': 'List[int]',
+            'expected_type_name': 'List',
+        },
+        {
+            'original_type_name': 'Dict[str, str]',
+            'expected_type_name': 'Dict',
+        },
+        {
+            'original_type_name': 'List[Dict[str, str]]',
+            'expected_type_name': 'List',
+        },
+    )
+    def test_get_short_type_name(self, original_type_name, expected_type_name):
+        self.assertEqual(
+            expected_type_name,
+            type_annotation_utils.get_short_type_name(original_type_name))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/containers/__init__.py
+++ b/kfp/containers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the speci
+
+from ._build_image_api import *
+from ._container_builder import *

--- a/kfp/containers/_build_image_api.py
+++ b/kfp/containers/_build_image_api.py
@@ -1,0 +1,149 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the speci
+
+__all__ = [
+    'build_image_from_working_dir',
+    'default_image_builder',
+]
+
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+import requests
+
+from ._cache import calculate_recursive_dir_hash, try_read_value_from_cache, write_value_to_cache
+from ._container_builder import ContainerBuilder
+
+default_base_image = 'gcr.io/deeplearning-platform-release/tf-cpu.1-14'
+
+_container_work_dir = '/python_env'
+
+default_image_builder = ContainerBuilder()
+
+
+def _generate_dockerfile_text(context_dir: str,
+                              dockerfile_path: str,
+                              base_image: str = None) -> str:
+    # Generating the Dockerfile
+    logging.info('Generating the Dockerfile')
+
+    requirements_rel_path = 'requirements.txt'
+    requirements_path = os.path.join(context_dir, requirements_rel_path)
+    requirements_file_exists = os.path.exists(requirements_path)
+
+    if not base_image:
+        base_image = default_base_image
+    if callable(base_image):
+        base_image = base_image()
+
+    dockerfile_lines = []
+    dockerfile_lines.append('FROM {}'.format(base_image))
+    dockerfile_lines.append('WORKDIR {}'.format(_container_work_dir))
+    if requirements_file_exists:
+        dockerfile_lines.append('COPY {} .'.format(requirements_rel_path))
+        dockerfile_lines.append(
+            'RUN python3 -m pip install -r {}'.format(requirements_rel_path))
+    dockerfile_lines.append('COPY . .')
+
+    return '\n'.join(dockerfile_lines)
+
+
+def build_image_from_working_dir(image_name: str = None,
+                                 working_dir: str = None,
+                                 file_filter_re: str = r'.*\.py',
+                                 timeout: int = 1000,
+                                 base_image: str = None,
+                                 builder: ContainerBuilder = None) -> str:
+    """Builds and pushes a new container image that captures the current python
+    working directory.
+
+    This function recursively scans the working directory and captures the following files in the container image context:
+
+    * :code:`requirements.txt` files
+    * All python files (can be overridden by passing a different `file_filter_re` argument)
+
+    The function generates Dockerfile that starts from a python container image, install packages from requirements.txt (if present) and copies all the captured python files to the container image.
+    The Dockerfile can be overridden by placing a custom Dockerfile in the root of the working directory.
+
+    Args:
+        image_name: Optional. The image repo name where the new container image will be pushed. The name will be generated if not not set.
+        working_dir: Optional. The directory that will be captured. The current directory will be used if omitted.
+        file_filter_re: Optional. A regular expression that will be used to decide which files to include in the container building context.
+        timeout: Optional. The image building timeout in seconds.
+        base_image: Optional. The container image to use as the base for the new image. If not set, the Google Deep Learning Tensorflow CPU image will be used.
+        builder: Optional. An instance of :py:class:`kfp.containers.ContainerBuilder` or compatible class that will be used to build the image.
+          The default builder uses "kubeflow-pipelines-container-builder" service account in "kubeflow" namespace. It works with Kubeflow Pipelines clusters installed in "kubeflow" namespace using Google Cloud Marketplace or Standalone with version > 0.4.0.
+          If your Kubeflow Pipelines is installed in a different namespace, you should use :code:`ContainerBuilder(namespace='<your-kfp-namespace>', ...)`.
+
+          Depending on how you installed Kubeflow Pipelines, you need to configure your :code:`ContainerBuilder` instance's namespace and service_account:
+
+          * For clusters installed with Kubeflow >= 0.7, use :code:`ContainerBuilder(namespace='<your-user-namespace>', service_account='default-editor', ...)`. You can omit the namespace if you use kfp sdk from in-cluster notebook, it uses notebook namespace by default.
+          * For clusters installed with Kubeflow < 0.7, use :code:`ContainerBuilder(service_account='default', ...)`.
+          * For clusters installed using Google Cloud Marketplace or Standalone with version <= 0.4.0, use :code:`ContainerBuilder(namespace='<your-kfp-namespace>' service_account='default')`
+            You may refer to `installation guide <https://www.kubeflow.org/docs/pipelines/installation/overview/>`_ for more details about different installation options.
+
+    Returns:
+        The full name of the container image including the hash digest. E.g. :code:`gcr.io/my-org/my-image@sha256:86c1...793c`.
+    """
+    current_dir = working_dir or os.getcwd()
+    with tempfile.TemporaryDirectory() as context_dir:
+        logging.info(
+            'Creating the build context directory: {}'.format(context_dir))
+
+        # Copying all *.py and requirements.txt files
+        for dirpath, dirnames, filenames in os.walk(current_dir):
+            dst_dirpath = os.path.join(context_dir,
+                                       os.path.relpath(dirpath, current_dir))
+            os.makedirs(dst_dirpath, exist_ok=True)
+            for file_name in filenames:
+                if re.match(file_filter_re,
+                            file_name) or file_name == 'requirements.txt':
+                    src_path = os.path.join(dirpath, file_name)
+                    dst_path = os.path.join(dst_dirpath, file_name)
+                    shutil.copy(src_path, dst_path)
+
+        src_dockerfile_path = os.path.join(current_dir, 'Dockerfile')
+        dst_dockerfile_path = os.path.join(context_dir, 'Dockerfile')
+        if os.path.exists(src_dockerfile_path):
+            if base_image:
+                raise ValueError(
+                    'Cannot specify base_image when using custom Dockerfile (which already specifies the base image).'
+                )
+            shutil.copy(src_dockerfile_path, dst_dockerfile_path)
+        else:
+            dockerfile_text = _generate_dockerfile_text(context_dir,
+                                                        dst_dockerfile_path,
+                                                        base_image)
+            with open(dst_dockerfile_path, 'w') as f:
+                f.write(dockerfile_text)
+
+        cache_name = 'build_image_from_working_dir'
+        cache_key = calculate_recursive_dir_hash(context_dir)
+        cached_image_name = try_read_value_from_cache(cache_name, cache_key)
+        if cached_image_name:
+            return cached_image_name
+
+        if builder is None:
+            builder = default_image_builder
+        image_name = builder.build(
+            local_dir=context_dir,
+            target_image=image_name,
+            timeout=timeout,
+        )
+        if image_name:
+            write_value_to_cache(cache_name, cache_key, image_name)
+        return image_name

--- a/kfp/containers/_cache.py
+++ b/kfp/containers/_cache.py
@@ -1,0 +1,73 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the speci
+
+import hashlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+def calculate_file_hash(file_path: str):
+    block_size = 64 * 1024
+    sha = hashlib.sha256()
+    with open(file_path, 'rb') as fp:
+        while True:
+            data = fp.read(block_size)
+            if not data:
+                break
+            sha.update(data)
+    return sha.hexdigest()
+
+
+def calculate_recursive_dir_hash(root_dir_path: str):
+    path_hashes = {}
+    for dirpath, dirnames, filenames in os.walk(root_dir_path):
+        for file_name in filenames:
+            file_path = os.path.join(dirpath, file_name)
+            rel_file_path = os.path.relpath(file_path, root_dir_path)
+            file_hash = calculate_file_hash(file_path)
+            path_hashes[rel_file_path] = file_hash
+    binary_path_hash_lines = sorted(
+        path.encode('utf-8') + b'\t' + path_hash.encode('utf-8') + b'\n'
+        for path, path_hash in path_hashes.items())
+    binary_path_hash_doc = b''.join(binary_path_hash_lines)
+
+    full_hash = hashlib.sha256(binary_path_hash_doc).hexdigest()
+    return full_hash
+
+
+def try_read_value_from_cache(cache_type: str, key: str) -> str:
+    cache_file_path = Path(tempfile.tempdir) / cache_type / key
+    if cache_file_path.exists():
+        return cache_file_path.read_text()
+    return None
+
+
+def write_value_to_cache(cache_type: str, key: str, value: str):
+    cache_file_path = Path(tempfile.tempdir) / cache_type / key
+    if cache_file_path.exists():
+        old_value = cache_file_path.read_text()
+        if value != old_value:
+            import warnings
+            warnings.warn(
+                'Overwriting existing cache entry "{}" with value "{}" != "{}".'
+                .format(key, value, old_value))
+    cache_file_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_file_path.write_text(value)
+
+
+def clear_cache(cache_type: str):
+    cache_file_path = Path(tempfile.tempdir) / cache_type
+    if cache_file_path.exists():
+        shutil.rmtree(cache_file_path)

--- a/kfp/containers/_component_builder.py
+++ b/kfp/containers/_component_builder.py
@@ -1,0 +1,432 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+import logging
+import shutil
+from collections import OrderedDict
+from typing import Callable, Dict, List, Optional
+
+from deprecated.sphinx import deprecated
+
+from ..components._components import _create_task_factory_from_component_spec
+from ..components._python_op import _func_to_component_spec
+from ._container_builder import ContainerBuilder
+from kfp import components
+from kfp import dsl
+from kfp.components import _components
+from kfp.components import _structures
+
+V2_COMPONENT_ANNOTATION = 'pipelines.kubeflow.org/component_v2'
+_PROGRAM_LAUNCHER_CMD = 'program_path=$(mktemp)\nprintf "%s" "$0" > ' \
+                        '"$program_path"\npython3 -u "$program_path" "$@"\n'
+FN_NAME_ARG = 'function_name' # From deleted entrypoint module
+
+
+class VersionedDependency(object):
+    """DependencyVersion specifies the versions."""
+
+    def __init__(self, name, version=None, min_version=None, max_version=None):
+        """if version is specified, no need for min_version or max_version; if
+        both are specified, version is adopted."""
+        self._name = name
+        if version is not None:
+            self._min_version = version
+            self._max_version = version
+        else:
+            self._min_version = min_version
+            self._max_version = max_version
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def min_version(self):
+        return self._min_version
+
+    @min_version.setter
+    def min_version(self, min_version):
+        self._min_version = min_version
+
+    def has_min_version(self):
+        return self._min_version != None
+
+    @property
+    def max_version(self):
+        return self._max_version
+
+    @max_version.setter
+    def max_version(self, max_version):
+        self._max_version = max_version
+
+    def has_max_version(self):
+        return self._max_version != None
+
+    def has_versions(self):
+        return (self.has_min_version()) or (self.has_max_version())
+
+
+class DependencyHelper(object):
+    """DependencyHelper manages software dependency information."""
+
+    def __init__(self):
+        self._PYTHON_PACKAGE = 'PYTHON_PACKAGE'
+        self._dependency = {self._PYTHON_PACKAGE: OrderedDict()}
+
+    @property
+    def python_packages(self):
+        return self._dependency[self._PYTHON_PACKAGE]
+
+    def add_python_package(self, dependency, override=True):
+        """add_single_python_package adds a dependency for the python package.
+
+        Args:
+          name: package name
+          version: it could be a specific version(1.10.0), or a range(>=1.0,<=2.0)
+            if not specified, the default is resolved automatically by the pip system.
+          override: whether to override the version if already existing in the dependency.
+        """
+        if dependency.name in self.python_packages and not override:
+            return
+        self.python_packages[dependency.name] = dependency
+
+    def generate_pip_requirements(self, target_file):
+        """write the python packages to a requirement file the generated file
+        follows the order of which the packages are added."""
+        with open(target_file, 'w') as f:
+            for name, version in self.python_packages.items():
+                version = self.python_packages[name]
+                version_str = ''
+                if version.has_min_version():
+                    version_str += ' >= ' + version.min_version + ','
+                if version.has_max_version():
+                    version_str += ' <= ' + version.max_version + ','
+                f.write(name + version_str.rstrip(',') + '\n')
+
+
+def _dependency_to_requirements(dependency=[], filename='requirements.txt'):
+    """
+    Generates a requirement file based on the dependency
+    Args:
+      dependency (list): a list of VersionedDependency, which includes the package name and versions
+      filename (str): requirement file name, default as requirements.txt
+  """
+    dependency_helper = DependencyHelper()
+    for version in dependency:
+        dependency_helper.add_python_package(version)
+    dependency_helper.generate_pip_requirements(filename)
+
+
+def _generate_dockerfile(filename: str,
+                         base_image: str,
+                         requirement_filename: Optional[str] = None,
+                         add_files: Optional[Dict[str, str]] = None):
+    """
+    generates dockerfiles
+    Args:
+      filename (str): target file name for the dockerfile.
+      base_image (str): the base image name.
+      requirement_filename (str): requirement file name
+      add_files (Dict[str, str]): Map containing the files thats should be added to the container. add_files maps the build context relative source paths to the container destination paths.
+  """
+    with open(filename, 'w') as f:
+        f.write('FROM ' + base_image + '\n')
+        f.write(
+            'RUN apt-get update -y && apt-get install --no-install-recommends -y -q python3 python3-pip python3-setuptools\n'
+        )
+        if requirement_filename is not None:
+            f.write('ADD ' + requirement_filename + ' /ml/requirements.txt\n')
+            f.write('RUN python3 -m pip install -r /ml/requirements.txt\n')
+
+        for src_path, dst_path in (add_files or {}).items():
+            f.write('ADD ' + src_path + ' ' + dst_path + '\n')
+
+
+def _configure_logger(logger):
+    """_configure_logger configures the logger such that the info level logs go
+    to the stdout and the error(or above) level logs go to the stderr.
+
+    It is important for the Jupyter notebook log rendering
+    """
+    if hasattr(_configure_logger, 'configured'):
+        # Skip the logger configuration the second time this function
+        # is called to avoid multiple streamhandlers bound to the logger.
+        return
+    setattr(_configure_logger, 'configured', 'true')
+    logger.setLevel(logging.INFO)
+    info_handler = logging.StreamHandler(stream=sys.stdout)
+    info_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+    info_handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s:%(levelname)s:%(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'))
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.addFilter(lambda record: record.levelno > logging.INFO)
+    error_handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s:%(levelname)s:%(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'))
+    logger.addHandler(info_handler)
+    logger.addHandler(error_handler)
+
+
+def _purge_program_launching_code(
+        commands: List[str],
+        entrypoint_container_path: Optional[str] = None,
+        is_v2: bool = False) -> str:
+    """Replaces the inline Python code with calling a local program.
+
+    For example,
+    Before: sh -ec '... && python3 -u ...' 'import sys ...' --param1 ...
+    After:  python -u /ml/main.py --param1 ...
+
+    Args:
+      commands: The container commands to be replaced.
+      entrypoint_container_path: The path to the entrypoint program in the
+        container.
+      is_v2: Whether the component being generated is a v2 component. Default is
+        False.
+
+    Returns:
+      The originally generated inline Python code.
+    """
+    if not (is_v2 or entrypoint_container_path):
+        raise ValueError(
+            'Only v2 component has default entrypoint path. '
+            'Conventional KFP component needs to specify container '
+            'entrypoint explicitly. For example, /ml/main.py')
+    program_launcher_index = commands.index(_PROGRAM_LAUNCHER_CMD)
+    # When there're preinstallation package specified when converting to component
+    # spec the index will be 3, otherwise it'll be 2.
+    assert program_launcher_index in [2, 3]
+    program_code_index = program_launcher_index + 1
+    result = commands[program_code_index]
+    if is_v2:
+        # TODO: Implement the v2 component entrypoint on KFP.
+        # The following are just placeholders.
+        commands[program_code_index] = 'kfp.containers.entrypoint'
+        commands.pop(program_launcher_index)
+        commands[program_launcher_index - 1] = '-m'
+        commands[program_launcher_index - 2] = 'python'
+    else:
+        commands[program_code_index] = entrypoint_container_path
+        commands.pop(program_launcher_index)
+        commands[program_launcher_index - 1] = '-u'  # -ec => -u
+        # sh => python3 or python2
+        commands[program_launcher_index - 2] = 'python'
+
+    return result
+
+
+def build_python_component(
+        component_func: Callable,
+        target_image: str,
+        base_image: Optional[str] = None,
+        dependency: Optional[List[VersionedDependency]] = None,
+        staging_gcs_path: Optional[str] = None,
+        timeout: int = 600,
+        namespace: Optional[str] = None,
+        target_component_file: Optional[str] = None,
+        is_v2: bool = False):
+    """build_component automatically builds a container image for the
+    component_func based on the base_image and pushes to the target_image.
+
+    Args:
+      component_func (python function): The python function to build components
+        upon.
+      base_image (str): Docker image to use as a base image.
+      target_image (str): Full URI to push the target image.
+      staging_gcs_path (str): GCS blob that can store temporary build files.
+      target_image (str): The target image path.
+      timeout (int): The timeout for the image build(in secs), default is 600
+        seconds.
+      namespace (str): The namespace within which to run the kubernetes Kaniko
+        job. If the job is running on GKE and value is None the underlying
+        functions will use the default namespace from GKE.
+      dependency (list): The list of VersionedDependency, which includes the
+        package name and versions, default is empty.
+      target_component_file (str): The path to save the generated component YAML
+        spec.
+      is_v2: Whether or not generating a v2 KFP component, default
+        is false.
+
+    Raises:
+      ValueError: The function is not decorated with python_component decorator or
+        the python_version is neither python2 nor python3
+    """
+
+    _configure_logger(logging.getLogger())
+
+    if component_func is None:
+        raise ValueError('component_func must not be None')
+    if target_image is None:
+        raise ValueError('target_image must not be None')
+
+    if staging_gcs_path is None:
+        raise ValueError('staging_gcs_path must not be None')
+
+    if base_image is None:
+        base_image = getattr(component_func, '_component_base_image', None)
+    if base_image is None:
+        from ..components._python_op import default_base_image_or_builder
+        base_image = default_base_image_or_builder
+        if isinstance(base_image, Callable):
+            base_image = base_image()
+    if not dependency:
+        dependency = []
+
+    logging.info('Build an image that is based on ' + base_image +
+                 ' and push the image to ' + target_image)
+
+    component_spec = _func_to_component_spec(
+        component_func, base_image=base_image)
+
+    if is_v2:
+        # TODO: Remove this warning once we make v2 component compatible with KFP
+        # v1 stack.
+        logging.warning(
+            'Currently V2 component is only compatible with v2 KFP.')
+        # Annotate the component to be a V2 one.
+        if not component_spec.metadata:
+            component_spec.metadata = _structures.MetadataSpec()
+        if not component_spec.metadata.annotations:
+            component_spec.metadata.annotations = {}
+        component_spec.metadata.annotations[V2_COMPONENT_ANNOTATION] = 'true'
+
+    command_line_args = component_spec.implementation.container.command
+
+    # The relative path to put the Python program code.
+    program_path = 'ml/main.py'
+    # The relative path used when building a V2 component.
+    v2_entrypoint_path = None
+    # Python program code extracted from the component spec.
+    program_code = None
+
+    if is_v2:
+
+        program_code = _purge_program_launching_code(
+            commands=command_line_args, is_v2=True)
+
+        # Override user program args for new-styled component.
+        # TODO: The actual program args will be changed after we support v2
+        # component on KFP.
+        # For v2 component, the received command line args are fixed as follows:
+        # --executor_input_str
+        # {Executor input pb message at runtime}
+        # --function_name
+        # {The name of user defined function}
+        # --output_metadata_path
+        # {The place to write output metadata JSON file}
+        program_args = [
+            '--executor_input_str',
+            _structures.ExecutorInputPlaceholder(),
+            '--{}'.format(FN_NAME_ARG), component_func.__name__,
+            '--output_metadata_path',
+            _structures.OutputMetadataPlaceholder()
+        ]
+
+        component_spec.implementation.container.args = program_args
+    else:
+        program_code = _purge_program_launching_code(
+            commands=command_line_args,
+            entrypoint_container_path='/' + program_path)
+
+    arc_docker_filename = 'Dockerfile'
+    arc_requirement_filename = 'requirements.txt'
+
+    with tempfile.TemporaryDirectory() as local_build_dir:
+        # Write the program code to a file in the context directory
+        local_python_filepath = os.path.join(local_build_dir, program_path)
+        os.makedirs(os.path.dirname(local_python_filepath), exist_ok=True)
+
+        with open(local_python_filepath, 'w') as f:
+            f.write(program_code)
+
+        # Generate the python package requirements file in the context directory
+        local_requirement_filepath = os.path.join(local_build_dir,
+                                                  arc_requirement_filename)
+        if is_v2:
+            # For v2 components, KFP are expected to be packed in the container.
+            dependency.append(
+                VersionedDependency(name='kfp', min_version='1.4.0'))
+
+        _dependency_to_requirements(dependency, local_requirement_filepath)
+
+        # Generate Dockerfile in the context directory
+        local_docker_filepath = os.path.join(local_build_dir,
+                                             arc_docker_filename)
+        add_files = {program_path: '/' + program_path}
+
+        _generate_dockerfile(
+            local_docker_filepath,
+            base_image,
+            arc_requirement_filename,
+            add_files=add_files)
+
+        logging.info('Building and pushing container image.')
+        container_builder = ContainerBuilder(staging_gcs_path, target_image,
+                                             namespace)
+        image_name_with_digest = container_builder.build(
+            local_build_dir, arc_docker_filename, target_image, timeout)
+
+    component_spec.implementation.container.image = image_name_with_digest
+
+    # Optionally writing the component definition to a local file for sharing
+    target_component_file = target_component_file or getattr(
+        component_func, '_component_target_component_file', None)
+    if target_component_file:
+        component_spec.save(target_component_file)
+
+    task_factory_function = _create_task_factory_from_component_spec(
+        component_spec)
+    return task_factory_function
+
+
+@deprecated(
+    version='0.1.32',
+    reason='`build_docker_image` is deprecated. Use `kfp.containers.build_image_from_working_dir` instead.'
+)
+def build_docker_image(staging_gcs_path,
+                       target_image,
+                       dockerfile_path,
+                       timeout=600,
+                       namespace=None):
+    """build_docker_image automatically builds a container image based on the
+    specification in the dockerfile and pushes to the target_image.
+
+    Args:
+      staging_gcs_path (str): GCS blob that can store temporary build files
+      target_image (str): gcr path to push the final image
+      dockerfile_path (str): local path to the dockerfile
+      timeout (int): the timeout for the image build(in secs), default is 600 seconds
+      namespace (str): the namespace within which to run the kubernetes kaniko job. Default is None. If the
+      job is running on GKE and value is None the underlying functions will use the default namespace from GKE.
+    """
+    _configure_logger(logging.getLogger())
+
+    with tempfile.TemporaryDirectory() as local_build_dir:
+        dockerfile_rel_path = 'Dockerfile'
+        dst_dockerfile_path = os.path.join(local_build_dir, dockerfile_rel_path)
+        shutil.copyfile(dockerfile_path, dst_dockerfile_path)
+
+        container_builder = ContainerBuilder(
+            staging_gcs_path, target_image, namespace=namespace)
+        image_name_with_digest = container_builder.build(
+            local_build_dir, dockerfile_rel_path, target_image, timeout)
+
+    logging.info('Build image complete.')
+    return image_name_with_digest

--- a/kfp/containers/_container_builder.py
+++ b/kfp/containers/_container_builder.py
@@ -1,0 +1,230 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'ContainerBuilder',
+]
+
+import logging
+import tarfile
+import tempfile
+import os
+import uuid
+
+SERVICEACCOUNT_NAMESPACE = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+GCS_STAGING_BLOB_DEFAULT_PREFIX = 'kfp_container_build_staging'
+GCR_DEFAULT_IMAGE_SUFFIX = 'kfp_container'
+KANIKO_EXECUTOR_IMAGE_DEFAULT = 'gcr.io/kaniko-project/executor@sha256:78d44ec4e9cb5545d7f85c1924695c89503ded86a59f92c7ae658afa3cff5400'
+
+
+def _get_project_id():
+    import requests
+    URL = "http://metadata.google.internal/computeMetadata/v1/project/project-id"
+    headers = {'Metadata-Flavor': 'Google'}
+    r = requests.get(url=URL, headers=headers)
+    if not r.ok:
+        raise RuntimeError(
+            'ContainerBuilder failed to retrieve the project id.')
+    return r.text
+
+
+def _get_instance_id():
+    import requests
+    URL = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    headers = {'Metadata-Flavor': 'Google'}
+    r = requests.get(url=URL, headers=headers)
+    if not r.ok:
+        raise RuntimeError(
+            'ContainerBuilder failed to retrieve the instance id.')
+    return r.text
+
+
+class ContainerBuilder(object):
+    """ContainerBuilder helps build a container image."""
+
+    def __init__(self,
+                 gcs_staging=None,
+                 default_image_name=None,
+                 namespace=None,
+                 service_account='kubeflow-pipelines-container-builder',
+                 kaniko_executor_image=KANIKO_EXECUTOR_IMAGE_DEFAULT,
+                 k8s_client_configuration=None):
+        """
+    Args:
+      gcs_staging (str): GCS bucket/blob that can store temporary build files,
+          default is gs://PROJECT_ID/kfp_container_build_staging. You have to
+          specify this when it doesn't run in cluster.
+      default_image_name (str): Target container image name that will be used by the build method if the target_image argument is not specified.
+      namespace (str): Kubernetes namespace where the container builder pod is launched,
+          default is the same namespace as the notebook service account in cluster
+          or 'kubeflow' if not in cluster. If using the full Kubeflow
+          deployment and not in cluster, you should specify your own user namespace.
+      service_account (str): Kubernetes service account the pod uses for container building,
+          The default value is "kubeflow-pipelines-container-builder". It works with Kubeflow Pipelines clusters installed using Google Cloud Marketplace or Standalone with version > 0.4.0.
+          The service account should have permission to read and write from staging gcs path and upload built images to gcr.io.
+      kaniko_executor_image (str): Docker image used to run kaniko executor. Defaults to gcr.io/kaniko-project/executor:v0.10.0.
+      k8s_client_configuration (kubernetes.Configuration): Kubernetes client configuration object to be used when talking with Kubernetes API.
+        This is optional. If not specified, it will use the default configuration. This can be used to personalize the client used to talk to the Kubernetes server and change authentication parameters.
+    """
+        self._gcs_staging = gcs_staging
+        self._gcs_staging_checked = False
+        self._default_image_name = default_image_name
+        self._namespace = namespace
+        self._service_account = service_account
+        self._kaniko_image = kaniko_executor_image
+        self._k8s_client_configuration = k8s_client_configuration
+
+    def _get_namespace(self):
+        if self._namespace is None:
+            # Configure the namespace
+            if os.path.exists(SERVICEACCOUNT_NAMESPACE):
+                with open(SERVICEACCOUNT_NAMESPACE, 'r') as f:
+                    self._namespace = f.read()
+            else:
+                self._namespace = 'kubeflow'
+        return self._namespace
+
+    def _get_staging_location(self):
+        if self._gcs_staging_checked:
+            return self._gcs_staging
+
+        # Configure the GCS staging bucket
+        if self._gcs_staging is None:
+            try:
+                gcs_bucket = _get_project_id()
+            except:
+                raise ValueError(
+                    'Cannot get the Google Cloud project ID, please specify the gcs_staging argument.'
+                )
+            self._gcs_staging = 'gs://' + gcs_bucket + '/' + GCS_STAGING_BLOB_DEFAULT_PREFIX
+        else:
+            from pathlib import PurePath
+            path = PurePath(self._gcs_staging).parts
+            if len(path) < 2 or not path[0].startswith('gs'):
+                raise ValueError('Error: {} should be a GCS path.'.format(
+                    self._gcs_staging))
+            gcs_bucket = path[1]
+        from ._gcs_helper import GCSHelper
+        GCSHelper.create_gcs_bucket_if_not_exist(gcs_bucket)
+        self._gcs_staging_checked = True
+        return self._gcs_staging
+
+    def _get_default_image_name(self):
+        if self._default_image_name is None:
+            # KubeFlow Jupyter notebooks have environment variable with the notebook ID
+            try:
+                nb_id = os.environ.get('NB_PREFIX', _get_instance_id())
+            except:
+                raise ValueError('Please provide the default_image_name.')
+            nb_id = nb_id.replace('/', '-').strip('-')
+            self._default_image_name = os.path.join('gcr.io', _get_project_id(),
+                                                    nb_id,
+                                                    GCR_DEFAULT_IMAGE_SUFFIX)
+        return self._default_image_name
+
+    def _generate_kaniko_spec(self, context, docker_filename, target_image):
+        """_generate_kaniko_yaml generates kaniko job yaml based on a template
+        yaml."""
+        content = {
+            'apiVersion': 'v1',
+            'metadata': {
+                'generateName': 'kaniko-',
+                'namespace': self._get_namespace(),
+                'annotations': {
+                    'sidecar.istio.io/inject': 'false'
+                },
+            },
+            'kind': 'Pod',
+            'spec': {
+                'restartPolicy': 'Never',
+                'containers': [{
+                    'name': 'kaniko',
+                    'args': [
+                        '--cache=true',
+                        '--dockerfile=' + docker_filename,
+                        '--context=' + context,
+                        '--destination=' + target_image,
+                        '--digest-file=/dev/termination-log',  # This is suggested by the Kaniko devs as a way to return the image digest from Kaniko Pod. See https://github.com/GoogleContainerTools/kaniko#--digest-file
+                    ],
+                    'image': self._kaniko_image,
+                }],
+                'serviceAccountName': self._service_account
+            }
+        }
+        return content
+
+    def _wrap_dir_in_tarball(self, tarball_path, dir_name):
+        """_wrap_files_in_tarball creates a tarball for all the files in the
+        directory."""
+        if not tarball_path.endswith('.tar.gz'):
+            raise ValueError('the tarball path should end with .tar.gz')
+        with tarfile.open(tarball_path, 'w:gz') as tarball:
+            tarball.add(dir_name, arcname='')
+
+    def build(self,
+              local_dir,
+              docker_filename: str = 'Dockerfile',
+              target_image=None,
+              timeout=1000):
+        """
+    Args:
+      local_dir (str): local directory that stores all the necessary build files
+      docker_filename (str): the path of the Dockerfile relative to the local_dir
+      target_image (str): The container image name where the data will be pushed. Can include tag. If not specified, the function will use the default_image_name specified when creating ContainerBuilder.
+      timeout (int): time out in seconds. Default: 1000
+    """
+        target_image = target_image or self._get_default_image_name()
+        # Prepare build context
+        with tempfile.TemporaryDirectory() as local_build_dir:
+            from ._gcs_helper import GCSHelper
+            logging.info('Generate build files.')
+            local_tarball_path = os.path.join(local_build_dir,
+                                              'docker.tmp.tar.gz')
+            self._wrap_dir_in_tarball(local_tarball_path, local_dir)
+            # Upload to the context
+            context = os.path.join(self._get_staging_location(),
+                                   str(uuid.uuid4()) + '.tar.gz')
+            GCSHelper.upload_gcs_file(local_tarball_path, context)
+
+            # Run kaniko job
+            kaniko_spec = self._generate_kaniko_spec(
+                context=context,
+                docker_filename=docker_filename,
+                target_image=target_image)
+            logging.info('Start a kaniko job for build.')
+            from ._k8s_job_helper import K8sJobHelper
+            k8s_helper = K8sJobHelper(self._k8s_client_configuration)
+            result_pod_obj = k8s_helper.run_job(kaniko_spec, timeout)
+            logging.info('Kaniko job complete.')
+
+            # Clean up
+            GCSHelper.remove_gcs_blob(context)
+
+            # Returning image name with digest
+            (image_repo, _, image_tag) = target_image.partition(':')
+            # When Kaniko build completes successfully, the termination message is the hash digest of the newly built image. Otherwise it's empty. See https://github.com/GoogleContainerTools/kaniko#--digest-file https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message
+            termination_message = [
+                status.state.terminated.message
+                for status in result_pod_obj.status.container_statuses
+                if status.name == 'kaniko'
+            ][0]  # Note: Using status.state instead of status.last_state since last_state entries can still be None
+            image_digest = termination_message
+            if not image_digest.startswith('sha256:'):
+                raise RuntimeError(
+                    "Kaniko returned invalid image digest: {}".format(
+                        image_digest))
+            strict_image_name = image_repo + '@' + image_digest
+            logging.info(
+                'Built and pushed image: {}.'.format(strict_image_name))
+            return strict_image_name

--- a/kfp/containers/_gcs_helper.py
+++ b/kfp/containers/_gcs_helper.py
@@ -1,0 +1,115 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import tempfile
+
+
+class GCSHelper(object):
+    """GCSHelper manages the connection with the GCS storage."""
+
+    @staticmethod
+    def get_blob_from_gcs_uri(gcs_path):
+        """
+    Args:
+      gcs_path (str) : gcs blob path
+    Returns:
+      gcs_blob: gcs blob object(https://github.com/googleapis/google-cloud-python/blob/5c9bb42cb3c9250131cfeef6e0bafe8f4b7c139f/storage/google/cloud/storage/blob.py#L105)
+    """
+        from google.cloud import storage
+        pure_path = pathlib.PurePath(gcs_path)
+        gcs_bucket = pure_path.parts[1]
+        gcs_blob = '/'.join(pure_path.parts[2:])
+        client = storage.Client()
+        bucket = client.get_bucket(gcs_bucket)
+        blob = bucket.blob(gcs_blob)
+        return blob
+
+    @staticmethod
+    def upload_gcs_file(local_path, gcs_path):
+        """
+    Args:
+      local_path (str): local file path
+      gcs_path (str) : gcs blob path
+    """
+        blob = GCSHelper.get_blob_from_gcs_uri(gcs_path)
+        blob.upload_from_filename(local_path)
+
+    @staticmethod
+    def write_to_gcs_path(path: str, content: str) -> None:
+        """Writes serialized content to a GCS location.
+
+        Args:
+          path: GCS path to write to.
+          content: The content to be written.
+        """
+        fd, temp_path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, 'w') as tmp:
+                tmp.write(content)
+
+            if not GCSHelper.get_blob_from_gcs_uri(path):
+                pure_path = pathlib.PurePath(path)
+                gcs_bucket = pure_path.parts[1]
+                GCSHelper.create_gcs_bucket_if_not_exist(gcs_bucket)
+
+            GCSHelper.upload_gcs_file(temp_path, path)
+        finally:
+            os.remove(temp_path)
+
+    @staticmethod
+    def remove_gcs_blob(gcs_path):
+        """
+    Args:
+      gcs_path (str) : gcs blob path
+    """
+        blob = GCSHelper.get_blob_from_gcs_uri(gcs_path)
+        blob.delete()
+
+    @staticmethod
+    def download_gcs_blob(local_path, gcs_path):
+        """
+    Args:
+      local_path (str): local file path
+      gcs_path (str) : gcs blob path
+    """
+        blob = GCSHelper.get_blob_from_gcs_uri(gcs_path)
+        blob.download_to_filename(local_path)
+
+    @staticmethod
+    def read_from_gcs_path(gcs_path: str) -> str:
+        """Reads the content of a file hosted on GCS."""
+        fd, temp_path = tempfile.mkstemp()
+        try:
+            GCSHelper.download_gcs_blob(temp_path, gcs_path)
+            with os.fdopen(fd, 'r') as tmp:
+                result = tmp.read()
+        finally:
+            os.remove(temp_path)
+        return result
+
+    @staticmethod
+    def create_gcs_bucket_if_not_exist(gcs_bucket):
+        """
+    Args:
+      gcs_bucket (str) : gcs bucket name
+    """
+        from google.cloud import storage
+        from google.cloud.exceptions import NotFound
+        client = storage.Client()
+        try:
+            client.get_bucket(gcs_bucket)
+        except NotFound:
+            client.create_bucket(gcs_bucket)

--- a/kfp/containers/_k8s_job_helper.py
+++ b/kfp/containers/_k8s_job_helper.py
@@ -1,0 +1,163 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from kubernetes import client as k8s_client
+from kubernetes import config
+import time
+import logging
+import os
+
+
+class K8sJobHelper(object):
+    """Kubernetes Helper."""
+
+    def __init__(self, k8s_client_configuration=None):
+        if not self._configure_k8s(k8s_client_configuration):
+            raise Exception('K8sHelper __init__ failure')
+
+    def _configure_k8s(self, k8s_client_configuration=None):
+        k8s_config_file = os.environ.get('KUBECONFIG')
+        if k8s_config_file:
+            try:
+                logging.info('Loading kubernetes config from the file %s',
+                             k8s_config_file)
+                config.load_kube_config(
+                    config_file=k8s_config_file,
+                    client_configuration=k8s_client_configuration)
+            except Exception as e:
+                raise RuntimeError(
+                    'Can not load kube config from the file %s, error: %s',
+                    k8s_config_file, e)
+        else:
+            try:
+                config.load_incluster_config()
+                logging.info('Initialized with in-cluster config.')
+            except:
+                logging.info(
+                    'Cannot find in-cluster config, trying the local kubernetes config. '
+                )
+                try:
+                    config.load_kube_config(
+                        client_configuration=k8s_client_configuration)
+                    logging.info(
+                        'Found local kubernetes config. Initialized with kube_config.'
+                    )
+                except:
+                    raise RuntimeError(
+                        'Forgot to run the gcloud command? Check out the link: \
+          https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl for more information'
+                    )
+        self._api_client = k8s_client.ApiClient()
+        self._corev1 = k8s_client.CoreV1Api(self._api_client)
+        return True
+
+    def _create_k8s_job(self, yaml_spec):
+        """_create_k8s_job creates a kubernetes job based on the yaml spec."""
+        pod = k8s_client.V1Pod(
+            metadata=k8s_client.V1ObjectMeta(
+                generate_name=yaml_spec['metadata']['generateName'],
+                annotations=yaml_spec['metadata']['annotations']))
+        container = k8s_client.V1Container(
+            name=yaml_spec['spec']['containers'][0]['name'],
+            image=yaml_spec['spec']['containers'][0]['image'],
+            args=yaml_spec['spec']['containers'][0]['args'])
+        pod.spec = k8s_client.V1PodSpec(
+            restart_policy=yaml_spec['spec']['restartPolicy'],
+            containers=[container],
+            service_account_name=yaml_spec['spec']['serviceAccountName'])
+        try:
+            api_response = self._corev1.create_namespaced_pod(
+                yaml_spec['metadata']['namespace'], pod)
+            return api_response.metadata.name, True
+        except k8s_client.rest.ApiException as e:
+            logging.exception(
+                "Exception when calling CoreV1Api->create_namespaced_pod: {}\n"
+                .format(str(e)))
+            return '', False
+
+    def _wait_for_k8s_job(self, pod_name, yaml_spec, timeout):
+        """_wait_for_k8s_job waits for the job to complete."""
+        status = 'running'
+        start_time = datetime.now()
+        while status in ['pending', 'running']:
+            # Pod pending values: https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodStatus.md
+            try:
+                api_response = self._corev1.read_namespaced_pod(
+                    pod_name, yaml_spec['metadata']['namespace'])
+                status = api_response.status.phase.lower()
+                time.sleep(5)
+                elapsed_time = (datetime.now() - start_time).seconds
+                logging.info('{} seconds: waiting for job to complete'.format(
+                    elapsed_time))
+                if elapsed_time > timeout:
+                    logging.info('Kubernetes job timeout')
+                    return False
+            except k8s_client.rest.ApiException as e:
+                logging.exception(
+                    'Exception when calling CoreV1Api->read_namespaced_pod: {}\n'
+                    .format(str(e)))
+                return False
+        return status == 'succeeded'
+
+    def _delete_k8s_job(self, pod_name, yaml_spec):
+        """_delete_k8s_job deletes a pod."""
+        try:
+            api_response = self._corev1.delete_namespaced_pod(
+                pod_name,
+                yaml_spec['metadata']['namespace'],
+                body=k8s_client.V1DeleteOptions())
+        except k8s_client.rest.ApiException as e:
+            logging.exception(
+                'Exception when calling CoreV1Api->delete_namespaced_pod: {}\n'
+                .format(str(e)))
+
+    def _read_pod_log(self, pod_name, yaml_spec):
+        try:
+            api_response = self._corev1.read_namespaced_pod_log(
+                pod_name, yaml_spec['metadata']['namespace'])
+        except k8s_client.rest.ApiException as e:
+            logging.exception(
+                'Exception when calling CoreV1Api->read_namespaced_pod_log: {}\n'
+                .format(str(e)))
+            return False
+        return api_response
+
+    def _read_pod_status(self, pod_name, namespace):
+        try:
+            # Using read_namespaced_pod due to the following error: "pods \"kaniko-p2phh\" is forbidden: User \"system:serviceaccount:kubeflow:jupyter-notebook\" cannot get pods/status in the namespace \"kubeflow\""
+            #api_response = self._corev1.read_namespaced_pod_status(pod_name, namespace)
+            api_response = self._corev1.read_namespaced_pod(pod_name, namespace)
+        except k8s_client.rest.ApiException as e:
+            logging.exception(
+                'Exception when calling CoreV1Api->read_namespaced_pod_status: {}\n'
+                .format(str(e)))
+            return False
+        return api_response
+
+    def run_job(self, yaml_spec, timeout=600):
+        """run_job runs a kubernetes job and clean up afterwards."""
+        pod_name, succ = self._create_k8s_job(yaml_spec)
+        namespace = yaml_spec['metadata']['namespace']
+        if not succ:
+            raise RuntimeError('Kubernetes job creation failed.')
+        # timeout in seconds
+        succ = self._wait_for_k8s_job(pod_name, yaml_spec, timeout)
+        if not succ:
+            logging.info('Kubernetes job failed.')
+            print(self._read_pod_log(pod_name, yaml_spec))
+            raise RuntimeError('Kubernetes job failed.')
+        status_obj = self._read_pod_status(pod_name, namespace)
+        self._delete_k8s_job(pod_name, yaml_spec)
+        return status_obj

--- a/kfp/dsl/__init__.py
+++ b/kfp/dsl/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2018-2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
+from ._pipeline import Pipeline, PipelineExecutionMode, pipeline, get_pipeline_conf, PipelineConf
+from ._container_op import BaseOp, ContainerOp, InputArgumentPath, UserContainer, Sidecar
+from ._resource_op import ResourceOp
+from ._volume_op import VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM
+from ._pipeline_volume import PipelineVolume
+from ._volume_snapshot_op import VolumeSnapshotOp
+from ._ops_group import OpsGroup, ExitHandler, Condition, ParallelFor, SubGraph
+from ._component import python_component, graph_component, component
+
+
+EXECUTION_ID_PLACEHOLDER = '{{workflow.uid}}-{{pod.name}}'
+RUN_ID_PLACEHOLDER = '{{workflow.uid}}'
+
+ROOT_PARAMETER_NAME = 'pipeline-root'

--- a/kfp/dsl/_component.py
+++ b/kfp/dsl/_component.py
@@ -1,0 +1,169 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from deprecated.sphinx import deprecated
+from ._pipeline_param import PipelineParam
+from .types import check_types, InconsistentTypeException
+from ._ops_group import Graph
+import kfp
+
+
+@deprecated(
+    version='0.2.6',
+    reason='This decorator does not seem to be used, so we deprecate it. '
+    'If you need this decorator, please create an issue at '
+    'https://github.com/kubeflow/pipelines/issues',
+)
+def python_component(name,
+                     description=None,
+                     base_image=None,
+                     target_component_file: str = None):
+    """Decorator for Python component functions.
+
+    This decorator adds the metadata to the function object itself.
+
+    Args:
+      name: Human-readable name of the component
+      description: Optional. Description of the component
+      base_image: Optional. Docker container image to use as the base of the
+        component. Needs to have Python 3.5+ installed.
+      target_component_file: Optional. Local file to store the component
+        definition. The file can then be used for sharing.
+
+    Returns:
+      The same function (with some metadata fields set).
+
+    Example:
+      ::
+
+        @dsl.python_component(
+          name='my awesome component',
+          description='Come, Let's play',
+          base_image='tensorflow/tensorflow:1.11.0-py3',
+        )
+        def my_component(a: str, b: int) -> str:
+          ...
+    """
+
+    def _python_component(func):
+        func._component_human_name = name
+        if description:
+            func._component_description = description
+        if base_image:
+            func._component_base_image = base_image
+        if target_component_file:
+            func._component_target_component_file = target_component_file
+        return func
+
+    return _python_component
+
+
+def component(func):
+    """Decorator for component functions that returns a ContainerOp.
+
+    This is useful to enable type checking in the DSL compiler.
+
+    Example:
+      ::
+
+        @dsl.component
+        def foobar(model: TFModel(), step: MLStep()):
+          return dsl.ContainerOp()
+    """
+    from functools import wraps
+
+    @wraps(func)
+    def _component(*args, **kargs):
+        from ..components._python_op import _extract_component_interface
+        component_meta = _extract_component_interface(func)
+        if kfp.TYPE_CHECK:
+            arg_index = 0
+            for arg in args:
+                if isinstance(arg, PipelineParam) and not check_types(
+                        arg.param_type, component_meta.inputs[arg_index].type):
+                    raise InconsistentTypeException(
+                        'Component "' + component_meta.name +
+                        '" is expecting ' +
+                        component_meta.inputs[arg_index].name + ' to be type(' +
+                        str(component_meta.inputs[arg_index].type) +
+                        '), but the passed argument is type(' +
+                        str(arg.param_type) + ')')
+                arg_index += 1
+            if kargs is not None:
+                for key in kargs:
+                    if isinstance(kargs[key], PipelineParam):
+                        for input_spec in component_meta.inputs:
+                            if input_spec.name == key and not check_types(
+                                    kargs[key].param_type, input_spec.type):
+                                raise InconsistentTypeException(
+                                    'Component "' + component_meta.name +
+                                    '" is expecting ' + input_spec.name +
+                                    ' to be type(' + str(input_spec.type) +
+                                    '), but the passed argument is type(' +
+                                    str(kargs[key].param_type) + ')')
+
+        container_op = func(*args, **kargs)
+        container_op._set_metadata(component_meta)
+        return container_op
+
+    return _component
+
+
+#TODO: combine the component and graph_component decorators into one
+def graph_component(func):
+    """Decorator for graph component functions.
+
+    This decorator returns an ops_group.
+
+    Example:
+      ::
+
+        # Warning: caching is tricky when recursion is involved. Please be careful
+        # and set proper max_cache_staleness in case of infinite loop.
+        import kfp.dsl as dsl
+        @dsl.graph_component
+        def flip_component(flip_result):
+          print_flip = PrintOp(flip_result)
+          flipA = FlipCoinOp().after(print_flip)
+          flipA.execution_options.caching_strategy.max_cache_staleness = "P0D"
+          with dsl.Condition(flipA.output == 'heads'):
+            flip_component(flipA.output)
+          return {'flip_result': flipA.output}
+    """
+    from functools import wraps
+
+    @wraps(func)
+    def _graph_component(*args, **kargs):
+        # We need to make sure that the arguments are correctly mapped to inputs
+        # regardless of the passing order
+        signature = inspect.signature(func)
+        bound_arguments = signature.bind(*args, **kargs)
+        graph_ops_group = Graph(func.__name__)
+        graph_ops_group.inputs = list(bound_arguments.arguments.values())
+        graph_ops_group.arguments = bound_arguments.arguments
+        for input in graph_ops_group.inputs:
+            if not isinstance(input, PipelineParam):
+                raise ValueError('arguments to ' + func.__name__ +
+                                 ' should be PipelineParams.')
+
+        # Entering the Graph Context
+        with graph_ops_group:
+            # Call the function
+            if not graph_ops_group.recursive_ref:
+                func(*args, **kargs)
+
+        return graph_ops_group
+
+    return _graph_component

--- a/kfp/dsl/_component_bridge.py
+++ b/kfp/dsl/_component_bridge.py
@@ -1,0 +1,312 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import copy
+import inspect
+import json
+import pathlib
+from typing import Any, Mapping, Optional
+
+import kfp
+from kfp.components import _structures
+from kfp.components import _components
+from kfp.components import _naming
+from kfp import dsl
+from kfp.dsl import _container_op
+from kfp.dsl import _for_loop
+from kfp.dsl import _pipeline_param
+from kfp.dsl import dsl_utils
+from kfp.dsl import types
+
+# Placeholder to represent the output directory hosting all the generated URIs.
+# Its actual value will be specified during pipeline compilation.
+# The format of OUTPUT_DIR_PLACEHOLDER is serialized dsl.PipelineParam, to
+# ensure being extracted as a pipeline parameter during compilation.
+# Note that we cannot direclty import dsl module here due to circular
+# dependencies.
+OUTPUT_DIR_PLACEHOLDER = '{{pipelineparam:op=;name=pipeline-root}}'
+# Placeholder to represent to UID of the current pipeline at runtime.
+# Will be replaced by engine-specific placeholder during compilation.
+RUN_ID_PLACEHOLDER = '{{kfp.run_uid}}'
+# Format of the Argo parameter used to pass the producer's Pod ID to
+# the consumer.
+PRODUCER_POD_NAME_PARAMETER = '{}-producer-pod-id-'
+# Format of the input output port name placeholder.
+INPUT_OUTPUT_NAME_PATTERN = '{{{{kfp.input-output-name.{}}}}}'
+# Fixed name for per-task output metadata json file.
+OUTPUT_METADATA_JSON = '/tmp/outputs/executor_output.json'
+# Executor input placeholder.
+_EXECUTOR_INPUT_PLACEHOLDER = '{{$}}'
+
+
+# TODO(chensun): block URI placeholder usage in v1.
+def _generate_output_uri_placeholder(port_name: str) -> str:
+    """Generates the URI placeholder for an output."""
+    return "{{{{$.outputs.artifacts['{}'].uri}}}}".format(port_name)
+
+
+def _generate_input_uri_placeholder(port_name: str) -> str:
+    """Generates the URI placeholder for an input."""
+    return "{{{{$.inputs.artifacts['{}'].uri}}}}".format(port_name)
+
+
+def _generate_output_metadata_path() -> str:
+    """Generates the URI to write the output metadata JSON file."""
+
+    return OUTPUT_METADATA_JSON
+
+
+def _generate_input_metadata_path(port_name: str) -> str:
+    """Generates the placeholder for input artifact metadata file."""
+
+    # Return a placeholder for path to input artifact metadata, which will be
+    # rewritten during pipeline compilation.
+    return str(
+        pathlib.PurePosixPath(
+            OUTPUT_DIR_PLACEHOLDER, RUN_ID_PLACEHOLDER,
+            '{{{{inputs.parameters.{input}}}}}'.format(
+                input=PRODUCER_POD_NAME_PARAMETER.format(port_name)),
+            OUTPUT_METADATA_JSON))
+
+
+def _generate_input_output_name(port_name: str) -> str:
+    """Generates the placeholder for input artifact's output name."""
+
+    # Return a placeholder for the output port name of the input artifact, which
+    # will be rewritten during pipeline compilation.
+    return INPUT_OUTPUT_NAME_PATTERN.format(port_name)
+
+
+def _generate_executor_input() -> str:
+    """Generates the placeholder for serialized executor input."""
+    return _EXECUTOR_INPUT_PLACEHOLDER
+
+
+class ExtraPlaceholderResolver:
+
+    def __init__(self):
+        self.input_paths = {}
+        self.input_metadata_paths = {}
+        self.output_paths = {}
+
+    def resolve_placeholder(
+        self,
+        arg,
+        component_spec: _structures.ComponentSpec,
+        arguments: dict,
+    ) -> str:
+        inputs_dict = {
+            input_spec.name: input_spec
+            for input_spec in component_spec.inputs or []
+        }
+
+        if isinstance(arg, _structures.InputUriPlaceholder):
+            input_name = arg.input_name
+            if input_name in arguments:
+                input_uri = _generate_input_uri_placeholder(input_name)
+                self.input_paths[
+                    input_name] = _components._generate_input_file_name(
+                        input_name)
+                return input_uri
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    return None
+                else:
+                    raise ValueError(
+                        'No value provided for input {}'.format(input_name))
+
+        elif isinstance(arg, _structures.OutputUriPlaceholder):
+            output_name = arg.output_name
+            output_uri = _generate_output_uri_placeholder(output_name)
+            self.output_paths[
+                output_name] = _components._generate_output_file_name(
+                    output_name)
+            return output_uri
+
+        elif isinstance(arg, _structures.InputMetadataPlaceholder):
+            input_name = arg.input_name
+            if input_name in arguments:
+                input_metadata_path = _generate_input_metadata_path(input_name)
+                self.input_metadata_paths[input_name] = input_metadata_path
+                return input_metadata_path
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    return None
+                else:
+                    raise ValueError(
+                        'No value provided for input {}'.format(input_name))
+
+        elif isinstance(arg, _structures.InputOutputPortNamePlaceholder):
+            input_name = arg.input_name
+            if input_name in arguments:
+                return _generate_input_output_name(input_name)
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    return None
+                else:
+                    raise ValueError(
+                        'No value provided for input {}'.format(input_name))
+
+        elif isinstance(arg, _structures.OutputMetadataPlaceholder):
+            # TODO: Consider making the output metadata per-artifact.
+            return _generate_output_metadata_path()
+        elif isinstance(arg, _structures.ExecutorInputPlaceholder):
+            return _generate_executor_input()
+
+        return None
+
+
+def _create_container_op_from_component_and_arguments(
+    component_spec: _structures.ComponentSpec,
+    arguments: Mapping[str, Any],
+    component_ref: Optional[_structures.ComponentReference] = None,
+) -> _container_op.ContainerOp:
+    """Instantiates ContainerOp object.
+
+    Args:
+      component_spec: The component spec object.
+      arguments: The dictionary of component arguments.
+      component_ref: (only for v1) The component references.
+
+    Returns:
+      A ContainerOp instance.
+    """
+    # Add component inputs with default value to the arguments dict if they are not
+    # in the arguments dict already.
+    arguments = arguments.copy()
+    for input_spec in component_spec.inputs or []:
+        if input_spec.name not in arguments and input_spec.default is not None:
+            default_value = input_spec.default
+            if input_spec.type == 'Integer':
+                default_value = int(default_value)
+            elif input_spec.type == 'Float':
+                default_value = float(default_value)
+            arguments[input_spec.name] = default_value
+
+    # Check types of the reference arguments and serialize PipelineParams
+    original_arguments = arguments
+    arguments = arguments.copy()
+    for input_name, argument_value in arguments.items():
+        if isinstance(argument_value, _pipeline_param.PipelineParam):
+            input_type = component_spec._inputs_dict[input_name].type
+            argument_type = argument_value.param_type
+            types.verify_type_compatibility(
+                argument_type, input_type,
+                'Incompatible argument passed to the input "{}" of component "{}": '
+                .format(input_name, component_spec.name))
+
+            arguments[input_name] = str(argument_value)
+        if isinstance(argument_value, _container_op.ContainerOp):
+            raise TypeError(
+                'ContainerOp object was passed to component as an input argument. '
+                'Pass a single output instead.')
+    placeholder_resolver = ExtraPlaceholderResolver()
+    resolved_cmd = _components._resolve_command_line_and_paths(
+        component_spec=component_spec,
+        arguments=arguments,
+        placeholder_resolver=placeholder_resolver.resolve_placeholder,
+    )
+
+    container_spec = component_spec.implementation.container
+
+    old_warn_value = _container_op.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING
+    _container_op.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+
+    output_paths = collections.OrderedDict(resolved_cmd.output_paths or {})
+    output_paths.update(placeholder_resolver.output_paths)
+    input_paths = collections.OrderedDict(resolved_cmd.input_paths or {})
+    input_paths.update(placeholder_resolver.input_paths)
+
+    artifact_argument_paths = [
+        dsl.InputArgumentPath(
+            argument=arguments[input_name],
+            input=input_name,
+            path=path,
+        ) for input_name, path in input_paths.items()
+    ]
+
+    task = _container_op.ContainerOp(
+        name=component_spec.name or _components._default_component_name,
+        image=container_spec.image,
+        command=resolved_cmd.command,
+        arguments=resolved_cmd.args,
+        file_outputs=output_paths,
+        artifact_argument_paths=artifact_argument_paths,
+    )
+    _container_op.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = old_warn_value
+
+    component_meta = copy.copy(component_spec)
+    task._set_metadata(component_meta, original_arguments)
+    if component_ref:
+        component_ref_without_spec = copy.copy(component_ref)
+        component_ref_without_spec.spec = None
+        task._component_ref = component_ref_without_spec
+
+    task._parameter_arguments = resolved_cmd.inputs_consumed_by_value
+    name_to_spec_type = {}
+    if component_meta.inputs:
+        name_to_spec_type = {
+            input.name: input.type for input in component_meta.inputs
+        }
+
+    for name in list(task.artifact_arguments.keys()):
+        if name in task._parameter_arguments:
+            del task.artifact_arguments[name]
+
+    for name in list(task.input_artifact_paths.keys()):
+        if name in task._parameter_arguments:
+            del task.input_artifact_paths[name]
+
+    # Previously, ContainerOp had strict requirements for the output names, so we
+    # had to convert all the names before passing them to the ContainerOp
+    # constructor.
+    # Outputs with non-pythonic names could not be accessed using their original
+    # names. Now ContainerOp supports any output names, so we're now using the
+    # original output names. However to support legacy pipelines, we're also
+    # adding output references with pythonic names.
+    # TODO: Add warning when people use the legacy output names.
+    output_names = [
+        output_spec.name for output_spec in component_spec.outputs or []
+    ]  # Stabilizing the ordering
+    output_name_to_python = _naming.generate_unique_name_conversion_table(
+        output_names, _naming._sanitize_python_function_name)
+    for output_name in output_names:
+        pythonic_output_name = output_name_to_python[output_name]
+        # Note: Some component outputs are currently missing from task.outputs
+        # (e.g. MLPipeline UI Metadata)
+        if pythonic_output_name not in task.outputs and output_name in task.outputs:
+            task.outputs[pythonic_output_name] = task.outputs[output_name]
+
+    if container_spec.env:
+        from kubernetes import client as k8s_client
+        for name, value in container_spec.env.items():
+            task.container.add_env_variable(
+                k8s_client.V1EnvVar(name=name, value=value))
+
+    if component_spec.metadata:
+        annotations = component_spec.metadata.annotations or {}
+        for key, value in annotations.items():
+            task.add_pod_annotation(key, value)
+        for key, value in (component_spec.metadata.labels or {}).items():
+            task.add_pod_label(key, value)
+        # Disabling the caching for the volatile components by default
+        if annotations.get('volatile_component', 'false') == 'true':
+            task.execution_options.caching_strategy.max_cache_staleness = 'P0D'
+
+    return task
+

--- a/kfp/dsl/_container_op.py
+++ b/kfp/dsl/_container_op.py
@@ -1,0 +1,1553 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import warnings
+from typing import (Any, Callable, Dict, List, Optional, Sequence, Tuple,
+                    TypeVar, Union)
+
+import kfp
+from kfp.components import _components, _structures
+from kfp.dsl import _pipeline_param, dsl_utils
+from kubernetes.client import V1Affinity, V1Toleration
+from kubernetes.client.models import (V1Container, V1ContainerPort,
+                                      V1EnvFromSource, V1EnvVar, V1Lifecycle,
+                                      V1Probe, V1ResourceRequirements,
+                                      V1SecurityContext, V1Volume,
+                                      V1VolumeDevice, V1VolumeMount)
+
+# generics
+T = TypeVar('T')
+# type alias: either a string or a list of string
+StringOrStringList = Union[str, List[str]]
+ContainerOpArgument = Union[str, int, float, bool,
+                            _pipeline_param.PipelineParam]
+ArgumentOrArguments = Union[ContainerOpArgument, List]
+
+ALLOWED_RETRY_POLICIES = (
+    'Always',
+    'OnError',
+    'OnFailure',
+    'OnTransientError',
+)
+
+# Unit constants for k8s size string.
+_E = 10**18  # Exa
+_EI = 1 << 60  # Exa: power-of-two approximate
+_P = 10**15  # Peta
+_PI = 1 << 50  # Peta: power-of-two approximate
+# noinspection PyShadowingBuiltins
+_T = 10**12  # Tera
+_TI = 1 << 40  # Tera: power-of-two approximate
+_G = 10**9  # Giga
+_GI = 1 << 30  # Giga: power-of-two approximate
+_M = 10**6  # Mega
+_MI = 1 << 20  # Mega: power-of-two approximate
+_K = 10**3  # Kilo
+_KI = 1 << 10  # Kilo: power-of-two approximate
+
+_GKE_ACCELERATOR_LABEL = 'cloud.google.com/gke-accelerator'
+
+_DEFAULT_CUSTOM_JOB_MACHINE_TYPE = 'n1-standard-4'
+
+
+# util functions
+def deprecation_warning(func: Callable, op_name: str,
+                        container_name: str) -> Callable:
+    """Decorator function to give a pending deprecation warning."""
+
+    def _wrapped(*args, **kwargs):
+        warnings.warn(
+            '`dsl.ContainerOp.%s` will be removed in future releases. '
+            'Use `dsl.ContainerOp.container.%s` instead.' %
+            (op_name, container_name), PendingDeprecationWarning)
+        return func(*args, **kwargs)
+
+    return _wrapped
+
+
+def _create_getter_setter(prop):
+    """Create a tuple of getter and setter methods for a property in
+    `Container`."""
+
+    def _getter(self):
+        return getattr(self._container, prop)
+
+    def _setter(self, value):
+        return setattr(self._container, prop, value)
+
+    return _getter, _setter
+
+
+def _proxy_container_op_props(cls: 'ContainerOp'):
+    """Takes the `ContainerOp` class and proxy the PendingDeprecation
+    properties in `ContainerOp` to the `Container` instance."""
+    # properties mapping to proxy: ContainerOps.<prop> => Container.<prop>
+    prop_map = dict(image='image', env_variables='env')
+    # itera and create class props
+    for op_prop, container_prop in prop_map.items():
+        # create getter and setter
+        _getter, _setter = _create_getter_setter(container_prop)
+        # decorate with deprecation warning
+        getter = deprecation_warning(_getter, op_prop, container_prop)
+        setter = deprecation_warning(_setter, op_prop, container_prop)
+        # update attribites with properties
+        setattr(cls, op_prop, property(getter, setter))
+    return cls
+
+
+def as_string_list(
+        list_or_str: Optional[Union[Any, Sequence[Any]]]) -> List[str]:
+    """Convert any value except None to a list if not already a list."""
+    if list_or_str is None:
+        return None
+    if isinstance(list_or_str, Sequence) and not isinstance(list_or_str, str):
+        list_value = list_or_str
+    else:
+        list_value = [list_or_str]
+    return [str(item) for item in list_value]
+
+
+def create_and_append(current_list: Union[List[T], None], item: T) -> List[T]:
+    """Create a list (if needed) and appends an item to it."""
+    current_list = current_list or []
+    current_list.append(item)
+    return current_list
+
+
+class Container(V1Container):
+    """A wrapper over k8s container definition object
+    (io.k8s.api.core.v1.Container), which is used to represent the `container`
+    property in argo's workflow template
+    (io.argoproj.workflow.v1alpha1.Template).
+
+    `Container` class also comes with utility functions to set and update the
+    the various properties for a k8s container definition.
+
+    NOTE: A notable difference is that `name` is not required and will not be
+    processed for `Container` (in contrast to `V1Container` where `name` is a
+    required property).
+
+    See:
+    *
+    https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container.py
+    * https://github.com/argoproj/argo-workflows/blob/master/api/openapi-spec/swagger.json
+
+    Example::
+
+      from kfp.dsl import ContainerOp
+      from kubernetes.client.models import V1EnvVar
+
+
+      # creates a operation
+      op = ContainerOp(name='bash-ops',
+                      image='busybox:latest',
+                      command=['echo'],
+                      arguments=['$MSG'])
+
+      # returns a `Container` object from `ContainerOp`
+      # and add an environment variable to `Container`
+      op.container.add_env_variable(V1EnvVar(name='MSG', value='hello world'))
+
+    Attributes:
+      attribute_map (dict): The key is attribute name and the value is json key
+        in definition.
+    """
+    # remove `name` from attribute_map, swagger_types and openapi_types so `name` is not generated in the JSON
+
+    if hasattr(V1Container, 'swagger_types'):
+        swagger_types = {
+            key: value
+            for key, value in V1Container.swagger_types.items()
+            if key != 'name'
+        }
+    if hasattr(V1Container, 'openapi_types'):
+        openapi_types = {
+            key: value
+            for key, value in V1Container.openapi_types.items()
+            if key != 'name'
+        }
+    attribute_map = {
+        key: value
+        for key, value in V1Container.attribute_map.items()
+        if key != 'name'
+    }
+
+    def __init__(self, image: str, command: List[str], args: List[str],
+                 **kwargs):
+        """Creates a new instance of `Container`.
+
+        Args:
+          image {str}: image to use, e.g. busybox:latest
+          command {List[str]}: entrypoint array.  Not executed within a shell.
+          args {List[str]}: arguments to entrypoint.
+          **kwargs: keyword arguments for `V1Container`
+        """
+        # set name to '' if name is not provided
+        # k8s container MUST have a name
+        # argo workflow template does not need a name for container def
+        if not kwargs.get('name'):
+            kwargs['name'] = ''
+
+        self.env_dict = {}
+
+        super(Container, self).__init__(
+            image=image, command=command, args=args, **kwargs)
+
+    def _validate_size_string(self, size_string):
+        """Validate a given string is valid for memory/ephemeral-storage
+        request or limit."""
+
+        if isinstance(size_string, _pipeline_param.PipelineParam):
+            if size_string.value:
+                size_string = size_string.value
+            else:
+                return
+
+        if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
+                    size_string) is None:
+            raise ValueError(
+                'Invalid memory string. Should be an integer, or integer followed '
+                'by one of "E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"')
+
+    def _validate_cpu_string(self, cpu_string):
+        """Validate a given string is valid for cpu request or limit."""
+
+        if isinstance(cpu_string, _pipeline_param.PipelineParam):
+            if cpu_string.value:
+                cpu_string = cpu_string.value
+            else:
+                return
+
+        if re.match(r'^[0-9]+m$', cpu_string) is not None:
+            return
+
+        try:
+            float(cpu_string)
+        except ValueError:
+            raise ValueError(
+                'Invalid cpu string. Should be float or integer, or integer followed '
+                'by "m".')
+
+    def _validate_positive_number(self, str_value, param_name):
+        """Validate a given string is in positive integer format."""
+
+        if isinstance(str_value, _pipeline_param.PipelineParam):
+            if str_value.value:
+                str_value = str_value.value
+            else:
+                return
+
+        try:
+            int_value = int(str_value)
+        except ValueError:
+            raise ValueError(
+                'Invalid {}. Should be integer.'.format(param_name))
+
+        if int_value <= 0:
+            raise ValueError('{} must be positive integer.'.format(param_name))
+
+    def add_resource_limit(self, resource_name, value) -> 'Container':
+        """Add the resource limit of the container.
+
+        Args:
+          resource_name: The name of the resource. It can be cpu, memory, etc.
+          value: The string value of the limit.
+        """
+
+        self.resources = self.resources or V1ResourceRequirements()
+        self.resources.limits = self.resources.limits or {}
+        self.resources.limits.update({resource_name: value})
+        return self
+
+    def add_resource_request(self, resource_name, value) -> 'Container':
+        """Add the resource request of the container.
+
+        Args:
+          resource_name: The name of the resource. It can be cpu, memory, etc.
+          value: The string value of the request.
+        """
+
+        self.resources = self.resources or V1ResourceRequirements()
+        self.resources.requests = self.resources.requests or {}
+        self.resources.requests.update({resource_name: value})
+        return self
+
+    def get_resource_limit(self, resource_name: str) -> Optional[str]:
+        """Get the resource limit of the container.
+
+        Args:
+          resource_name: The name of the resource. It can be cpu, memory, etc.
+        """
+
+        if not self.resources or not self.resources.limits:
+            return None
+        return self.resources.limits.get(resource_name)
+
+    def get_resource_request(self, resource_name: str) -> Optional[str]:
+        """Get the resource request of the container.
+
+        Args:
+          resource_name: The name of the resource. It can be cpu, memory, etc.
+        """
+
+        if not self.resources or not self.resources.requests:
+            return None
+        return self.resources.requests.get(resource_name)
+
+    def set_memory_request(
+            self, memory: Union[str,
+                                _pipeline_param.PipelineParam]) -> 'Container':
+        """Set memory request (minimum) for this operator.
+
+        Args:
+          memory(Union[str, PipelineParam]): a string which can be a number or a number followed by one of
+            "E", "P", "T", "G", "M", "K".
+        """
+
+        if not isinstance(memory, _pipeline_param.PipelineParam):
+            self._validate_size_string(memory)
+        return self.add_resource_request('memory', memory)
+
+    def set_memory_limit(
+            self, memory: Union[str,
+                                _pipeline_param.PipelineParam]) -> 'Container':
+        """Set memory limit (maximum) for this operator.
+
+        Args:
+          memory(Union[str, PipelineParam]): a string which can be a number or a number followed by one of
+            "E", "P", "T", "G", "M", "K".
+        """
+        if not isinstance(memory, _pipeline_param.PipelineParam):
+            self._validate_size_string(memory)
+        return self.add_resource_limit('memory', memory)
+
+    def set_ephemeral_storage_request(self, size: Union[str,
+                                                        _pipeline_param.PipelineParam]) -> 'Container':
+        """Set ephemeral-storage request (minimum) for this operator.
+
+        Args:
+          size(Union[str, PipelineParam]): A string which can be a number or a number followed by one of
+            "E", "P", "T", "G", "M", "K".
+        """
+        if not isinstance(size, _pipeline_param.PipelineParam):
+            self._validate_size_string(size)
+        return self.add_resource_request('ephemeral-storage', size)
+
+    def set_ephemeral_storage_limit(self, size: Union[str,
+                                                        _pipeline_param.PipelineParam]) -> 'Container':
+        """Set ephemeral-storage request (maximum) for this operator.
+
+        Args:
+          size(Union[str, PipelineParam]): A string which can be a number or a number followed by one of
+            "E", "P", "T", "G", "M", "K".
+        """
+        if not isinstance(size, _pipeline_param.PipelineParam):
+            self._validate_size_string(size)
+        return self.add_resource_limit('ephemeral-storage', size)
+
+    def set_cpu_request(
+            self, cpu: Union[str,
+                             _pipeline_param.PipelineParam]) -> 'Container':
+        """Set cpu request (minimum) for this operator.
+
+        Args:
+          cpu(Union[str, PipelineParam]): A string which can be a number or a number followed by "m", which
+            means 1/1000.
+        """
+        if not isinstance(cpu, _pipeline_param.PipelineParam):
+            self._validate_cpu_string(cpu)
+        return self.add_resource_request('cpu', cpu)
+
+    def set_cpu_limit(
+            self, cpu: Union[str,
+                             _pipeline_param.PipelineParam]) -> 'Container':
+        """Set cpu limit (maximum) for this operator.
+
+        Args:
+          cpu(Union[str, PipelineParam]): A string which can be a number or a number followed by "m", which
+            means 1/1000.
+        """
+
+        if not isinstance(cpu, _pipeline_param.PipelineParam):
+            self._validate_cpu_string(cpu)
+        return self.add_resource_limit('cpu', cpu)
+
+    def set_gpu_limit(
+        self,
+        gpu: Union[str, _pipeline_param.PipelineParam],
+        vendor: Union[str, _pipeline_param.PipelineParam] = 'nvidia'
+    ) -> 'Container':
+        """Set gpu limit for the operator.
+
+        This function add '<vendor>.com/gpu' into resource limit.
+        Note that there is no need to add GPU request. GPUs are only supposed to
+        be specified in the limits section. See
+        https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/.
+
+        Args:
+          gpu(Union[str, PipelineParam]): A string which must be a positive number.
+          vendor(Union[str, PipelineParam]): Optional. A string which is the vendor of the requested gpu.
+            The supported values are: 'nvidia' (default), and 'amd'. The value is
+            ignored in v2.
+        """
+
+        if not isinstance(gpu, _pipeline_param.PipelineParam):
+            self._validate_positive_number(gpu, 'gpu')
+
+            if vendor != 'nvidia' and vendor != 'amd':
+                raise ValueError('vendor can only be nvidia or amd.')
+
+            return self.add_resource_limit('%s.com/gpu' % vendor, gpu)
+
+        return self.add_resource_limit(vendor, gpu)
+
+    def add_volume_mount(self, volume_mount) -> 'Container':
+        """Add volume to the container.
+
+        Args:
+          volume_mount: Kubernetes volume mount For detailed spec, check volume
+            mount definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_mount.py
+        """
+
+        if not isinstance(volume_mount, V1VolumeMount):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1VolumeMount`.')
+
+        self.volume_mounts = create_and_append(self.volume_mounts, volume_mount)
+        return self
+
+    def add_volume_devices(self, volume_device) -> 'Container':
+        """Add a block device to be used by the container.
+
+        Args:
+          volume_device: Kubernetes volume device For detailed spec, volume
+            device definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_device.py
+        """
+
+        if not isinstance(volume_device, V1VolumeDevice):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1VolumeDevice`.')
+
+        self.volume_devices = create_and_append(self.volume_devices,
+                                                volume_device)
+        return self
+
+    def add_env_variable(self, env_variable) -> 'Container':
+        """Add environment variable to the container.
+
+        Args:
+          env_variable: Kubernetes environment variable For detailed spec, check
+            environment variable definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var.py
+        """
+
+        if not isinstance(env_variable, V1EnvVar):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1EnvVar`.')
+
+        self.env = create_and_append(self.env, env_variable)
+        return self
+
+    def add_env_from(self, env_from) -> 'Container':
+        """Add a source to populate environment variables int the container.
+
+        Args:
+          env_from: Kubernetes environment from source For detailed spec, check
+            environment from source definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var_source.py
+        """
+
+        if not isinstance(env_from, V1EnvFromSource):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1EnvFromSource`.')
+
+        self.env_from = create_and_append(self.env_from, env_from)
+        return self
+
+    def set_image_pull_policy(self, image_pull_policy) -> 'Container':
+        """Set image pull policy for the container.
+
+        Args:
+          image_pull_policy: One of `Always`, `Never`, `IfNotPresent`.
+        """
+        if image_pull_policy not in ['Always', 'Never', 'IfNotPresent']:
+            raise ValueError(
+                'Invalid imagePullPolicy. Must be one of `Always`, `Never`, `IfNotPresent`.'
+            )
+
+        self.image_pull_policy = image_pull_policy
+        return self
+
+    def add_port(self, container_port) -> 'Container':
+        """Add a container port to the container.
+
+        Args:
+          container_port: Kubernetes container port For detailed spec, check
+            container port definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container_port.py
+        """
+
+        if not isinstance(container_port, V1ContainerPort):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1ContainerPort`.')
+
+        self.ports = create_and_append(self.ports, container_port)
+        return self
+
+    def set_security_context(self, security_context) -> 'Container':
+        """Set security configuration to be applied on the container.
+
+        Args:
+          security_context: Kubernetes security context For detailed spec, check
+            security context definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_security_context.py
+        """
+
+        if not isinstance(security_context, V1SecurityContext):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1SecurityContext`.')
+
+        self.security_context = security_context
+        return self
+
+    def set_stdin(self, stdin=True) -> 'Container':
+        """Whether this container should allocate a buffer for stdin in the
+        container runtime. If this is not set, reads from stdin in the
+        container will always result in EOF.
+
+        Args:
+          stdin: boolean flag
+        """
+
+        self.stdin = stdin
+        return self
+
+    def set_stdin_once(self, stdin_once=True) -> 'Container':
+        """Whether the container runtime should close the stdin channel after
+        it has been opened by a single attach. When stdin is true the stdin
+        stream will remain open across multiple attach sessions. If stdinOnce
+        is set to true, stdin is opened on container start, is empty until the
+        first client attaches to stdin, and then remains open and accepts data
+        until the client disconnects, at which time stdin is closed and remains
+        closed until the container is restarted. If this flag is false, a
+        container processes that reads from stdin will never receive an EOF.
+
+        Args:
+          stdin_once: boolean flag
+        """
+
+        self.stdin_once = stdin_once
+        return self
+
+    def set_termination_message_path(self,
+                                     termination_message_path) -> 'Container':
+        """Path at which the file to which the container's termination message
+        will be written is mounted into the container's filesystem. Message
+        written is intended to be brief final status, such as an assertion
+        failure message. Will be truncated by the node if greater than 4096
+        bytes. The total message length across all containers will be limited
+        to 12kb.
+
+        Args:
+          termination_message_path: path for the termination message
+        """
+        self.termination_message_path = termination_message_path
+        return self
+
+    def set_termination_message_policy(
+            self, termination_message_policy) -> 'Container':
+        """Indicate how the termination message should be populated. File will
+        use the contents of terminationMessagePath to populate the container
+        status message on both success and failure. FallbackToLogsOnError will
+        use the last chunk of container log output if the termination message
+        file is empty and the container exited with an error. The log output is
+        limited to 2048 bytes or 80 lines, whichever is smaller.
+
+        Args:
+          termination_message_policy: `File` or `FallbackToLogsOnError`
+        """
+        if termination_message_policy not in ['File', 'FallbackToLogsOnError']:
+            raise ValueError(
+                'terminationMessagePolicy must be `File` or `FallbackToLogsOnError`'
+            )
+        self.termination_message_policy = termination_message_policy
+        return self
+
+    def set_tty(self, tty: bool = True) -> 'Container':
+        """Whether this container should allocate a TTY for itself, also
+        requires 'stdin' to be true.
+
+        Args:
+          tty: boolean flag
+        """
+
+        self.tty = tty
+        return self
+
+    def set_readiness_probe(self, readiness_probe) -> 'Container':
+        """Set a readiness probe for the container.
+
+        Args:
+          readiness_probe: Kubernetes readiness probe For detailed spec, check
+            probe definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
+        """
+
+        if not isinstance(readiness_probe, V1Probe):
+            raise ValueError('invalid argument. Must be of instance `V1Probe`.')
+
+        self.readiness_probe = readiness_probe
+        return self
+
+    def set_liveness_probe(self, liveness_probe) -> 'Container':
+        """Set a liveness probe for the container.
+
+        Args:
+          liveness_probe: Kubernetes liveness probe For detailed spec, check
+            probe definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
+        """
+
+        if not isinstance(liveness_probe, V1Probe):
+            raise ValueError('invalid argument. Must be of instance `V1Probe`.')
+
+        self.liveness_probe = liveness_probe
+        return self
+
+    def set_lifecycle(self, lifecycle) -> 'Container':
+        """Setup a lifecycle config for the container.
+
+        Args:
+          lifecycle: Kubernetes lifecycle For detailed spec, lifecycle
+            definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_lifecycle.py
+        """
+
+        if not isinstance(lifecycle, V1Lifecycle):
+            raise ValueError(
+                'invalid argument. Must be of instance `V1Lifecycle`.')
+
+        self.lifecycle = lifecycle
+        return self
+
+
+class UserContainer(Container):
+    """Represents an argo workflow UserContainer
+    (io.argoproj.workflow.v1alpha1.UserContainer) to be used in `UserContainer`
+    property in argo's workflow template
+    (io.argoproj.workflow.v1alpha1.Template).
+
+    `UserContainer` inherits from `Container` class with an addition of
+    `mirror_volume_mounts`
+    attribute (`mirrorVolumeMounts` property).
+
+    See
+    https://github.com/argoproj/argo-workflows/blob/master/api/openapi-spec/swagger.json
+
+    Args:
+      name: unique name for the user container
+      image: image to use for the user container, e.g. redis:alpine
+      command: entrypoint array.  Not executed within a shell.
+      args: arguments to the entrypoint.
+      mirror_volume_mounts: MirrorVolumeMounts will mount the same volumes
+        specified in the main container to the container (including
+        artifacts), at the same mountPaths. This enables dind daemon to
+        partially see the same filesystem as the main container in order to
+        use features such as docker volume binding
+      **kwargs: keyword arguments available for `Container`
+
+    Attributes:
+      swagger_types (dict): The key is attribute name and the value is attribute
+        type.
+
+    Example ::
+
+      from kfp.dsl import ContainerOp, UserContainer
+      # creates a `ContainerOp` and adds a redis init container
+      op = (ContainerOp(name='foo-op', image='busybox:latest')
+         .add_initContainer(UserContainer(name='redis', image='redis:alpine')))
+    """
+    # adds `mirror_volume_mounts` to `UserContainer` swagger definition
+    # NOTE inherits definition from `V1Container` rather than `Container`
+    #      because `Container` has no `name` property.
+    if hasattr(V1Container, 'swagger_types'):
+        swagger_types = dict(
+            **V1Container.swagger_types, mirror_volume_mounts='bool')
+    if hasattr(V1Container, 'openapi_types'):
+        openapi_types = dict(
+            **V1Container.openapi_types, mirror_volume_mounts='bool')
+    attribute_map = dict(
+        **V1Container.attribute_map, mirror_volume_mounts='mirrorVolumeMounts')
+
+    def __init__(self,
+                 name: str,
+                 image: str,
+                 command: StringOrStringList = None,
+                 args: StringOrStringList = None,
+                 mirror_volume_mounts: bool = None,
+                 **kwargs):
+        super().__init__(
+            name=name,
+            image=image,
+            command=as_string_list(command),
+            args=as_string_list(args),
+            **kwargs)
+
+        self.mirror_volume_mounts = mirror_volume_mounts
+
+    def set_mirror_volume_mounts(self, mirror_volume_mounts=True):
+        """Setting mirrorVolumeMounts to true will mount the same volumes
+        specified in the main container to the container (including artifacts),
+        at the same mountPaths. This enables dind daemon to partially see the
+        same filesystem as the main container in order to use features such as
+        docker volume binding.
+
+        Args:
+            mirror_volume_mounts: boolean flag
+        """
+
+        self.mirror_volume_mounts = mirror_volume_mounts
+        return self
+
+    @property
+    def inputs(self):
+        """A list of PipelineParam found in the UserContainer object."""
+        return _pipeline_param.extract_pipelineparams_from_any(self)
+
+
+class Sidecar(UserContainer):
+    """Creates a new instance of `Sidecar`.
+
+    Args:
+      name: unique name for the sidecar container
+      image: image to use for the sidecar container, e.g. redis:alpine
+      command: entrypoint array.  Not executed within a shell.
+      args: arguments to the entrypoint.
+      mirror_volume_mounts: MirrorVolumeMounts will mount the same volumes
+        specified in the main container to the sidecar (including artifacts),
+        at the same mountPaths. This enables dind daemon to partially see the
+        same filesystem as the main container in order to use features such as
+        docker volume binding
+      **kwargs: keyword arguments available for `Container`
+    """
+
+    def __init__(self,
+                 name: str,
+                 image: str,
+                 command: StringOrStringList = None,
+                 args: StringOrStringList = None,
+                 mirror_volume_mounts: bool = None,
+                 **kwargs):
+        super().__init__(
+            name=name,
+            image=image,
+            command=command,
+            args=args,
+            mirror_volume_mounts=mirror_volume_mounts,
+            **kwargs)
+
+
+def _make_hash_based_id_for_op(op):
+    # Generating a unique ID for Op. For class instances, the hash is the object's memory address which is unique.
+    return op.human_name + ' ' + hex(2**63 + hash(op))[2:]
+
+
+# Pointer to a function that generates a unique ID for the Op instance (Possibly by registering the Op instance in some system).
+_register_op_handler = _make_hash_based_id_for_op
+
+
+class BaseOp(object):
+    """Base operator.
+
+    Args:
+      name: the name of the op. It does not have to be unique within a
+        pipeline because the pipeline will generates a unique new name in case
+        of conflicts.
+      init_containers: the list of `UserContainer` objects describing the
+        InitContainer to deploy before the `main` container.
+      sidecars: the list of `Sidecar` objects describing the sidecar
+        containers to deploy together with the `main` container.
+      is_exit_handler: Deprecated.
+    """
+
+    # list of attributes that might have pipeline params - used to generate
+    # the input parameters during compilation.
+    # Excludes `file_outputs` and `outputs` as they are handled separately
+    # in the compilation process to generate the DAGs and task io parameters.
+    attrs_with_pipelineparams = [
+        'node_selector', 'volumes', 'pod_annotations', 'pod_labels',
+        'num_retries', 'init_containers', 'sidecars', 'tolerations'
+    ]
+
+    def __init__(self,
+                 name: str,
+                 init_containers: List[UserContainer] = None,
+                 sidecars: List[Sidecar] = None,
+                 is_exit_handler: bool = False):
+
+        if is_exit_handler:
+            warnings.warn('is_exit_handler=True is no longer needed.',
+                          DeprecationWarning)
+
+        self.is_exit_handler = is_exit_handler
+
+        # human_name must exist to construct operator's name
+        self.human_name = name
+        self.display_name = None  #TODO Set display_name to human_name
+        # ID of the current Op. Ideally, it should be generated by the compiler that sees the bigger context.
+        # However, the ID is used in the task output references (PipelineParams) which can be serialized to strings.
+        # Because of this we must obtain a unique ID right now.
+        self.name = _register_op_handler(self)
+
+        # TODO: proper k8s definitions so that `convert_k8s_obj_to_json` can be used?
+        # `io.argoproj.workflow.v1alpha1.Template` properties
+        self.node_selector = {}
+        self.volumes = []
+        self.tolerations = []
+        self.affinity = {}
+        self.pod_annotations = {}
+        self.pod_labels = {}
+
+        # Retry strategy
+        self.num_retries = 0
+        self.retry_policy = None
+        self.backoff_factor = None
+        self.backoff_duration = None
+        self.backoff_max_duration = None
+
+        self.timeout = 0
+        self.init_containers = init_containers or []
+        self.sidecars = sidecars or []
+
+        # used to mark this op with loop arguments
+        self.loop_args = None
+
+        # Placeholder for inputs when adding ComponentSpec metadata to this
+        # ContainerOp. This holds inputs defined in ComponentSpec that have
+        # a corresponding PipelineParam.
+        self._component_spec_inputs_with_pipeline_params = []
+
+        # attributes specific to `BaseOp`
+        self._inputs = []
+        self.dependent_names = []
+
+        # Caching option, default to True
+        self.enable_caching = True
+
+    @property
+    def inputs(self):
+        """List of PipelineParams that will be converted into input parameters
+        (io.argoproj.workflow.v1alpha1.Inputs) for the argo workflow."""
+        # Iterate through and extract all the `PipelineParam` in Op when
+        # called the 1st time (because there are in-place updates to `PipelineParam`
+        # during compilation - remove in-place updates for easier debugging?)
+        if not self._inputs:
+            self._inputs = self._component_spec_inputs_with_pipeline_params or []
+            # TODO replace with proper k8s obj?
+            for key in self.attrs_with_pipelineparams:
+                self._inputs += _pipeline_param.extract_pipelineparams_from_any(
+                    getattr(self, key))
+            # keep only unique
+            self._inputs = list(set(self._inputs))
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, value):
+        # to support in-place updates
+        self._inputs = value
+
+    def apply(self, mod_func):
+        """Applies a modifier function to self.
+
+        The function should return the passed object.
+        This is needed to chain "extention methods" to this class.
+
+        Example::
+
+          from kfp.gcp import use_gcp_secret
+          task = (
+              train_op(...)
+                  .set_memory_request('1G')
+                  .apply(use_gcp_secret('user-gcp-sa'))
+                  .set_memory_limit('2G')
+          )
+        """
+        return mod_func(self) or self
+
+    def after(self, *ops):
+        """Specify explicit dependency on other ops."""
+        for op in ops:
+            self.dependent_names.append(op.name)
+        return self
+
+    def add_volume(self, volume):
+        """Add K8s volume to the container.
+
+        Args:
+          volume: Kubernetes volumes For detailed spec, check volume definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume.py
+        """
+        self.volumes.append(volume)
+        return self
+
+    def add_toleration(self, tolerations: V1Toleration):
+        """Add K8s tolerations.
+
+        Args:
+          tolerations: Kubernetes toleration For detailed spec, check toleration
+            definition
+            https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_toleration.py
+        """
+        self.tolerations.append(tolerations)
+        return self
+
+    def add_affinity(self, affinity: V1Affinity):
+        """Add K8s Affinity.
+
+        Args:
+          affinity: Kubernetes affinity For detailed spec, check affinity
+            definition
+          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_affinity.py
+
+        Example::
+
+          V1Affinity(
+              node_affinity=V1NodeAffinity(
+                  required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                      node_selector_terms=[V1NodeSelectorTerm(
+                          match_expressions=[V1NodeSelectorRequirement(
+                              key='beta.kubernetes.io/instance-type',
+                              operator='In',
+                              values=['p2.xlarge'])])])))
+        """
+        self.affinity = affinity
+        return self
+
+    def add_node_selector_constraint(
+            self, label_name: Union[str, _pipeline_param.PipelineParam],
+            value: Union[str, _pipeline_param.PipelineParam]):
+        """Add a constraint for nodeSelector.
+
+        Each constraint is a key-value pair label.
+        For the container to be eligible to run on a node, the node must have each
+        of the constraints appeared as labels.
+
+        Args:
+          label_name(Union[str, PipelineParam]): The name of the constraint label.
+          value(Union[str, PipelineParam]): The value of the constraint label.
+        """
+
+        self.node_selector[label_name] = value
+        return self
+
+    def add_pod_annotation(self, name: str, value: str):
+        """Adds a pod's metadata annotation.
+
+        Args:
+          name: The name of the annotation.
+          value: The value of the annotation.
+        """
+
+        self.pod_annotations[name] = value
+        return self
+
+    def add_pod_label(self, name: str, value: str):
+        """Adds a pod's metadata label.
+
+        Args:
+          name: The name of the label.
+          value: The value of the label.
+        """
+
+        self.pod_labels[name] = value
+        return self
+
+    def set_retry(self,
+                  num_retries: int,
+                  policy: Optional[str] = None,
+                  backoff_duration: Optional[str] = None,
+                  backoff_factor: Optional[float] = None,
+                  backoff_max_duration: Optional[str] = None):
+        """Sets the number of times the task is retried until it's declared
+        failed.
+
+        Args:
+          num_retries: Number of times to retry on failures.
+          policy: Retry policy name.
+          backoff_duration: The time interval between retries. Defaults to an
+            immediate retry. In case you specify a simple number, the unit
+            defaults to seconds. You can also specify a different unit, for
+            instance, 2m (2 minutes), 1h (1 hour).
+          backoff_factor: The exponential backoff factor applied to
+            backoff_duration. For example, if backoff_duration="60"
+            (60 seconds) and backoff_factor=2, the first retry will happen
+            after 60 seconds, then after 120, 240, and so on.
+          backoff_max_duration: The maximum interval that can be reached with
+            the backoff strategy.
+        """
+        if policy is not None and policy not in ALLOWED_RETRY_POLICIES:
+            raise ValueError('policy must be one of: %r' %
+                             (ALLOWED_RETRY_POLICIES,))
+
+        self.num_retries = num_retries
+        self.retry_policy = policy
+        self.backoff_factor = backoff_factor
+        self.backoff_duration = backoff_duration
+        self.backoff_max_duration = backoff_max_duration
+        return self
+
+    def set_timeout(self, seconds: int):
+        """Sets the timeout for the task in seconds.
+
+        Args:
+          seconds: Number of seconds.
+        """
+
+        self.timeout = seconds
+        return self
+
+    def add_init_container(self, init_container: UserContainer):
+        """Add a init container to the Op.
+
+        Args:
+          init_container: UserContainer object.
+        """
+
+        self.init_containers.append(init_container)
+        return self
+
+    def add_sidecar(self, sidecar: Sidecar):
+        """Add a sidecar to the Op.
+
+        Args:
+          sidecar: SideCar object.
+        """
+
+        self.sidecars.append(sidecar)
+        return self
+
+    def set_display_name(self, name: str):
+        self.display_name = name
+        return self
+
+    def set_caching_options(self, enable_caching: bool) -> 'BaseOp':
+        """Sets caching options for the Op.
+
+        Args:
+          enable_caching: Whether or not to enable caching for this task.
+
+        Returns:
+          Self return to allow chained setting calls.
+        """
+        self.enable_caching = enable_caching
+        return self
+
+    def __repr__(self):
+        return str({self.__class__.__name__: self.__dict__})
+
+
+from ._pipeline_volume import \
+    PipelineVolume  # The import is here to prevent circular reference problems.
+
+
+class InputArgumentPath:
+
+    def __init__(self, argument, input=None, path=None):
+        self.argument = argument
+        self.input = input
+        self.path = path
+
+
+def _is_legacy_output_name(output_name: str) -> Tuple[bool, str]:
+    normalized_output_name = re.sub('[^a-zA-Z0-9]', '-', output_name.lower())
+    if normalized_output_name in [
+            'mlpipeline-ui-metadata',
+            'mlpipeline-metrics',
+    ]:
+        return True, normalized_output_name
+    return False, output_name
+
+
+class ContainerOp(BaseOp):
+    """Represents an op implemented by a container image.
+
+    Args:
+      name: the name of the op. It does not have to be unique within a
+        pipeline because the pipeline will generates a unique new name in case
+        of conflicts.
+      image: the container image name, such as 'python:3.5-jessie'
+      command: the command to run in the container. If None, uses default CMD
+        in defined in container.
+      arguments: the arguments of the command. The command can include "%s"
+        and supply a PipelineParam as the string replacement. For example,
+        ('echo %s' % input_param). At container run time the argument will be
+        'echo param_value'.
+      init_containers: the list of `UserContainer` objects describing the
+        InitContainer to deploy before the `main` container.
+      sidecars: the list of `Sidecar` objects describing the sidecar
+        containers to deploy together with the `main` container.
+      container_kwargs: the dict of additional keyword arguments to pass to
+        the op's `Container` definition.
+      artifact_argument_paths: Optional. Maps input artifact arguments (values
+        or references) to the local file paths where they'll be placed. At
+        pipeline run time, the value of the artifact argument is saved to a
+        local file with specified path. This parameter is only needed when the
+        input file paths are hard-coded in the program. Otherwise it's better
+        to pass input artifact placement paths by including artifact arguments
+        in the command-line using the InputArgumentPath class instances.
+      file_outputs: Maps output names to container local output file paths.
+        The system will take the data from those files and will make it
+        available for passing to downstream tasks. For each output in the
+        file_outputs map there will be a corresponding output reference
+        available in the task.outputs dictionary. These output references can
+        be passed to the other tasks as arguments. The following output names
+        are handled specially by the frontend and
+            backend: "mlpipeline-ui-metadata" and "mlpipeline-metrics".
+      output_artifact_paths: Deprecated. Maps output artifact labels to local
+        artifact file paths. Deprecated: Use file_outputs instead. It now
+          supports big data outputs.
+      is_exit_handler: Deprecated. This is no longer needed.
+      pvolumes: Dictionary for the user to match a path on the op's fs with a
+        V1Volume or it inherited type.
+          E.g {"/my/path": vol, "/mnt": other_op.pvolumes["/output"]}.
+
+    Example::
+
+      from kfp import dsl
+      from kubernetes.client.models import V1EnvVar, V1SecretKeySelector
+      @dsl.pipeline(
+          name='foo',
+          description='hello world')
+      def foo_pipeline(tag: str, pull_image_policy: str):
+        # any attributes can be parameterized (both serialized string or actual PipelineParam)
+        op = dsl.ContainerOp(name='foo',
+                            image='busybox:%s' % tag,
+                            # pass in init_container list
+                            init_containers=[dsl.UserContainer('print', 'busybox:latest', command='echo "hello"')],
+                            # pass in sidecars list
+                            sidecars=[dsl.Sidecar('print', 'busybox:latest', command='echo "hello"')],
+                            # pass in k8s container kwargs
+                            container_kwargs={'env': [V1EnvVar('foo', 'bar')]},
+        )
+        # set `imagePullPolicy` property for `container` with `PipelineParam`
+        op.container.set_image_pull_policy(pull_image_policy)
+        # add sidecar with parameterized image tag
+        # sidecar follows the argo sidecar swagger spec
+        op.add_sidecar(dsl.Sidecar('redis', 'redis:%s' % tag).set_image_pull_policy('Always'))
+    """
+
+    # list of attributes that might have pipeline params - used to generate
+    # the input parameters during compilation.
+    # Excludes `file_outputs` and `outputs` as they are handled separately
+    # in the compilation process to generate the DAGs and task io parameters.
+
+    _DISABLE_REUSABLE_COMPONENT_WARNING = False
+
+    def __init__(
+        self,
+        name: str,
+        image: str,
+        command: Optional[StringOrStringList] = None,
+        arguments: Optional[ArgumentOrArguments] = None,
+        init_containers: Optional[List[UserContainer]] = None,
+        sidecars: Optional[List[Sidecar]] = None,
+        container_kwargs: Optional[Dict] = None,
+        artifact_argument_paths: Optional[List[InputArgumentPath]] = None,
+        file_outputs: Optional[Dict[str, str]] = None,
+        output_artifact_paths: Optional[Dict[str, str]] = None,
+        is_exit_handler: bool = False,
+        pvolumes: Optional[Dict[str, V1Volume]] = None,
+    ):
+        super().__init__(
+            name=name,
+            init_containers=init_containers,
+            sidecars=sidecars,
+            is_exit_handler=is_exit_handler)
+
+        self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + [
+            '_container', 'artifact_arguments', '_parameter_arguments'
+        ]  #Copying the BaseOp class variable!
+
+        input_artifact_paths = {}
+        artifact_arguments = {}
+        file_outputs = dict(file_outputs or {})  # Making a copy
+        output_artifact_paths = dict(output_artifact_paths or
+                                     {})  # Making a copy
+
+        self._is_v2 = False
+
+        def resolve_artifact_argument(artarg):
+            from ..components._components import _generate_input_file_name
+            if not isinstance(artarg, InputArgumentPath):
+                return artarg
+            input_name = getattr(
+                artarg.input, 'name',
+                artarg.input) or ('input-' + str(len(artifact_arguments)))
+            input_path = artarg.path or _generate_input_file_name(input_name)
+            input_artifact_paths[input_name] = input_path
+            artifact_arguments[input_name] = str(artarg.argument)
+            return input_path
+
+        for artarg in artifact_argument_paths or []:
+            resolve_artifact_argument(artarg)
+
+        if isinstance(command, Sequence) and not isinstance(command, str):
+            command = list(map(resolve_artifact_argument, command))
+        if isinstance(arguments, Sequence) and not isinstance(arguments, str):
+            arguments = list(map(resolve_artifact_argument, arguments))
+
+        # convert to list if not a list
+        command = as_string_list(command)
+        arguments = as_string_list(arguments)
+
+        if (not ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING) and (
+                '--component_launcher_class_path' not in (arguments or [])):
+            # The warning is suppressed for pipelines created using the TFX SDK.
+            warnings.warn(
+                'Please create reusable components instead of constructing ContainerOp instances directly.'
+                ' Reusable components are shareable, portable and have compatibility and support guarantees.'
+                ' Please see the documentation: https://www.kubeflow.org/docs/pipelines/sdk/component-development/#writing-your-component-definition-file'
+                ' The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op)'
+                ' and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: '
+                'https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file',
+                category=FutureWarning,
+            )
+            if kfp.COMPILING_FOR_V2:
+                raise RuntimeError(
+                    'Constructing ContainerOp instances directly is deprecated and not '
+                    'supported when compiling to v2 (using v2 compiler or v1 compiler '
+                    'with V2_COMPATIBLE or V2_ENGINE mode).')
+
+        # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
+        container_kwargs = container_kwargs or {}
+        self._container = Container(
+            image=image, args=arguments, command=command, **container_kwargs)
+
+        # NOTE for backward compatibility (remove in future?)
+        # proxy old ContainerOp callables to Container
+
+        # attributes to NOT proxy
+        ignore_set = frozenset(['to_dict', 'to_str'])
+
+        # decorator func to proxy a method in `Container` into `ContainerOp`
+        def _proxy(proxy_attr):
+            """Decorator func to proxy to ContainerOp.container."""
+
+            def _decorated(*args, **kwargs):
+                # execute method
+                ret = getattr(self._container, proxy_attr)(*args, **kwargs)
+                if ret == self._container:
+                    return self
+                return ret
+
+            return deprecation_warning(_decorated, proxy_attr, proxy_attr)
+
+        # iter thru container and attach a proxy func to the container method
+        for attr_to_proxy in dir(self._container):
+            func = getattr(self._container, attr_to_proxy)
+            # ignore private methods, and bypass method overrided by subclasses.
+            if (not hasattr(self, attr_to_proxy) and
+                    hasattr(func, '__call__') and (attr_to_proxy[0] != '_') and
+                (attr_to_proxy not in ignore_set)):
+                # only proxy public callables
+                setattr(self, attr_to_proxy, _proxy(attr_to_proxy))
+
+        if output_artifact_paths:
+            warnings.warn(
+                'The output_artifact_paths parameter is deprecated since SDK v0.1.32. '
+                'Use the file_outputs parameter instead. file_outputs now supports '
+                'outputting big data.', DeprecationWarning)
+
+        # Skip the special handling that is unnecessary in v2.
+        if not kfp.COMPILING_FOR_V2:
+            # Special handling for the mlpipeline-ui-metadata and mlpipeline-metrics
+            # outputs that should always be saved as artifacts
+            # TODO: Remove when outputs are always saved as artifacts
+            for output_name, path in dict(file_outputs).items():
+                is_legacy_name, normalized_name = _is_legacy_output_name(
+                    output_name)
+                if is_legacy_name:
+                    output_artifact_paths[normalized_name] = path
+                    del file_outputs[output_name]
+
+        # attributes specific to `ContainerOp`
+        self.input_artifact_paths = input_artifact_paths
+        self.artifact_arguments = artifact_arguments
+        self.file_outputs = file_outputs
+        self.output_artifact_paths = output_artifact_paths or {}
+
+        self._metadata = None
+        self._parameter_arguments = None
+
+        self.execution_options = _structures.ExecutionOptionsSpec(
+            caching_strategy=_structures.CachingStrategySpec(),)
+
+        self.outputs = {}
+        if file_outputs:
+            self.outputs = {
+                name: _pipeline_param.PipelineParam(name, op_name=self.name)
+                for name in file_outputs.keys()
+            }
+
+        self._set_single_output_attribute()
+
+        self.pvolumes = {}
+        self.add_pvolumes(pvolumes)
+
+    def _set_single_output_attribute(self):
+        # Syntactic sugar: Add task.output attribute if the component has a single
+        # output.
+        # TODO: Currently the "MLPipeline UI Metadata" output is removed from
+        # outputs to preserve backwards compatibility. Maybe stop excluding it from
+        # outputs, but rather exclude it from unique_outputs.
+        unique_outputs = set(self.outputs.values())
+        if len(unique_outputs) == 1:
+            self.output = list(unique_outputs)[0]
+        else:
+            self.output = _MultipleOutputsError()
+
+    @property
+    def is_v2(self):
+        return self._is_v2
+
+    @is_v2.setter
+    def is_v2(self, is_v2: bool):
+        self._is_v2 = is_v2
+
+    @property
+    def command(self):
+        return self._container.command
+
+    @command.setter
+    def command(self, value):
+        self._container.command = as_string_list(value)
+
+    @property
+    def arguments(self):
+        return self._container.args
+
+    @arguments.setter
+    def arguments(self, value):
+        self._container.args = as_string_list(value)
+
+    @property
+    def container(self):
+        """`Container` object that represents the `container` property in
+        `io.argoproj.workflow.v1alpha1.Template`. Can be used to update the
+        container configurations.
+
+        Example::
+
+          import kfp.dsl as dsl
+          from kubernetes.client.models import V1EnvVar
+
+          @dsl.pipeline(name='example_pipeline')
+          def immediate_value_pipeline():
+            op1 = (dsl.ContainerOp(name='example', image='nginx:alpine')
+                    .container
+                        .add_env_variable(V1EnvVar(name='HOST',
+                        value='foo.bar'))
+                        .add_env_variable(V1EnvVar(name='PORT', value='80'))
+                        .parent # return the parent `ContainerOp`
+                    )
+        """
+        return self._container
+
+    def _set_metadata(self,
+                      metadata,
+                      arguments: Optional[Dict[str, Any]] = None):
+        """Passes the ContainerOp the metadata information and configures the
+        right output.
+
+        Args:
+          metadata (ComponentSpec): component metadata
+          arguments: Dictionary of input arguments to the component.
+        """
+        if not isinstance(metadata, _structures.ComponentSpec):
+            raise ValueError('_set_metadata is expecting ComponentSpec.')
+
+        self._metadata = metadata
+
+        if self._metadata.outputs:
+            declared_outputs = {
+                output.name:
+                _pipeline_param.PipelineParam(output.name, op_name=self.name)
+                for output in self._metadata.outputs
+            }
+            self.outputs.update(declared_outputs)
+
+            for output in self._metadata.outputs:
+                if output.name in self.file_outputs:
+                    continue
+                is_legacy_name, normalized_name = _is_legacy_output_name(
+                    output.name)
+                if is_legacy_name and normalized_name in self.output_artifact_paths:
+                    output_filename = self.output_artifact_paths[normalized_name]
+                else:
+                    output_filename = _components._generate_output_file_name(
+                        output.name)
+                self.file_outputs[output.name] = output_filename
+
+            if not kfp.COMPILING_FOR_V2:
+                for output_name, path in dict(self.file_outputs).items():
+                    is_legacy_name, normalized_name = _is_legacy_output_name(
+                        output_name)
+                    if is_legacy_name:
+                        self.output_artifact_paths[normalized_name] = path
+                        del self.file_outputs[output_name]
+                        del self.outputs[output_name]
+
+        if arguments is not None:
+            for input_name, value in arguments.items():
+                self.artifact_arguments[input_name] = str(value)
+                if (isinstance(value, _pipeline_param.PipelineParam)):
+                    self._component_spec_inputs_with_pipeline_params.append(
+                        value)
+
+                if input_name not in self.input_artifact_paths:
+                    input_artifact_path = _components._generate_input_file_name(
+                        input_name)
+                    self.input_artifact_paths[input_name] = input_artifact_path
+
+        if self.file_outputs:
+            for output in self.file_outputs.keys():
+                output_type = self.outputs[output].param_type
+                for output_meta in self._metadata.outputs:
+                    if output_meta.name == output:
+                        output_type = output_meta.type
+                self.outputs[output].param_type = output_type
+
+        self._set_single_output_attribute()
+
+    def add_pvolumes(self, pvolumes: Dict[str, V1Volume] = None):
+        """Updates the existing pvolumes dict, extends volumes and
+        volume_mounts and redefines the pvolume attribute.
+
+        Args:
+          pvolumes: Dictionary. Keys are mount paths, values are Kubernetes
+            volumes or inherited types (e.g. PipelineVolumes).
+        """
+        if pvolumes:
+            for mount_path, pvolume in pvolumes.items():
+                if hasattr(pvolume, 'dependent_names'):
+                    self.dependent_names.extend(pvolume.dependent_names)
+                else:
+                    pvolume = PipelineVolume(volume=pvolume)
+                pvolume = pvolume.after(self)
+                self.pvolumes[mount_path] = pvolume
+                self.add_volume(pvolume)
+                self._container.add_volume_mount(
+                    V1VolumeMount(name=pvolume.name, mount_path=mount_path))
+
+        self.pvolume = None
+        if len(self.pvolumes) == 1:
+            self.pvolume = list(self.pvolumes.values())[0]
+        return self
+
+    def add_node_selector_constraint(
+            self, label_name: Union[str, _pipeline_param.PipelineParam],
+            value: Union[str, _pipeline_param.PipelineParam]) -> 'ContainerOp':
+        """Sets accelerator type requirement for this task.
+
+        When compiling for v2, this function can be optionally used with
+        set_gpu_limit to set the number of accelerator required. Otherwise, by
+        default the number requested will be 1.
+
+        Args:
+          label_name: The name of the constraint label.
+            For v2, only 'cloud.google.com/gke-accelerator' is supported now.
+          value: The name of the accelerator.
+            For v2, available values include 'nvidia-tesla-k80', 'tpu-v3'.
+
+        Returns:
+          self return to allow chained call with other resource specification.
+        """
+        super(ContainerOp, self).add_node_selector_constraint(label_name, value)
+        return self
+
+
+# proxy old ContainerOp properties to ContainerOp.container
+# with PendingDeprecationWarning.
+ContainerOp = _proxy_container_op_props(ContainerOp)
+
+
+class _MultipleOutputsError:
+
+    @staticmethod
+    def raise_error():
+        raise RuntimeError(
+            'This task has multiple outputs. Use `task.outputs[<output name>]` '
+            'dictionary to refer to the one you need.')
+
+    def __getattribute__(self, name):
+        _MultipleOutputsError.raise_error()
+
+    def __str__(self):
+        _MultipleOutputsError.raise_error()
+
+
+def _get_cpu_number(cpu_string: str) -> float:
+    """Converts the cpu string to number of vCPU core."""
+    # dsl.ContainerOp._validate_cpu_string guaranteed that cpu_string is either
+    # 1) a string can be converted to a float; or
+    # 2) a string followed by 'm', and it can be converted to a float.
+    if cpu_string.endswith('m'):
+        return float(cpu_string[:-1]) / 1000
+    else:
+        return float(cpu_string)
+
+
+def _get_resource_number(resource_string: str) -> float:
+    """Converts the resource string to number of resource in GB."""
+    # dsl.ContainerOp._validate_size_string guaranteed that memory_string
+    # represents an integer, optionally followed by one of (E, Ei, P, Pi, T, Ti,
+    # G, Gi, M, Mi, K, Ki).
+    # See the meaning of different suffix at
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+    # Also, ResourceSpec in pipeline IR expects a number in GB.
+    if resource_string.endswith('E'):
+        return float(resource_string[:-1]) * _E / _G
+    elif resource_string.endswith('Ei'):
+        return float(resource_string[:-2]) * _EI / _G
+    elif resource_string.endswith('P'):
+        return float(resource_string[:-1]) * _P / _G
+    elif resource_string.endswith('Pi'):
+        return float(resource_string[:-2]) * _PI / _G
+    elif resource_string.endswith('T'):
+        return float(resource_string[:-1]) * _T / _G
+    elif resource_string.endswith('Ti'):
+        return float(resource_string[:-2]) * _TI / _G
+    elif resource_string.endswith('G'):
+        return float(resource_string[:-1])
+    elif resource_string.endswith('Gi'):
+        return float(resource_string[:-2]) * _GI / _G
+    elif resource_string.endswith('M'):
+        return float(resource_string[:-1]) * _M / _G
+    elif resource_string.endswith('Mi'):
+        return float(resource_string[:-2]) * _MI / _G
+    elif resource_string.endswith('K'):
+        return float(resource_string[:-1]) * _K / _G
+    elif resource_string.endswith('Ki'):
+        return float(resource_string[:-2]) * _KI / _G
+    else:
+        # By default interpret as a plain integer, in the unit of Bytes.
+        return float(resource_string) / _G
+
+
+def _sanitize_gpu_type(gpu_type: str) -> str:
+    """Converts the GPU type to conform the enum style."""
+    return gpu_type.replace('-', '_').upper()

--- a/kfp/dsl/_for_loop.py
+++ b/kfp/dsl/_for_loop.py
@@ -1,0 +1,257 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from kfp import dsl
+from kfp.dsl import _pipeline_param
+
+ItemList = List[Union[int, float, str, Dict[str, Any]]]
+
+
+class LoopArguments(dsl.PipelineParam):
+    """Class representing the arguments that are looped over in a ParallelFor
+    loop in the KFP DSL.
+
+    This doesn't need to be instantiated by the end user, rather it will
+    be automatically created by a ParallelFor ops group.
+    """
+    LOOP_ITEM_NAME_BASE = 'loop-item'
+    LOOP_ITEM_PARAM_NAME_BASE = 'loop-item-param'
+    # number of characters in the code which is passed to the constructor
+    NUM_CODE_CHARS = 8
+    LEGAL_SUBVAR_NAME_REGEX = re.compile(r'^[a-zA-Z_][0-9a-zA-Z_]*$')
+
+    @classmethod
+    def _subvar_name_is_legal(cls, proposed_variable_name: str):
+        return re.match(cls.LEGAL_SUBVAR_NAME_REGEX,
+                        proposed_variable_name) is not None
+
+    def __init__(self,
+                 items: Union[ItemList, dsl.PipelineParam],
+                 code: str,
+                 name_override: Optional[str] = None,
+                 op_name: Optional[str] = None,
+                 *args,
+                 **kwargs):
+        """LoopArguments represent the set of items to loop over in a
+        ParallelFor loop.
+
+        This class shouldn't be instantiated by the user but rather is created by
+        _ops_group.ParallelFor.
+
+        Args:
+          items: List of items to loop over.  If a list of dicts then, all
+            dicts must have the same keys and every key must be a legal Python
+            variable name.
+          code: A unique code used to identify these loop arguments.  Should
+            match the code for the ParallelFor ops_group which created these
+            LoopArguments.  This prevents parameter name collisions.
+        """
+        if name_override is None:
+            super().__init__(name=self._make_name(code), *args, **kwargs)
+        else:
+            super().__init__(
+                name=name_override, op_name=op_name, *args, **kwargs)
+
+        if not isinstance(items, (list, tuple, dsl.PipelineParam)):
+            raise TypeError(
+                'Expected list, tuple, or PipelineParam, got {}.'.format(
+                    type(items)))
+
+        if isinstance(items, tuple):
+            items = list(items)
+
+        if isinstance(items, list) and isinstance(items[0], dict):
+            subvar_names = set(items[0].keys())
+            for item in items:
+                if not set(item.keys()) == subvar_names:
+                    raise ValueError(
+                        'If you input a list of dicts then all dicts should have the same keys. '
+                        'Got: {}.'.format(items))
+
+            # then this block creates loop_args.variable_a and loop_args.variable_b
+            for subvar_name in subvar_names:
+                if not self._subvar_name_is_legal(subvar_name):
+                    raise ValueError(
+                        "Tried to create subvariable named {} but that's not a legal Python variable "
+                        'name.'.format(subvar_name))
+                setattr(
+                    self, subvar_name,
+                    LoopArgumentVariable(
+                        loop_args_name=self.name,
+                        this_variable_name=subvar_name,
+                        loop_args_op_name=self.op_name,
+                        loop_args=self,
+                    ))
+
+        self.items_or_pipeline_param = items
+        self.referenced_subvar_names = []
+
+    @classmethod
+    def from_pipeline_param(cls, param: dsl.PipelineParam) -> 'LoopArguments':
+        return LoopArguments(
+            items=param,
+            code=None,
+            name_override=param.name + '-' + cls.LOOP_ITEM_NAME_BASE,
+            op_name=param.op_name,
+            value=param.value,
+        )
+
+    def __getattr__(self, item):
+        # this is being overridden so that we can access subvariables of the
+        # LoopArguments (i.e.: item.a) without knowing the subvariable names ahead
+        # of time
+        self.referenced_subvar_names.append(item)
+        return LoopArgumentVariable(
+            loop_args_name=self.name,
+            this_variable_name=item,
+            loop_args_op_name=self.op_name,
+            loop_args=self,
+        )
+
+    def to_list_for_task_yaml(self):
+        if isinstance(self.items_or_pipeline_param, (list, tuple)):
+            return self.items_or_pipeline_param
+        else:
+            raise ValueError(
+                'You should only call this method on loop args which have list items, '
+                'not pipeline param items.')
+
+    @classmethod
+    def _make_name(cls, code: str):
+        """Make a name for this parameter.
+
+        Code is a
+        """
+        return '{}-{}'.format(cls.LOOP_ITEM_PARAM_NAME_BASE, code)
+
+    @classmethod
+    def name_is_loop_argument(cls, param_name: str) -> bool:
+        """Return True if the given parameter name looks like a loop argument.
+
+        Either it came from a withItems loop item or withParams loop
+        item.
+        """
+        return cls.name_is_withitems_loop_argument(param_name) \
+          or cls.name_is_withparams_loop_argument(param_name)
+
+    @classmethod
+    def name_is_withitems_loop_argument(cls, param_name: str) -> bool:
+        """Return True if the given parameter name looks like it came from a
+        loop arguments parameter."""
+        return (cls.LOOP_ITEM_PARAM_NAME_BASE + '-') in param_name
+
+    @classmethod
+    def name_is_withparams_loop_argument(cls, param_name: str) -> bool:
+        """Return True if the given parameter name looks like it came from a
+        withParams loop item."""
+        return ('-' + cls.LOOP_ITEM_NAME_BASE) in param_name
+
+    @classmethod
+    def remove_loop_item_base_name(cls, param_name: str) -> str:
+        """Removes the last LOOP_ITEM_NAME_BASE from the end of param name."""
+        if ('-' + cls.LOOP_ITEM_NAME_BASE) in param_name:
+            # Split from the right, so that it handles multi-level nested args.
+            return param_name.rsplit('-' + cls.LOOP_ITEM_NAME_BASE, 1)[0]
+        return param_name
+
+
+class LoopArgumentVariable(dsl.PipelineParam):
+    """Represents a subvariable for loop arguments.
+
+    This is used for cases where we're looping over maps,   each of
+    which contains several variables.
+    """
+    SUBVAR_NAME_DELIMITER = '-subvar-'
+
+    def __init__(
+        self,
+        loop_args_name: str,
+        this_variable_name: str,
+        loop_args_op_name: Optional[str],
+        # For backward compatible, add loop_args as an optional argument.
+        # Ideally, this should replace loop_args_name and loop_args_op_name.
+        loop_args: Optional[LoopArguments] = None,
+    ):
+        """
+    If the user ran:
+        with dsl.ParallelFor([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]) as item:
+            ...
+    Then there's be one LoopArgumentsVariable for 'a' and another for 'b'.
+
+    Args:
+      loop_args_name:  The name of the LoopArguments object that this is
+        a subvariable to.
+      this_variable_name: The name of this subvariable, which is the name
+        of the dict key that spawned this subvariable.
+      loop_args_op_name: The name of the op that produced the loop arguments.
+      loop_args: Optional; The LoopArguments object this subvariable is based on.
+    """
+        super().__init__(
+            name=self.get_name(
+                loop_args_name=loop_args_name,
+                this_variable_name=this_variable_name),
+            op_name=loop_args_op_name,
+        )
+        self.loop_args = loop_args
+
+    @property
+    def items_or_pipeline_param(
+            self) -> Union[ItemList, _pipeline_param.PipelineParam]:
+        return self.loop_args.items_or_pipeline_param
+
+    @classmethod
+    def get_name(cls, loop_args_name: str, this_variable_name: str) -> str:
+        """Get the name.
+
+        Args:
+          loop_args_name: the name of the loop args parameter that this
+            LoopArgsVariable is attached to.
+          this_variable_name: the name of this LoopArgumentsVariable subvar.
+
+        Returns:
+          The name of this loop args variable.
+        """
+        return '{}{}{}'.format(loop_args_name, cls.SUBVAR_NAME_DELIMITER,
+                               this_variable_name)
+
+    @classmethod
+    def name_is_loop_arguments_variable(cls, param_name: str) -> bool:
+        """Return True if the given parameter name looks like it came from a
+        LoopArgumentsVariable."""
+        return re.match('.+%s.+' % cls.SUBVAR_NAME_DELIMITER,
+                        param_name) is not None
+
+    @classmethod
+    def parse_loop_args_name_and_this_var_name(cls, t: str) -> Tuple[str, str]:
+        """Get the loop arguments param name and this subvariable name from the
+        given parameter name."""
+        m = re.match(
+            '(?P<loop_args_name>.*){}(?P<this_var_name>.*)'.format(
+                cls.SUBVAR_NAME_DELIMITER), t)
+        if m is None:
+            return None
+        else:
+            return m.groupdict()['loop_args_name'], m.groupdict(
+            )['this_var_name']
+
+    @classmethod
+    def get_subvar_name(cls, t: str) -> str:
+        """Get the subvariable name from a given LoopArgumentsVariable
+        parameter name."""
+        out = cls.parse_loop_args_name_and_this_var_name(t)
+        if out is None:
+            raise ValueError("Couldn't parse variable name: {}".format(t))
+        return out[1]

--- a/kfp/dsl/_metadata.py
+++ b/kfp/dsl/_metadata.py
@@ -1,0 +1,98 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from .types import BaseType, _check_valid_type_dict
+from ..components._data_passing import serialize_value
+from ..components.structures import ComponentSpec, InputSpec, OutputSpec
+
+
+def _annotation_to_typemeta(annotation):
+    """_annotation_to_type_meta converts an annotation to a type structure.
+
+    Args:
+      annotation(BaseType/str/dict): input/output annotations
+        BaseType: registered in kfp.dsl.types
+        str: either a string of a dict serialization or a string of the type name
+        dict: type name and properties. note that the properties values can be
+          dict.
+
+    Returns:
+      dict or string representing the type
+    """
+    if isinstance(annotation, BaseType):
+        arg_type = annotation.to_dict()
+    elif isinstance(annotation, str):
+        arg_type = annotation
+    elif isinstance(annotation, dict):
+        if not _check_valid_type_dict(annotation):
+            raise ValueError('Annotation ' + str(annotation) +
+                             ' is not a valid type dictionary.')
+        arg_type = annotation
+    else:
+        return None
+    return arg_type
+
+
+def _extract_pipeline_metadata(func):
+    """Creates pipeline metadata structure instance based on the function
+    signature."""
+
+    # Most of this code is only needed for verifying the default values against
+    # "openapi_schema_validator" type properties.
+    # TODO: Move the value verification code to some other place
+
+    from ._pipeline_param import PipelineParam
+
+    import inspect
+    fullargspec = inspect.getfullargspec(func)
+    args = fullargspec.args
+    annotations = fullargspec.annotations
+
+    # defaults
+    arg_defaults = {}
+    if fullargspec.defaults:
+        for arg, default in zip(
+                reversed(fullargspec.args), reversed(fullargspec.defaults)):
+            arg_defaults[arg] = default
+
+    for arg in args:
+        arg_type = None
+        arg_default = arg_defaults[arg] if arg in arg_defaults else None
+        if isinstance(arg_default, PipelineParam):
+            warnings.warn(
+                'Explicit creation of `kfp.dsl.PipelineParam`s by the users is '
+                'deprecated. The users should define the parameter type and default '
+                'values using standard pythonic constructs: '
+                'def my_func(a: int = 1, b: str = "default"):')
+            arg_default = arg_default.value
+        if arg in annotations:
+            arg_type = _annotation_to_typemeta(annotations[arg])
+        arg_type_properties = list(arg_type.values())[0] if isinstance(
+            arg_type, dict) else {}
+        if 'openapi_schema_validator' in arg_type_properties and (arg_default
+                                                                  is not None):
+            from jsonschema import validate
+            import json
+            schema_object = arg_type_properties['openapi_schema_validator']
+            if isinstance(schema_object, str):
+                # In case the property value for the schema validator is a string
+                # instead of a dict.
+                schema_object = json.loads(schema_object)
+            # Only validating non-serialized values
+            validate(instance=arg_default, schema=schema_object)
+
+    from kfp.components._python_op import _extract_component_interface
+    component_spec = _extract_component_interface(func)
+    return component_spec

--- a/kfp/dsl/_ops_group.py
+++ b/kfp/dsl/_ops_group.py
@@ -1,0 +1,246 @@
+# Copyright 2018-2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+import uuid
+
+from kfp.dsl import _for_loop, _pipeline_param
+
+from . import _container_op
+from . import _pipeline
+
+
+class OpsGroup(object):
+    """Represents a logical group of ops and group of OpsGroups.
+
+    This class is the base class for groups of ops, such as ops sharing
+    an exit handler, a condition branch, or a loop. This class is not
+    supposed to be used by pipeline authors. It is useful for
+    implementing a compiler.
+    """
+
+    def __init__(self,
+                 group_type: str,
+                 name: str = None,
+                 parallelism: int = None):
+        """Create a new instance of OpsGroup.
+
+        Args:
+          group_type (str): one of 'pipeline', 'exit_handler', 'condition',
+            'for_loop', and 'graph'.
+          name (str): name of the opsgroup
+          parallelism (int): parallelism for the sub-DAG:s
+        """
+        #TODO: declare the group_type to be strongly typed
+        self.type = group_type
+        self.ops = list()
+        self.groups = list()
+        self.name = name
+        self.dependencies = []
+        self.parallelism = parallelism
+        # recursive_ref points to the opsgroups with the same name if exists.
+        self.recursive_ref = None
+
+        self.loop_args = None
+
+    @staticmethod
+    def _get_matching_opsgroup_already_in_pipeline(group_type, name):
+        """Retrieves the opsgroup when the pipeline already contains it.
+
+        the opsgroup might be already in the pipeline in case of recursive calls.
+
+        Args:
+          group_type (str): one of 'pipeline', 'exit_handler', 'condition', and
+            'graph'.
+          name (str): the name before conversion.
+        """
+        if not _pipeline.Pipeline.get_default_pipeline():
+            raise ValueError('Default pipeline not defined.')
+        if name is None:
+            return None
+        name_pattern = '^' + (group_type + '-' + name + '-').replace(
+            '_', '-') + '[\d]+$'
+        for ops_group_already_in_pipeline in _pipeline.Pipeline.get_default_pipeline(
+        ).groups:
+            import re
+            if ops_group_already_in_pipeline.type == group_type \
+                    and re.match(name_pattern ,ops_group_already_in_pipeline.name):
+                return ops_group_already_in_pipeline
+        return None
+
+    def _make_name_unique(self):
+        """Generate a unique opsgroup name in the pipeline."""
+        if not _pipeline.Pipeline.get_default_pipeline():
+            raise ValueError('Default pipeline not defined.')
+
+        self.name = (
+            self.type + '-' + ('' if self.name is None else self.name + '-') +
+            str(_pipeline.Pipeline.get_default_pipeline().get_next_group_id()))
+        self.name = self.name.replace('_', '-')
+
+    def __enter__(self):
+        if not _pipeline.Pipeline.get_default_pipeline():
+            raise ValueError('Default pipeline not defined.')
+
+        self.recursive_ref = self._get_matching_opsgroup_already_in_pipeline(
+            self.type, self.name)
+        if not self.recursive_ref:
+            self._make_name_unique()
+
+        _pipeline.Pipeline.get_default_pipeline().push_ops_group(self)
+        return self
+
+    def __exit__(self, *args):
+        _pipeline.Pipeline.get_default_pipeline().pop_ops_group()
+
+    def after(self, *ops):
+        """Specify explicit dependency on other ops."""
+        for op in ops:
+            self.dependencies.append(op)
+        return self
+
+    def remove_op_recursive(self, op):
+        if self.ops and op in self.ops:
+            self.ops.remove(op)
+        for sub_group in self.groups or []:
+            sub_group.remove_op_recursive(op)
+
+
+class SubGraph(OpsGroup):
+    TYPE_NAME = 'subgraph'
+
+    def __init__(self, parallelism: int):
+        if parallelism < 1:
+            raise ValueError(
+                'SubGraph parallism set to < 1, allowed values are > 0')
+        super(SubGraph, self).__init__(self.TYPE_NAME, parallelism=parallelism)
+
+
+class ExitHandler(OpsGroup):
+    """Represents an exit handler that is invoked upon exiting a group of ops.
+
+    Args:
+      exit_op: An operator invoked at exiting a group of ops.
+
+    Raises:
+      ValueError: Raised if the exit_op is invalid.
+
+    Example:
+      ::
+
+        exit_op = ContainerOp(...)
+        with ExitHandler(exit_op):
+          op1 = ContainerOp(...)
+          op2 = ContainerOp(...)
+    """
+
+    def __init__(
+        self,
+        exit_op: _container_op.ContainerOp,
+        name: Optional[str] = None,
+    ):
+        super(ExitHandler, self).__init__('exit_handler')
+
+        # Use user specified name as display name directly, instead of passing
+        # it to the super class constructor.
+        self.display_name = name
+        if exit_op.dependent_names:
+            raise ValueError('exit_op cannot depend on any other ops.')
+
+        # Removing exit_op form any group
+        _pipeline.Pipeline.get_default_pipeline().remove_op_from_groups(exit_op)
+
+        # Setting is_exit_handler since the compiler might be using this attribute.
+        # TODO: Check that it's needed
+        exit_op.is_exit_handler = True
+
+        self.exit_op = exit_op
+
+
+class Condition(OpsGroup):
+    """Represents an condition group with a condition.
+
+    Args:
+      condition (ConditionOperator): the condition.
+      name (str): name of the condition
+    Example: ::
+        with Condition(param1=='pizza', '[param1 is pizza]'): op1 =
+          ContainerOp(...) op2 = ContainerOp(...)
+    """
+
+    def __init__(self, condition, name=None):
+        super(Condition, self).__init__('condition', name)
+        self.condition = condition
+
+
+class Graph(OpsGroup):
+    """Graph DAG with inputs, recursive_inputs, and outputs.
+
+    This is not used directly by the users but auto generated when the
+    graph_component decoration exists
+
+    Args:
+      name: Name of the graph.
+    """
+
+    def __init__(self, name):
+        super(Graph, self).__init__(group_type='graph', name=name)
+        self.inputs = []
+        self.outputs = {}
+        self.dependencies = []
+
+
+class ParallelFor(OpsGroup):
+    """Represents a parallel for loop over a static set of items.
+
+    Example:
+      In this case :code:`op1` would be executed twice, once with case
+      :code:`args=['echo 1']` and once with case :code:`args=['echo 2']`::
+
+        with dsl.ParallelFor([{'a': 1, 'b': 10}, {'a': 2, 'b': 20}]) as item:
+          op1 = ContainerOp(..., args=['echo {}'.format(item.a)])
+          op2 = ContainerOp(..., args=['echo {}'.format(item.b])
+    """
+    TYPE_NAME = 'for_loop'
+
+    def __init__(self,
+                 loop_args: Union[_for_loop.ItemList,
+                                  _pipeline_param.PipelineParam],
+                 parallelism: Optional[int] = None):
+        parallelism = parallelism or 0
+        if parallelism < 0:
+            raise ValueError(
+                f'ParallelFor parallelism must be >= 0. Got: {parallelism}.')
+
+        self.items_is_pipeline_param = isinstance(loop_args,
+                                                  _pipeline_param.PipelineParam)
+
+        super().__init__(self.TYPE_NAME, parallelism=parallelism)
+
+        if self.items_is_pipeline_param:
+            loop_args = _for_loop.LoopArguments.from_pipeline_param(loop_args)
+        elif not self.items_is_pipeline_param and not isinstance(
+                loop_args, _for_loop.LoopArguments):
+            # we were passed a raw list, wrap it in loop args
+            loop_args = _for_loop.LoopArguments(
+                loop_args,
+                code=str(_pipeline.Pipeline.get_default_pipeline()
+                         .get_next_group_id()),
+            )
+
+        self.loop_args = loop_args
+
+    def __enter__(self) -> _for_loop.LoopArguments:
+        _ = super().__enter__()
+        return self.loop_args

--- a/kfp/dsl/_pipeline.py
+++ b/kfp/dsl/_pipeline.py
@@ -1,0 +1,374 @@
+# Copyright 2018-2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+from typing import Callable, Optional, Union
+
+from kubernetes.client.models import V1PodDNSConfig
+from kfp.dsl import _container_op
+from kfp.dsl import _resource_op
+from kfp.dsl import _ops_group
+from kfp.dsl import _component_bridge
+from kfp.components import _components
+from kfp.components import _naming
+import sys
+
+# This handler is called whenever the @pipeline decorator is applied.
+# It can be used by command-line DSL compiler to inject code that runs for every
+# pipeline definition.
+_pipeline_decorator_handler = None
+
+
+class PipelineExecutionMode(enum.Enum):
+    # Compile to Argo YAML without support for metadata-enabled components.
+    V1_LEGACY = 1
+    # Compiles to Argo YAML with support for metadata-enabled components.
+    # Pipelines compiled using this mode aim to be compatible with v2 semantics.
+    V2_COMPATIBLE = 2
+    # Compiles to KFP v2 IR for execution using the v2 engine.
+    # This option is unsupported right now.
+    V2_ENGINE = 3
+
+
+def pipeline(name: Optional[str] = None,
+             description: Optional[str] = None,
+             pipeline_root: Optional[str] = None):
+    """Decorator of pipeline functions.
+
+    Example
+      ::
+
+        @pipeline(
+          name='my-pipeline',
+          description='My ML Pipeline.'
+          pipeline_root='gs://my-bucket/my-output-path'
+        )
+        def my_pipeline(a: PipelineParam, b: PipelineParam):
+          ...
+
+    Args:
+      name: The pipeline name. Default to a sanitized version of the function
+        name.
+      description: Optionally, a human-readable description of the pipeline.
+      pipeline_root: The root directory to generate input/output URI under this
+        pipeline. This is required if input/output URI placeholder is used in this
+        pipeline.
+    """
+
+    def _pipeline(func: Callable):
+        if name:
+            func._component_human_name = name
+        if description:
+            func._component_description = description
+        if pipeline_root:
+            func.pipeline_root = pipeline_root
+
+        if _pipeline_decorator_handler:
+            return _pipeline_decorator_handler(func) or func
+        else:
+            return func
+
+    return _pipeline
+
+
+class PipelineConf():
+    """PipelineConf contains pipeline level settings."""
+
+    def __init__(self):
+        self.image_pull_secrets = []
+        self.timeout = 0
+        self.ttl_seconds_after_finished = -1
+        self._pod_disruption_budget_min_available = None
+        self.op_transformers = []
+        self.default_pod_node_selector = {}
+        self.image_pull_policy = None
+        self.parallelism = None
+        self._data_passing_method = None
+        self.dns_config = None
+
+    def set_image_pull_secrets(self, image_pull_secrets):
+        """Configures the pipeline level imagepullsecret.
+
+        Args:
+          image_pull_secrets: a list of Kubernetes V1LocalObjectReference For
+            detailed description, check Kubernetes V1LocalObjectReference definition
+            https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LocalObjectReference.md
+        """
+        self.image_pull_secrets = image_pull_secrets
+        return self
+
+    def set_timeout(self, seconds: int):
+        """Configures the pipeline level timeout.
+
+        Args:
+          seconds: number of seconds for timeout
+        """
+        self.timeout = seconds
+        return self
+
+    def set_parallelism(self, max_num_pods: int):
+        """Configures the max number of total parallel pods that can execute at
+        the same time in a workflow.
+
+        Args:
+          max_num_pods: max number of total parallel pods.
+        """
+        if max_num_pods < 1:
+            raise ValueError(
+                'Pipeline max_num_pods set to < 1, allowed values are > 0')
+
+        self.parallelism = max_num_pods
+        return self
+
+    def set_ttl_seconds_after_finished(self, seconds: int):
+        """Configures the ttl after the pipeline has finished.
+
+        Args:
+          seconds: number of seconds for the workflow to be garbage collected after
+            it is finished.
+        """
+        self.ttl_seconds_after_finished = seconds
+        return self
+
+    def set_pod_disruption_budget(self, min_available: Union[int, str]):
+        """PodDisruptionBudget holds the number of concurrent disruptions that
+        you allow for pipeline Pods.
+
+        Args:
+          min_available (Union[int, str]):  An eviction is allowed if at least
+            "minAvailable" pods selected by "selector" will still be available after
+            the eviction, i.e. even in the absence of the evicted pod.  So for
+            example you can prevent all voluntary evictions by specifying "100%".
+            "minAvailable" can be either an absolute number or a percentage.
+        """
+        self._pod_disruption_budget_min_available = min_available
+        return self
+
+    def set_default_pod_node_selector(self, label_name: str, value: str):
+        """Add a constraint for nodeSelector for a pipeline.
+
+        Each constraint is a key-value pair label.
+
+        For the container to be eligible to run on a node, the node must have each
+        of the constraints appeared as labels.
+
+        Args:
+          label_name: The name of the constraint label.
+          value: The value of the constraint label.
+        """
+        self.default_pod_node_selector[label_name] = value
+        return self
+
+    def set_image_pull_policy(self, policy: str):
+        """Configures the default image pull policy.
+
+        Args:
+          policy: the pull policy, has to be one of: Always, Never, IfNotPresent.
+            For more info:
+            https://github.com/kubernetes-client/python/blob/10a7f95435c0b94a6d949ba98375f8cc85a70e5a/kubernetes/docs/V1Container.md
+        """
+        self.image_pull_policy = policy
+        return self
+
+    def add_op_transformer(self, transformer):
+        """Configures the op_transformers which will be applied to all ops in
+        the pipeline. The ops can be ResourceOp, VolumeOp, or ContainerOp.
+
+        Args:
+          transformer: A function that takes a kfp Op as input and returns a kfp Op
+        """
+        self.op_transformers.append(transformer)
+
+    def set_dns_config(self, dns_config: V1PodDNSConfig):
+        """Set the dnsConfig to be given to each pod.
+
+        Args:
+          dns_config: Kubernetes V1PodDNSConfig For detailed description, check
+            Kubernetes V1PodDNSConfig definition
+            https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodDNSConfig.md
+
+        Example:
+          ::
+
+            import kfp
+            from kubernetes.client.models import V1PodDNSConfig, V1PodDNSConfigOption
+            pipeline_conf = kfp.dsl.PipelineConf()
+            pipeline_conf.set_dns_config(dns_config=V1PodDNSConfig(
+                nameservers=["1.2.3.4"],
+                options=[V1PodDNSConfigOption(name="ndots", value="2")],
+            ))
+        """
+        self.dns_config = dns_config
+
+    @property
+    def data_passing_method(self):
+        return self._data_passing_method
+
+    @data_passing_method.setter
+    def data_passing_method(self, value):
+        """Sets the object representing the method used for intermediate data
+        passing.
+
+        Example:
+          ::
+
+            from kfp.dsl import PipelineConf, data_passing_methods
+            from kubernetes.client.models import V1Volume, V1PersistentVolumeClaimVolumeSource
+            pipeline_conf = PipelineConf()
+            pipeline_conf.data_passing_method =
+            data_passing_methods.KubernetesVolume(
+                volume=V1Volume(
+                    name='data',
+                    persistent_volume_claim=V1PersistentVolumeClaimVolumeSource('data-volume'),
+                ),
+                path_prefix='artifact_data/',
+            )
+        """
+        self._data_passing_method = value
+
+
+def get_pipeline_conf():
+    """Configure the pipeline level setting to the current pipeline
+    Note: call the function inside the user defined pipeline function.
+  """
+    return Pipeline.get_default_pipeline().conf
+
+
+# TODO: Pipeline is in fact an opsgroup, refactor the code.
+class Pipeline():
+    """A pipeline contains a list of operators.
+
+    This class is not supposed to be used by pipeline authors since pipeline
+    authors can use pipeline functions (decorated with @pipeline) to reference
+    their pipelines.
+    This class is useful for implementing a compiler. For example, the compiler
+    can use the following to get the pipeline object and its ops:
+
+    Example:
+      ::
+
+        with Pipeline() as p:
+          pipeline_func(*args_list)
+
+        traverse(p.ops)
+    """
+
+    # _default_pipeline is set when it (usually a compiler) runs "with Pipeline()"
+    _default_pipeline = None
+
+    @staticmethod
+    def get_default_pipeline():
+        """Get default pipeline."""
+        return Pipeline._default_pipeline
+
+    @staticmethod
+    def add_pipeline(name, description, func):
+        """Add a pipeline function with the specified name and description."""
+        # Applying the @pipeline decorator to the pipeline function
+        func = pipeline(name=name, description=description)(func)
+
+    def __init__(self, name: str):
+        """Create a new instance of Pipeline.
+
+        Args:
+          name: the name of the pipeline. Once deployed, the name will show up in
+            Pipeline System UI.
+        """
+        self.name = name
+        self.ops = {}
+        # Add the root group.
+        self.groups = [_ops_group.OpsGroup('pipeline', name=name)]
+        self.group_id = 0
+        self.conf = PipelineConf()
+        self._metadata = None
+
+    def __enter__(self):
+        if Pipeline._default_pipeline:
+            raise Exception('Nested pipelines are not allowed.')
+
+        Pipeline._default_pipeline = self
+        self._old_container_task_constructor = (
+            _components._container_task_constructor)
+        _components._container_task_constructor = (
+            _component_bridge._create_container_op_from_component_and_arguments)
+
+        def register_op_and_generate_id(op):
+            return self.add_op(op, op.is_exit_handler)
+
+        self._old__register_op_handler = _container_op._register_op_handler
+        _container_op._register_op_handler = register_op_and_generate_id
+        return self
+
+    def __exit__(self, *args):
+        Pipeline._default_pipeline = None
+        _container_op._register_op_handler = self._old__register_op_handler
+        _components._container_task_constructor = (
+            self._old_container_task_constructor)
+
+    def add_op(self, op: _container_op.BaseOp, define_only: bool):
+        """Add a new operator.
+
+        Args:
+          op: An operator of ContainerOp, ResourceOp or their inherited types.
+            Returns
+          op_name: a unique op name.
+        """
+        # Sanitizing the op name.
+        # Technically this could be delayed to the compilation stage, but string
+        # serialization of PipelineParams make unsanitized names problematic.
+        op_name = _naming._sanitize_python_function_name(op.human_name).replace(
+            '_', '-')
+        #If there is an existing op with this name then generate a new name.
+        op_name = _naming._make_name_unique_by_adding_index(
+            op_name, list(self.ops.keys()), '-')
+        if op_name == '':
+            op_name = _naming._make_name_unique_by_adding_index(
+                'task', list(self.ops.keys()), '-')
+
+        self.ops[op_name] = op
+        if not define_only:
+            self.groups[-1].ops.append(op)
+
+        return op_name
+
+    def push_ops_group(self, group: _ops_group.OpsGroup):
+        """Push an OpsGroup into the stack.
+
+        Args:
+          group: An OpsGroup. Typically it is one of ExitHandler, Branch, and Loop.
+        """
+        self.groups[-1].groups.append(group)
+        self.groups.append(group)
+
+    def pop_ops_group(self):
+        """Remove the current OpsGroup from the stack."""
+        del self.groups[-1]
+
+    def remove_op_from_groups(self, op):
+        for group in self.groups:
+            group.remove_op_recursive(op)
+
+    def get_next_group_id(self):
+        """Get next id for a new group."""
+
+        self.group_id += 1
+        return self.group_id
+
+    def _set_metadata(self, metadata):
+        """_set_metadata passes the containerop the metadata information.
+
+        Args:
+          metadata (ComponentMeta): component metadata
+        """
+        self._metadata = metadata

--- a/kfp/dsl/_pipeline_param.py
+++ b/kfp/dsl/_pipeline_param.py
@@ -1,0 +1,253 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from collections import namedtuple
+from typing import Dict, List, Optional, Union
+
+# TODO: Move this to a separate class
+# For now, this identifies a condition with only "==" operator supported.
+ConditionOperator = namedtuple('ConditionOperator',
+                               'operator operand1 operand2')
+PipelineParamTuple = namedtuple('PipelineParamTuple', 'name op pattern')
+
+
+def sanitize_k8s_name(name, allow_capital_underscore=False):
+    """Cleans and converts the names in the workflow.
+
+    Args:
+      name: original name,
+      allow_capital_underscore: whether to allow capital letter and underscore in
+        this name.
+
+    Returns:
+      A sanitized name.
+    """
+    if allow_capital_underscore:
+        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z]+', '-',
+                                        name)).lstrip('-').rstrip('-')
+    else:
+        return re.sub('-+', '-', re.sub('[^-0-9a-z]+', '-',
+                                        name.lower())).lstrip('-').rstrip('-')
+
+
+def match_serialized_pipelineparam(payload: str) -> List[PipelineParamTuple]:
+    """Matches the supplied serialized pipelineparam.
+
+    Args:
+      payloads: The search space for the serialized pipelineparams.
+
+    Returns:
+      The matched pipeline params we found in the supplied payload.
+    """
+    matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+)}}',
+                         payload)
+    param_tuples = []
+    for match in matches:
+        pattern = '{{pipelineparam:op=%s;name=%s}}' % (match[0], match[1])
+        param_tuples.append(
+            PipelineParamTuple(
+                name=sanitize_k8s_name(match[1], True),
+                op=sanitize_k8s_name(match[0]),
+                pattern=pattern))
+    return param_tuples
+
+
+def _extract_pipelineparams(
+        payloads: Union[str, List[str]]) -> List['PipelineParam']:
+    """Extracts a list of PipelineParam instances from the payload string.
+
+    Note: this function removes all duplicate matches.
+
+    Args:
+      payload: a string/a list of strings that contains serialized pipelineparams
+
+    Return: List[]
+    """
+    if isinstance(payloads, str):
+        payloads = [payloads]
+    param_tuples = []
+    for payload in payloads:
+        param_tuples += match_serialized_pipelineparam(payload)
+    pipeline_params = []
+    for param_tuple in list(set(param_tuples)):
+        pipeline_params.append(
+            PipelineParam(
+                param_tuple.name, param_tuple.op, pattern=param_tuple.pattern))
+    return pipeline_params
+
+
+def extract_pipelineparams_from_any(
+    payload: Union['PipelineParam', str, list, tuple, dict]
+) -> List['PipelineParam']:
+    """Recursively extract PipelineParam instances or serialized string from
+    any object or list of objects.
+
+    Args:
+      payload (str or k8_obj or list[str or k8_obj]): a string/a list of strings
+        that contains serialized pipelineparams or a k8 definition object.
+
+    Return: List[PipelineParam]
+    """
+    if not payload:
+        return []
+
+    # PipelineParam
+    if isinstance(payload, PipelineParam):
+        return [payload]
+
+    # str
+    if isinstance(payload, str):
+        return list(set(_extract_pipelineparams(payload)))
+
+    # list or tuple
+    if isinstance(payload, list) or isinstance(payload, tuple):
+        pipeline_params = []
+        for item in payload:
+            pipeline_params += extract_pipelineparams_from_any(item)
+        return list(set(pipeline_params))
+
+    # dict
+    if isinstance(payload, dict):
+        pipeline_params = []
+        for key, value in payload.items():
+            pipeline_params += extract_pipelineparams_from_any(key)
+            pipeline_params += extract_pipelineparams_from_any(value)
+        return list(set(pipeline_params))
+
+    # k8s OpenAPI object
+    if hasattr(payload, 'attribute_map') and isinstance(payload.attribute_map,
+                                                        dict):
+        pipeline_params = []
+        for key in payload.attribute_map:
+            pipeline_params += extract_pipelineparams_from_any(
+                getattr(payload, key))
+
+        return list(set(pipeline_params))
+
+    # return empty list
+    return []
+
+
+class PipelineParam(object):
+    """Representing a future value that is passed between pipeline components.
+
+    A PipelineParam object can be used as a pipeline function argument so that it
+    will be a pipeline parameter that shows up in ML Pipelines system UI. It can
+    also represent an intermediate value passed between components.
+
+    Args:
+      name: name of the pipeline parameter.
+      op_name: the name of the operation that produces the PipelineParam. None
+        means it is not produced by any operator, so if None, either user
+        constructs it directly (for providing an immediate value), or it is a
+        pipeline function argument.
+      value: The actual value of the PipelineParam. If provided, the PipelineParam
+        is "resolved" immediately. For now, we support string only.
+      param_type: the type of the PipelineParam.
+      pattern: the serialized string regex pattern this pipeline parameter created
+        from.
+
+    Raises: ValueError in name or op_name contains invalid characters, or both
+      op_name and value are set.
+    """
+
+    def __init__(self,
+                 name: str,
+                 op_name: Optional[str] = None,
+                 value: Optional[str] = None,
+                 param_type: Optional[Union[str, Dict]] = None,
+                 pattern: Optional[str] = None):
+        valid_name_regex = r'^[A-Za-z][A-Za-z0-9\s_-]*$'
+        if not re.match(valid_name_regex, name):
+            raise ValueError(
+                'Only letters, numbers, spaces, "_", and "-" are allowed in name. '
+                'Must begin with a letter. Got name: {}'.format(name))
+
+        if op_name and value:
+            raise ValueError('op_name and value cannot be both set.')
+
+        self.name = name
+        # ensure value is None even if empty string or empty list
+        # so that serialization and unserialization remain consistent
+        # (i.e. None => '' => None)
+        self.op_name = op_name if op_name else None
+        self.value = value
+        self.param_type = param_type
+        self.pattern = pattern or str(self)
+
+    @property
+    def full_name(self):
+        """Unique name in the argo yaml for the PipelineParam."""
+        if self.op_name:
+            return self.op_name + '-' + self.name
+        return self.name
+
+    def __str__(self):
+        """String representation.
+
+        The string representation is a string identifier so we can mix
+        the PipelineParam inline with other strings such as arguments.
+        For example, we can support: ['echo %s' % param] as the
+        container command and later a compiler can replace the
+        placeholder "{{pipelineparam:op=%s;name=%s}}" with its own
+        parameter identifier.
+        """
+
+        #This is deleted because if users specify default values to PipelineParam,
+        # The compiler can not detect it as the value is not NULL.
+        #if self.value:
+        #  return str(self.value)
+
+        op_name = self.op_name if self.op_name else ''
+        return '{{pipelineparam:op=%s;name=%s}}' % (op_name, self.name)
+
+    def __repr__(self):
+        # return str({self.__class__.__name__: self.__dict__})
+        # We make repr return the placeholder string so that if someone uses
+        # str()-based serialization of complex objects containing `PipelineParam`,
+        # it works properly.
+        # (e.g. str([1, 2, 3, kfp.dsl.PipelineParam("aaa"), 4, 5, 6,]))
+        return str(self)
+
+    def to_struct(self):
+        # Used by the json serializer. Outputs a JSON-serializable representation of
+        # the object
+        return str(self)
+
+    def __eq__(self, other):
+        return ConditionOperator('==', self, other)
+
+    def __ne__(self, other):
+        return ConditionOperator('!=', self, other)
+
+    def __lt__(self, other):
+        return ConditionOperator('<', self, other)
+
+    def __le__(self, other):
+        return ConditionOperator('<=', self, other)
+
+    def __gt__(self, other):
+        return ConditionOperator('>', self, other)
+
+    def __ge__(self, other):
+        return ConditionOperator('>=', self, other)
+
+    def __hash__(self):
+        return hash((self.op_name, self.name))
+
+    def ignore_type(self):
+        """ignore_type ignores the type information such that type checking
+        would also pass."""
+        self.param_type = None
+        return self

--- a/kfp/dsl/_pipeline_volume.py
+++ b/kfp/dsl/_pipeline_volume.py
@@ -1,0 +1,125 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+
+from kubernetes.client.models import (V1Volume,
+                                      V1PersistentVolumeClaimVolumeSource)
+
+from . import _pipeline
+
+
+def prune_none_dict_values(d: dict) -> dict:
+    return {
+        k: prune_none_dict_values(v) if isinstance(v, dict) else v
+        for k, v in d.items()
+        if v is not None
+    }
+
+
+class PipelineVolume(V1Volume):
+    """Representing a volume that is passed between pipeline operators and is.
+
+    to be mounted by a ContainerOp or its inherited type.
+
+    A PipelineVolume object can be used as an extention of the pipeline
+    function's filesystem. It may then be passed between ContainerOps,
+    exposing dependencies.
+
+    TODO(https://github.com/kubeflow/pipelines/issues/4822): Determine the
+        stability level of this feature.
+
+    Args:
+      pvc: The name of an existing PVC
+      volume: Create a deep copy out of a V1Volume or PipelineVolume with no
+        deps
+
+    Raises:
+      ValueError: If volume is not None and kwargs is not None
+                  If pvc is not None and kwargs.pop("name") is not None
+    """
+
+    def __init__(self, pvc: str = None, volume: V1Volume = None, **kwargs):
+        if volume and kwargs:
+            raise ValueError("You can't pass a volume along with other "
+                             "kwargs.")
+
+        name_provided = True
+        init_volume = {}
+        if volume:
+            init_volume = {
+                attr: getattr(volume, attr)
+                for attr in self.attribute_map.keys()
+            }
+        else:
+            if "name" in kwargs:
+                if len(kwargs["name"]) > 63:
+                    raise ValueError("PipelineVolume name must be no more than"
+                                     " 63 characters")
+                init_volume = {"name": kwargs.pop("name")}
+            else:
+                name_provided = False
+                init_volume = {"name": "pvolume-placeholder"}
+            if pvc and kwargs:
+                raise ValueError("You can only pass 'name' along with 'pvc'.")
+            elif pvc and not kwargs:
+                pvc_volume_source = V1PersistentVolumeClaimVolumeSource(
+                    claim_name=str(pvc))
+                init_volume["persistent_volume_claim"] = pvc_volume_source
+        super().__init__(**init_volume, **kwargs)
+        if not name_provided:
+            volume_dict = prune_none_dict_values(self.to_dict())
+            hash_value = hashlib.sha256(
+                bytes(json.dumps(volume_dict, sort_keys=True),
+                      "utf-8")).hexdigest()
+            name = "pvolume-{}".format(hash_value)
+            self.name = name[0:63] if len(name) > 63 else name
+        self.dependent_names = []
+
+    def after(self, *ops):
+        """Creates a duplicate of self with the required dependecies excluding
+        the redundant dependenices.
+
+        Args:
+          *ops: Pipeline operators to add as dependencies
+        """
+
+        def implies(newdep, olddep):
+            if newdep.name == olddep:
+                return True
+            for parentdep_name in newdep.dependent_names:
+                if parentdep_name == olddep:
+                    return True
+                else:
+                    parentdep = _pipeline.Pipeline.get_default_pipeline(
+                    ).ops[parentdep_name]
+                    if parentdep:
+                        if implies(parentdep, olddep):
+                            return True
+            return False
+
+        ret = self.__class__(volume=self)
+        ret.dependent_names = [op.name for op in ops]
+
+        for olddep in self.dependent_names:
+            implied = False
+            for newdep in ops:
+                implied = implies(newdep, olddep)
+                if implied:
+                    break
+            if not implied:
+                ret.dependent_names.append(olddep)
+
+        return ret

--- a/kfp/dsl/_resource_op.py
+++ b/kfp/dsl/_resource_op.py
@@ -1,0 +1,230 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional
+import warnings
+
+from ._container_op import BaseOp, ContainerOp
+from . import _pipeline_param
+
+
+class Resource(object):
+    """A wrapper over Argo ResourceTemplate definition object
+    (io.argoproj.workflow.v1alpha1.ResourceTemplate) which is used to represent
+    the `resource` property in argo's workflow template
+    (io.argoproj.workflow.v1alpha1.Template)."""
+    swagger_types = {
+        "action": "str",
+        "merge_strategy": "str",
+        "success_condition": "str",
+        "failure_condition": "str",
+        "set_owner_reference": "bool",
+        "manifest": "str",
+        "flags": "list[str]"
+    }
+    openapi_types = {
+        "action": "str",
+        "merge_strategy": "str",
+        "success_condition": "str",
+        "failure_condition": "str",
+        "set_owner_reference": "bool",
+        "manifest": "str",
+        "flags": "list[str]"
+    }
+    attribute_map = {
+        "action": "action",
+        "merge_strategy": "mergeStrategy",
+        "success_condition": "successCondition",
+        "failure_condition": "failureCondition",
+        "set_owner_reference": "setOwnerReference",
+        "manifest": "manifest",
+        "flags": "flags"
+    }
+
+    def __init__(self,
+                 action: str = None,
+                 merge_strategy: str = None,
+                 success_condition: str = None,
+                 failure_condition: str = None,
+                 set_owner_reference: bool = None,
+                 manifest: str = None,
+                 flags: Optional[List[str]] = None):
+        """Create a new instance of Resource."""
+        self.action = action
+        self.merge_strategy = merge_strategy
+        self.success_condition = success_condition
+        self.failure_condition = failure_condition
+        self.set_owner_reference = set_owner_reference
+        self.manifest = manifest
+        self.flags = flags
+
+
+class ResourceOp(BaseOp):
+    """Represents an op which will be translated into a resource template.
+
+    TODO(https://github.com/kubeflow/pipelines/issues/4822): Determine the
+        stability level of this feature.
+
+    Args:
+      k8s_resource: A k8s resource which will be submitted to the cluster
+      action: One of "create"/"delete"/"apply"/"patch" (default is "create")
+      merge_strategy: The merge strategy for the "apply" action
+      success_condition: The successCondition of the template
+      failure_condition: The failureCondition of the template
+          For more info see:
+          https://github.com/argoproj/argo-workflows/blob/master/examples/k8s-jobs.yaml
+      attribute_outputs: Maps output labels to resource's json paths,
+        similarly to file_outputs of ContainerOp
+      kwargs: name, sidecars. See BaseOp definition
+
+    Raises:
+      ValueError: if not inside a pipeline
+          if the name is an invalid string
+          if no k8s_resource is provided
+          if merge_strategy is set without "apply" action
+    """
+
+    def __init__(self,
+                 k8s_resource=None,
+                 action: str = "create",
+                 merge_strategy: str = None,
+                 success_condition: str = None,
+                 failure_condition: str = None,
+                 set_owner_reference: bool = None,
+                 attribute_outputs: Optional[Dict[str, str]] = None,
+                 flags: Optional[List[str]] = None,
+                 **kwargs):
+
+        super().__init__(**kwargs)
+        self.attrs_with_pipelineparams = list(self.attrs_with_pipelineparams)
+        self.attrs_with_pipelineparams.extend(
+            ["_resource", "k8s_resource", "attribute_outputs"])
+
+        if k8s_resource is None:
+            raise ValueError("You need to provide a k8s_resource.")
+
+        if action == "delete":
+            warnings.warn(
+                'Please use `kubernetes_resource_delete_op` instead of '
+                '`ResourceOp(action="delete")`', DeprecationWarning)
+
+        if merge_strategy and action != "apply":
+            raise ValueError(
+                "You can't set merge_strategy when action != 'apply'")
+
+        # if action is delete, there should not be any outputs, success_condition,
+        # and failure_condition
+        if action == "delete" and (success_condition or failure_condition or
+                                   attribute_outputs):
+            raise ValueError(
+                "You can't set success_condition, failure_condition, or "
+                "attribute_outputs when action == 'delete'")
+
+        if action == "delete" and flags is None:
+            flags = ["--wait=false"]
+        init_resource = {
+            "action": action,
+            "merge_strategy": merge_strategy,
+            "success_condition": success_condition,
+            "failure_condition": failure_condition,
+            "set_owner_reference": set_owner_reference,
+            "flags": flags
+        }
+        # `resource` prop in `io.argoproj.workflow.v1alpha1.Template`
+        self._resource = Resource(**init_resource)
+
+        self.k8s_resource = k8s_resource
+
+        # if action is delete, there should not be any outputs, success_condition,
+        # and failure_condition
+        if action == "delete":
+            self.attribute_outputs = {}
+            self.outputs = {}
+            self.output = None
+            return
+
+        # Set attribute_outputs
+        extra_attribute_outputs = \
+            attribute_outputs if attribute_outputs else {}
+        self.attribute_outputs = \
+            self.attribute_outputs if hasattr(self, "attribute_outputs") \
+            else {}
+        self.attribute_outputs.update(extra_attribute_outputs)
+        # Add name and manifest if not specified by the user
+        if "name" not in self.attribute_outputs:
+            self.attribute_outputs["name"] = "{.metadata.name}"
+        if "manifest" not in self.attribute_outputs:
+            self.attribute_outputs["manifest"] = "{}"
+
+        # Set outputs
+        self.outputs = {
+            name: _pipeline_param.PipelineParam(name, op_name=self.name)
+            for name in self.attribute_outputs.keys()
+        }
+        # If user set a single attribute_output, set self.output as that
+        # parameter, else set it as the resource name
+        self.output = self.outputs["name"]
+        if len(extra_attribute_outputs) == 1:
+            self.output = self.outputs[list(extra_attribute_outputs)[0]]
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`."""
+        return self._resource
+
+    def delete(self, flags: Optional[List[str]] = None):
+        """Returns a ResourceOp which deletes the resource."""
+        if self.resource.action == "delete":
+            raise ValueError("This operation is already a resource deletion.")
+
+        if isinstance(self.k8s_resource, dict):
+            kind = self.k8s_resource["kind"]
+        else:
+            kind = self.k8s_resource.kind
+
+        return kubernetes_resource_delete_op(
+            name=self.outputs["name"],
+            kind=kind,
+            flags=flags or ["--wait=false"])
+
+
+def kubernetes_resource_delete_op(
+    name: str,
+    kind: str,
+    namespace: str = None,
+    flags: Optional[List[str]] = None,
+) -> ContainerOp:
+    """Operation that deletes a Kubernetes resource.
+
+    Outputs:
+      name: The name of the deleted resource
+    """
+
+    command = [
+        "kubectl", "delete",
+        str(kind),
+        str(name), "--ignore-not-found", "--output", "name"
+    ]
+    if namespace:
+        command.extend(["--namespace", str(namespace)])
+    if flags:
+        command.extend(flags)
+
+    result = ContainerOp(
+        name="kubernetes_resource_delete",
+        image="gcr.io/cloud-builders/kubectl",
+        command=command,
+    )
+    return result

--- a/kfp/dsl/_volume_op.py
+++ b/kfp/dsl/_volume_op.py
@@ -1,0 +1,136 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import List, Dict
+from kubernetes.client.models import (V1ObjectMeta, V1ResourceRequirements,
+                                      V1PersistentVolumeClaimSpec,
+                                      V1PersistentVolumeClaim,
+                                      V1TypedLocalObjectReference)
+
+from ._resource_op import ResourceOp
+from ._pipeline_param import (PipelineParam, match_serialized_pipelineparam,
+                              sanitize_k8s_name)
+from ._pipeline_volume import PipelineVolume
+
+VOLUME_MODE_RWO = ["ReadWriteOnce"]
+VOLUME_MODE_RWM = ["ReadWriteMany"]
+VOLUME_MODE_ROM = ["ReadOnlyMany"]
+
+
+class VolumeOp(ResourceOp):
+    """Represents an op which will be translated into a resource template which
+    will be creating a PVC.
+
+    TODO(https://github.com/kubeflow/pipelines/issues/4822): Determine the
+        stability level of this feature.
+
+    Args:
+      resource_name: A desired name for the PVC which will be created
+      size: The size of the PVC which will be created
+      storage_class: The storage class to use for the dynamically created PVC
+      modes: The access modes for the PVC
+      annotations: Annotations to be patched in the PVC
+      data_source: May be a V1TypedLocalObjectReference, and then it is used
+        in the data_source field of the PVC as is. Can also be a
+        string/PipelineParam, and in that case it will be used as a
+        VolumeSnapshot name (Alpha feature)
+      volume_name: VolumeName is the binding reference to the PersistentVolume
+        backing this claim.
+      generate_unique_name: Generate unique name for the PVC
+      kwargs: See :py:class:`kfp.dsl.ResourceOp`
+
+    Raises:
+      ValueError: if k8s_resource is provided along with other arguments
+                  if k8s_resource is not a V1PersistentVolumeClaim
+                  if size is None
+                  if size is an invalid memory string (when not a
+                      PipelineParam)
+                  if data_source is not one of (str, PipelineParam,
+                      V1TypedLocalObjectReference)
+    """
+
+    def __init__(self,
+                 resource_name: str = None,
+                 size: str = None,
+                 storage_class: str = None,
+                 modes: List[str] = None,
+                 annotations: Dict[str, str] = None,
+                 data_source=None,
+                 volume_name=None,
+                 generate_unique_name: bool = True,
+                 **kwargs):
+        # Add size to attribute outputs
+        self.attribute_outputs = {"size": "{.status.capacity.storage}"}
+
+        if "k8s_resource" in kwargs:
+            if resource_name or size or storage_class or modes or annotations:
+                raise ValueError("You cannot provide k8s_resource along with "
+                                 "other arguments.")
+            if not isinstance(kwargs["k8s_resource"], V1PersistentVolumeClaim):
+                raise ValueError("k8s_resource in VolumeOp must be an instance"
+                                 " of V1PersistentVolumeClaim")
+            super().__init__(**kwargs)
+            self.volume = PipelineVolume(
+                name=sanitize_k8s_name(self.name), pvc=self.outputs["name"])
+            return
+
+        if not size:
+            raise ValueError("Please provide size")
+        elif not match_serialized_pipelineparam(str(size)):
+            self._validate_memory_string(size)
+
+        if data_source and not isinstance(
+                data_source, (str, PipelineParam, V1TypedLocalObjectReference)):
+            raise ValueError("data_source can be one of (str, PipelineParam, "
+                             "V1TypedLocalObjectReference).")
+        if data_source and isinstance(data_source, (str, PipelineParam)):
+            data_source = V1TypedLocalObjectReference(
+                api_group="snapshot.storage.k8s.io",
+                kind="VolumeSnapshot",
+                name=data_source)
+
+        # Set the k8s_resource
+        if not match_serialized_pipelineparam(str(resource_name)):
+            resource_name = sanitize_k8s_name(resource_name)
+        pvc_metadata = V1ObjectMeta(
+            name="{{workflow.name}}-%s" % resource_name if generate_unique_name else resource_name,
+            annotations=annotations)
+        requested_resources = V1ResourceRequirements(requests={"storage": size})
+        pvc_spec = V1PersistentVolumeClaimSpec(
+            access_modes=modes or VOLUME_MODE_RWM,
+            resources=requested_resources,
+            storage_class_name=storage_class,
+            data_source=data_source,
+            volume_name=volume_name)
+        k8s_resource = V1PersistentVolumeClaim(
+            api_version="v1",
+            kind="PersistentVolumeClaim",
+            metadata=pvc_metadata,
+            spec=pvc_spec)
+
+        super().__init__(
+            k8s_resource=k8s_resource,
+            **kwargs,
+        )
+        self.volume = PipelineVolume(
+            name=sanitize_k8s_name(self.name), pvc=self.outputs["name"])
+
+    def _validate_memory_string(self, memory_string):
+        """Validate a given string is valid for memory request or limit."""
+        if re.match(r"^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$",
+                    memory_string) is None:
+            raise ValueError("Invalid memory string. Should be an integer, " +
+                             "or integer followed by one of " +
+                             '"E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"')

--- a/kfp/dsl/_volume_snapshot_op.py
+++ b/kfp/dsl/_volume_snapshot_op.py
@@ -1,0 +1,117 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+from kubernetes.client.models import (V1Volume, V1TypedLocalObjectReference,
+                                      V1ObjectMeta)
+
+from ._resource_op import ResourceOp
+from ._pipeline_param import match_serialized_pipelineparam, sanitize_k8s_name
+
+
+class VolumeSnapshotOp(ResourceOp):
+    """Represents an op which will be translated into a resource template which
+    will be creating a VolumeSnapshot.
+
+    TODO(https://github.com/kubeflow/pipelines/issues/4822): Determine the
+        stability level of this feature.
+
+    Args:
+      resource_name: A desired name for the VolumeSnapshot which will be
+        created
+      pvc: The name of the PVC which will be snapshotted
+      snapshot_class: The snapshot class to use for the dynamically created
+        VolumeSnapshot
+      annotations: Annotations to be patched in the VolumeSnapshot
+      volume: An instance of V1Volume
+      kwargs: See :py:class:`kfp.dsl.ResourceOp`
+
+    Raises:
+      ValueError: if k8s_resource is provided along with other arguments
+                  if k8s_resource is not a VolumeSnapshot
+                  if pvc and volume are None
+                  if pvc and volume are not None
+                  if volume does not reference a PVC
+    """
+
+    def __init__(self,
+                 resource_name: str = None,
+                 pvc: str = None,
+                 snapshot_class: str = None,
+                 annotations: Dict[str, str] = None,
+                 volume: V1Volume = None,
+                 api_version: str = "snapshot.storage.k8s.io/v1alpha1",
+                 **kwargs):
+        # Add size to output params
+        self.attribute_outputs = {"size": "{.status.restoreSize}"}
+        # Add default success_condition if None provided
+        if "success_condition" not in kwargs:
+            kwargs["success_condition"] = "status.readyToUse == true"
+
+        if "k8s_resource" in kwargs:
+            if resource_name or pvc or snapshot_class or annotations or volume:
+                raise ValueError("You cannot provide k8s_resource along with "
+                                 "other arguments.")
+            # TODO: Check if is VolumeSnapshot
+            super().__init__(**kwargs)
+            self.snapshot = V1TypedLocalObjectReference(
+                api_group="snapshot.storage.k8s.io",
+                kind="VolumeSnapshot",
+                name=self.outputs["name"])
+            return
+
+        if not (pvc or volume):
+            raise ValueError("You must provide a pvc or a volume.")
+        elif pvc and volume:
+            raise ValueError("You can't provide both pvc and volume.")
+
+        source = None
+        deps = []
+        if pvc:
+            source = V1TypedLocalObjectReference(
+                kind="PersistentVolumeClaim", name=pvc)
+        else:
+            if not hasattr(volume, "persistent_volume_claim"):
+                raise ValueError("The volume must be referencing a PVC.")
+            if hasattr(volume,
+                       "dependent_names"):  #TODO: Replace with type check
+                deps = list(volume.dependent_names)
+            source = V1TypedLocalObjectReference(
+                kind="PersistentVolumeClaim",
+                name=volume.persistent_volume_claim.claim_name)
+
+        # Set the k8s_resource
+        # TODO: Use VolumeSnapshot
+        if not match_serialized_pipelineparam(str(resource_name)):
+            resource_name = sanitize_k8s_name(resource_name)
+        snapshot_metadata = V1ObjectMeta(
+            name="{{workflow.name}}-%s" % resource_name,
+            annotations=annotations)
+        k8s_resource = {
+            "apiVersion": api_version,
+            "kind": "VolumeSnapshot",
+            "metadata": snapshot_metadata,
+            "spec": {
+                "source": source
+            }
+        }
+        if snapshot_class:
+            k8s_resource["spec"]["snapshotClassName"] = snapshot_class
+
+        super().__init__(k8s_resource=k8s_resource, **kwargs)
+        self.dependent_names.extend(deps)
+        self.snapshot = V1TypedLocalObjectReference(
+            api_group="snapshot.storage.k8s.io",
+            kind="VolumeSnapshot",
+            name=self.outputs["name"])

--- a/kfp/dsl/artifact_utils.py
+++ b/kfp/dsl/artifact_utils.py
@@ -1,0 +1,111 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper utils used in artifact and ontology_artifact classes."""
+
+from typing import Any, Dict, Tuple
+
+import enum
+import jsonschema
+import os
+import yaml
+
+
+class SchemaFieldType(enum.Enum):
+    """Supported Schema field types."""
+    NUMBER = 'number'
+    INTEGER = 'integer'
+    STRING = 'string'
+    BOOL = 'bool'
+    OBJECT = 'object'
+    ARRAY = 'array'
+
+
+def parse_schema(yaml_schema: str) -> Tuple[str, Dict[str, SchemaFieldType]]:
+    """Parses yaml schema.
+
+    Ensures that schema is well-formed and returns dictionary of properties and
+    its type for type-checking.
+
+    Args:
+      yaml_schema: Yaml schema to be parsed.
+
+    Returns:
+      str: Title set in the schema.
+      Dict: Property name to SchemaFieldType enum.
+
+    Raises:
+      ValueError if title field is not set in schema or an
+        unsupported(i.e. not defined in SchemaFieldType)
+        type is specified for the field.
+    """
+
+    schema = yaml.full_load(yaml_schema)
+    if 'title' not in schema.keys():
+        raise ValueError('Invalid _schema, title must be set. \
+      Got: {}'.format(yaml_schema))
+
+    title = schema['title']
+    properties = {}
+    if 'properties' in schema.keys():
+        schema_properties = schema['properties'] or {}
+        for property_name, property_def in schema_properties.items():
+            try:
+                properties[property_name] = SchemaFieldType(
+                    property_def['type'])
+            except ValueError:
+                raise ValueError('Unsupported type:{} specified for field: {} \
+          in schema'.format(property_def['type'], property_name))
+
+    return title, properties
+
+
+def verify_schema_instance(schema: str, instance: Dict[str, Any]):
+    """Verifies instnace is well-formed against the schema.
+
+    Args:
+      schema: Schema to use for verification.
+      instance: Object represented as Dict to be verified.
+
+    Raises:
+      RuntimeError if schema is not well-formed or instance is invalid against
+       the schema.
+    """
+
+    if len(instance) == 0:
+        return
+
+    try:
+        jsonschema.validate(instance=instance, schema=yaml.full_load(schema))
+    except jsonschema.exceptions.SchemaError:
+        raise RuntimeError('Invalid schema schema: {} used for \
+        verification'.format(schema))
+    except jsonschema.exceptions.ValidationError:
+        raise RuntimeError('Invalid values set: {} in object for schema: \
+      {}'.format(instance, schema))
+
+
+def read_schema_file(schema_file: str) -> str:
+    """Reads yamls schema from type_scheams folder.
+
+    Args:
+      schema_file: Name of the file to read schema from.
+
+    Returns:
+      Read schema from the schema file.
+    """
+    schema_file_path = os.path.join(
+        os.path.dirname(__file__), 'type_schemas', schema_file)
+
+    with open(schema_file_path) as schema_file:
+        return schema_file.read()

--- a/kfp/dsl/data_passing_methods.py
+++ b/kfp/dsl/data_passing_methods.py
@@ -1,0 +1,27 @@
+import kubernetes
+from kubernetes.client.models import V1Volume
+
+
+class KubernetesVolume:
+    """KubernetesVolume data passing method involves passing data by mounting a
+    single multi-write Kubernetes volume to containers instead of using Argo's
+    artifact passing method (which stores the data in an S3 blob store)."""
+
+    def __init__(self, volume: V1Volume, path_prefix: str = 'artifact_data/'):
+        if not isinstance(volume, (dict, V1Volume)):
+            raise TypeError('volume must be either V1Volume or dict')
+        self._volume = volume
+        self._path_prefix = path_prefix
+
+    def transform_workflow(self, workflow: dict) -> dict:
+        from ..compiler._data_passing_using_volume import rewrite_data_passing_to_use_volumes
+        if isinstance(self._volume, dict):
+            volume_dict = self._volume
+        else:
+            volume_dict = kubernetes.kubernetes.client.ApiClient(
+            ).sanitize_for_serialization(self._volume)
+        return rewrite_data_passing_to_use_volumes(workflow, volume_dict,
+                                                   self._path_prefix)
+
+    def __call__(self, workflow: dict) -> dict:
+        return self.transform_workflow(workflow)

--- a/kfp/dsl/dsl_utils.py
+++ b/kfp/dsl/dsl_utils.py
@@ -1,0 +1,119 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities functions KFP DSL."""
+
+import re
+from typing import Callable, List, Optional, Union
+
+from kfp.components import _structures
+
+_COMPONENT_NAME_PREFIX = 'comp-'
+_EXECUTOR_LABEL_PREFIX = 'exec-'
+
+# TODO: Support all declared types in
+# components._structures.CommandlineArgumenType
+_CommandlineArgumentType = Union[str, int, float,
+                                 _structures.InputValuePlaceholder,
+                                 _structures.InputPathPlaceholder,
+                                 _structures.OutputPathPlaceholder,
+                                 _structures.InputUriPlaceholder,
+                                 _structures.OutputUriPlaceholder,
+                                 _structures.ExecutorInputPlaceholder]
+
+
+def sanitize_component_name(name: str) -> str:
+    """Sanitizes component name."""
+    return _COMPONENT_NAME_PREFIX + _sanitize_name(name)
+
+
+def sanitize_task_name(name: str) -> str:
+    """Sanitizes task name."""
+    return _sanitize_name(name)
+
+
+def sanitize_executor_label(label: str) -> str:
+    """Sanitizes executor label."""
+    return _EXECUTOR_LABEL_PREFIX + _sanitize_name(label)
+
+
+def _sanitize_name(name: str) -> str:
+    """Sanitizes name to comply with IR naming convention.
+
+    The sanitized name contains only lower case alphanumeric characters
+    and dashes.
+    """
+    return re.sub('-+', '-', re.sub('[^-0-9a-z]+', '-',
+                                    name.lower())).lstrip('-').rstrip('-')
+
+# TODO: share with dsl._component_bridge
+def _input_artifact_uri_placeholder(input_key: str) -> str:
+    return "{{{{$.inputs.artifacts['{}'].uri}}}}".format(input_key)
+
+
+def _input_artifact_path_placeholder(input_key: str) -> str:
+    return "{{{{$.inputs.artifacts['{}'].path}}}}".format(input_key)
+
+
+def _input_parameter_placeholder(input_key: str) -> str:
+    return "{{{{$.inputs.parameters['{}']}}}}".format(input_key)
+
+
+def _output_artifact_uri_placeholder(output_key: str) -> str:
+    return "{{{{$.outputs.artifacts['{}'].uri}}}}".format(output_key)
+
+
+def _output_artifact_path_placeholder(output_key: str) -> str:
+    return "{{{{$.outputs.artifacts['{}'].path}}}}".format(output_key)
+
+
+def _output_parameter_path_placeholder(output_key: str) -> str:
+    return "{{{{$.outputs.parameters['{}'].output_file}}}}".format(output_key)
+
+
+def _executor_input_placeholder() -> str:
+    return "{{{{$}}}}"
+
+
+def resolve_cmd_lines(cmds: Optional[List[_CommandlineArgumentType]],
+                      is_output_parameter: Callable[[str], bool]) -> None:
+    """Resolves a list of commands/args."""
+
+    def _resolve_cmd(cmd: Optional[_CommandlineArgumentType]) -> Optional[str]:
+        """Resolves a single command line cmd/arg."""
+        if cmd is None:
+            return None
+        elif isinstance(cmd, (str, float, int)):
+            return str(cmd)
+        elif isinstance(cmd, _structures.InputValuePlaceholder):
+            return _input_parameter_placeholder(cmd.input_name)
+        elif isinstance(cmd, _structures.InputPathPlaceholder):
+            return _input_artifact_path_placeholder(cmd.input_name)
+        elif isinstance(cmd, _structures.InputUriPlaceholder):
+            return _input_artifact_uri_placeholder(cmd.input_name)
+        elif isinstance(cmd, _structures.OutputPathPlaceholder):
+            if is_output_parameter(cmd.output_name):
+                return _output_parameter_path_placeholder(cmd.output_name)
+            else:
+                return _output_artifact_path_placeholder(cmd.output_name)
+        elif isinstance(cmd, _structures.OutputUriPlaceholder):
+            return _output_artifact_uri_placeholder(cmd.output_name)
+        elif isinstance(cmd, _structures.ExecutorInputPlaceholder):
+            return _executor_input_placeholder()
+        else:
+            raise TypeError('Got unexpected placeholder type for %s' % cmd)
+
+    if not cmds:
+        return
+    for idx, cmd in enumerate(cmds):
+        cmds[idx] = _resolve_cmd(cmd)

--- a/kfp/dsl/extensions/kubernetes.py
+++ b/kfp/dsl/extensions/kubernetes.py
@@ -1,0 +1,79 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import string
+
+
+def use_secret(secret_name: str,
+               secret_volume_mount_path: str,
+               env_variable: str = None,
+               secret_file_path_in_volume: str = None):
+    """An operator that configures the container to use a secret.
+
+       This assumes that the secret is created and availabel in the k8s cluster.
+
+    Keyword Arguments:
+        secret_name {String} -- [Required] The k8s secret name.
+        secret_volume_mount_path {String} -- [Required] The path to the secret that is mounted.
+        env_variable {String} -- Env variable pointing to the mounted secret file. Requires both the env_variable and secret_file_path_in_volume to be defined.
+                                 The value is the path to the secret.
+        secret_file_path_in_volume {String} -- The path to the secret in the volume. This will be the value of env_variable.
+                                 Both env_variable and secret_file_path_in_volume needs to be set if any env variable should be created.
+
+    Raises:
+        ValueError: If not the necessary variables (secret_name, volume_name", secret_volume_mount_path) are supplied.
+                    Or only one of  env_variable and secret_file_path_in_volume are supplied
+
+    Returns:
+        [ContainerOperator] -- Returns the container operator after it has been modified.
+    """
+
+    secret_name = str(secret_name)
+    if '{{' in secret_name:
+        volume_name = ''.join(
+            random.choices(string.ascii_lowercase + string.digits,
+                           k=10)) + "_volume"
+    else:
+        volume_name = secret_name
+    for param, param_name in zip([secret_name, secret_volume_mount_path],
+                                 ["secret_name", "secret_volume_mount_path"]):
+        if param == "":
+            raise ValueError("The '{}' must not be empty".format(param_name))
+    if bool(env_variable) != bool(secret_file_path_in_volume):
+        raise ValueError(
+            "Both {} and {} needs to be supplied together or not at all".format(
+                env_variable, secret_file_path_in_volume))
+
+    def _use_secret(task):
+        import os
+        from kubernetes import client as k8s_client
+        task = task.add_volume(
+            k8s_client.V1Volume(
+                name=volume_name,
+                secret=k8s_client.V1SecretVolumeSource(
+                    secret_name=secret_name))).add_volume_mount(
+                        k8s_client.V1VolumeMount(
+                            name=volume_name,
+                            mount_path=secret_volume_mount_path))
+        if env_variable:
+            task.container.add_env_variable(
+                k8s_client.V1EnvVar(
+                    name=env_variable,
+                    value=os.path.join(secret_volume_mount_path,
+                                       secret_file_path_in_volume),
+                ))
+        return task
+
+    return _use_secret

--- a/kfp/dsl/metrics_utils.py
+++ b/kfp/dsl/metrics_utils.py
@@ -1,0 +1,176 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp.dsl import artifact_utils
+from typing import Any, List
+
+
+class ComplexMetricsBase(object):
+
+    def get_schema(self):
+        """Returns the set YAML schema for the metric class.
+
+        Returns:
+          YAML schema of the metrics type.
+        """
+        return self._schema
+
+    def get_metrics(self):
+        """Returns the stored metrics.
+
+        The metrics are type checked against the set schema.
+
+        Returns:
+          Dictionary of metrics data in the format of the set schema.
+        """
+        artifact_utils.verify_schema_instance(self._schema, self._values)
+        return self._values
+
+    def __init__(self, schema_file: str):
+        self._schema = artifact_utils.read_schema_file(schema_file)
+
+        self._type_name, self._metric_fields = artifact_utils.parse_schema(
+            self._schema)
+
+        self._values = {}
+
+
+class ConfidenceMetrics(ComplexMetricsBase):
+    """Metrics class representing a Confidence Metrics."""
+
+    # Initialization flag to support setattr / getattr behavior.
+    _initialized = False
+
+    def __getattr__(self, name: str) -> Any:
+        """Custom __getattr__ to allow access to metrics schema fields."""
+
+        if name not in self._metric_fields:
+            raise AttributeError('No field: {} in metrics.'.format(name))
+
+        return self._values[name]
+
+    def __setattr__(self, name: str, value: Any):
+        """Custom __setattr__ to allow access to metrics schema fields."""
+
+        if not self._initialized:
+            object.__setattr__(self, name, value)
+            return
+
+        if name not in self._metric_fields:
+            raise RuntimeError(
+                'Field: {} not defined in metirc schema'.format(name))
+
+        self._values[name] = value
+
+    def __init__(self):
+        super().__init__('confidence_metrics.yaml')
+        self._initialized = True
+
+
+class ConfusionMatrix(ComplexMetricsBase):
+    """Metrics class representing a confusion matrix."""
+
+    def __init__(self):
+        super().__init__('confusion_matrix.yaml')
+
+        self._matrix = [[]]
+        self._categories = []
+        self._initialized = True
+
+    def set_categories(self, categories: List[str]):
+        """Sets the categories for Confusion Matrix.
+
+        Args:
+          categories: List of strings specifying the categories.
+        """
+        self._categories = []
+        annotation_specs = []
+        for category in categories:
+            annotation_spec = {'displayName': category}
+            self._categories.append(category)
+            annotation_specs.append(annotation_spec)
+
+        self._values['annotationSpecs'] = annotation_specs
+        self._matrix = [[0
+                         for i in range(len(self._categories))]
+                        for j in range(len(self._categories))]
+        self._values['row'] = self._matrix
+
+    def log_row(self, row_category: str, row: List[int]):
+        """Logs a confusion matrix row.
+
+        Args:
+          row_category: Category to which the row belongs.
+          row: List of integers specifying the values for the row.
+
+        Raises:
+          ValueError: If row_category is not in the list of categories set in
+            set_categories or size of the row does not match the size of
+            categories.
+        """
+        if row_category not in self._categories:
+            raise ValueError('Invalid category: {} passed. Expected one of: {}'.\
+              format(row_category, self._categories))
+
+        if len(row) != len(self._categories):
+            raise ValueError('Invalid row. Expected size: {} got: {}'.\
+              format(len(self._categories), len(row)))
+
+        self._matrix[self._categories.index(row_category)] = row
+
+    def log_cell(self, row_category: str, col_category: str, value: int):
+        """Logs a cell in the confusion matrix.
+
+        Args:
+          row_category: String representing the name of the row category.
+          col_category: String representing the name of the column category.
+          value: Int value of the cell.
+
+        Raises:
+          ValueError: If row_category or col_category is not in the list of
+           categories set in set_categories.
+        """
+        if row_category not in self._categories:
+            raise ValueError('Invalid category: {} passed. Expected one of: {}'.\
+              format(row_category, self._categories))
+
+        if col_category not in self._categories:
+            raise ValueError('Invalid category: {} passed. Expected one of: {}'.\
+              format(row_category, self._categories))
+
+        self._matrix[self._categories.index(row_category)][
+            self._categories.index(col_category)] = value
+
+    def load_matrix(self, categories: List[str], matrix: List[List[int]]):
+        """Supports bulk loading the whole confusion matrix.
+
+        Args:
+          categories: List of the category names.
+          matrix: Complete confusion matrix.
+
+        Raises:
+          ValueError: Length of categories does not match number of rows or columns.
+        """
+        self.set_categories(categories)
+
+        if len(matrix) != len(categories):
+            raise ValueError('Invalid matrix: {} passed for categories: {}'.\
+              format(matrix, categories))
+
+        for index in range(len(categories)):
+            if len(matrix[index]) != len(categories):
+                raise ValueError('Invalid matrix: {} passed for categories: {}'.\
+                  format(matrix, categories))
+
+            self.log_row(categories[index], matrix[index])

--- a/kfp/dsl/metrics_utils_test.py
+++ b/kfp/dsl/metrics_utils_test.py
@@ -1,0 +1,70 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.dsl.metrics_utils."""
+
+import os
+import unittest
+import yaml
+import json
+import jsonschema
+
+from google.protobuf import json_format
+from google.protobuf.struct_pb2 import Struct
+
+from kfp.dsl import metrics_utils
+
+from google.protobuf import json_format
+
+
+class MetricsUtilsTest(unittest.TestCase):
+
+    def test_confusion_matrix(self):
+        conf_matrix = metrics_utils.ConfusionMatrix()
+        conf_matrix.set_categories(['dog', 'cat', 'horses'])
+        conf_matrix.log_row('dog', [2, 6, 0])
+        conf_matrix.log_cell('cat', 'dog', 3)
+        with open(
+                os.path.join(
+                    os.path.dirname(__file__), 'test_data',
+                    'expected_confusion_matrix.json')) as json_file:
+            expected_json = json.load(json_file)
+            self.assertEqual(expected_json, conf_matrix.get_metrics())
+
+    def test_bulkload_confusion_matrix(self):
+        conf_matrix = metrics_utils.ConfusionMatrix()
+        conf_matrix.load_matrix(['dog', 'cat', 'horses'],
+                                [[2, 6, 0], [3, 5, 6], [5, 7, 8]])
+
+        with open(
+                os.path.join(
+                    os.path.dirname(__file__), 'test_data',
+                    'expected_bulk_loaded_confusion_matrix.json')) as json_file:
+            expected_json = json.load(json_file)
+            self.assertEqual(expected_json, conf_matrix.get_metrics())
+
+    def test_confidence_metrics(self):
+        confid_metrics = metrics_utils.ConfidenceMetrics()
+        confid_metrics.confidenceThreshold = 24.3
+        confid_metrics.recall = 24.5
+        confid_metrics.falsePositiveRate = 98.4
+        expected_dict = {
+            'confidenceThreshold': 24.3,
+            'recall': 24.5,
+            'falsePositiveRate': 98.4
+        }
+        self.assertEqual(expected_dict, confid_metrics.get_metrics())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kfp/dsl/serialization_utils.py
+++ b/kfp/dsl/serialization_utils.py
@@ -1,0 +1,41 @@
+# Copyright 2020 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for serialization/deserialization."""
+from typing import Any, Dict
+import yaml
+
+
+# Serialize None as blank instead of 'null'.
+def _represent_none(self, _):
+    return self.represent_scalar('tag:yaml.org,2002:null', '')
+
+
+class _NoneAsBlankDumper(yaml.SafeDumper):
+    """Alternative dumper to print YAML literal.
+
+    The behavior is mostly identical to yaml.SafeDumper, except for this
+    dumper dumps None object as blank, instead of 'null'.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_representer(type(None), _represent_none)
+
+
+def yaml_dump(data: Dict[str, Any]) -> str:
+    """Dumps YAML string.
+
+    None will be represented as blank.
+    """
+    return yaml.dump(data, Dumper=_NoneAsBlankDumper)

--- a/kfp/dsl/serialization_utils_test.py
+++ b/kfp/dsl/serialization_utils_test.py
@@ -1,0 +1,48 @@
+# Copyright 2020 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.dsl.serialization_utils module."""
+import unittest
+
+from kfp.dsl import serialization_utils
+
+_DICT_DATA = {
+    'int1': 1,
+    'str1': 'helloworld',
+    'float1': 1.11,
+    'none1': None,
+    'dict1': {
+        'int2': 2,
+        'list2': ['inside the list', None, 42]
+    }
+}
+
+_EXPECTED_YAML_LITERAL = """\
+dict1:
+  int2: 2
+  list2:
+  - inside the list
+  -
+  - 42
+float1: 1.11
+int1: 1
+none1:
+str1: helloworld
+"""
+
+
+class SerializationUtilsTest(unittest.TestCase):
+
+    def testDumps(self):
+        self.assertEqual(_EXPECTED_YAML_LITERAL,
+                         serialization_utils.yaml_dump(_DICT_DATA))

--- a/kfp/dsl/type_schemas/classification_metrics.yaml
+++ b/kfp/dsl/type_schemas/classification_metrics.yaml
@@ -1,0 +1,81 @@
+title: system.ClassificationMetrics
+type: object
+properties:
+  auPrc:
+    type: number
+    format: float
+  auRoc:
+    type: number
+    format: float
+  logLoss:
+    type: number
+    format: float
+  confidenceMetrics:
+    type: array
+    items:
+      type: object
+      properties:
+        confidenceThreshold:
+          type: number
+          format: float
+        maxPredictions:
+          type: integer
+          format: int32
+        recall:
+          type: number
+          format: float
+        precision:
+          type: number
+          format: float
+        falsePositiveRate:
+          type: number
+          format: float
+        f1Score:
+          type: number
+          format: float
+        recallAt1:
+          type: number
+          format: float
+        precisionAt1:
+          type: number
+          format: float
+        falsePositiveRateAt1:
+          type: number
+          format: float
+        f1ScoreAt1:
+          type: number
+          format: float
+        truePositiveCount:
+          type: integer
+          format: int64
+        falsePositiveCount:
+          type: integer
+          format: int64
+        falseNegativeCount:
+          type: integer
+          format: int64
+        trueNegativeCount:
+          type: integer
+          format: int64
+  confusionMatrix:
+    type: object
+    properties:
+      annotationSpecs:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            displayName:
+              type: string
+      rows:
+        type: array
+        items:
+          type: object
+          properties:
+            row:
+              type: array
+              items:
+                type: integer
+                format: int64

--- a/kfp/dsl/type_schemas/confidence_metrics.yaml
+++ b/kfp/dsl/type_schemas/confidence_metrics.yaml
@@ -1,0 +1,45 @@
+title: system.ConfidenceMetrics
+type: object
+properties:
+  confidenceThreshold:
+    type: number
+    format: float
+  maxPredictions:
+    type: integer
+    format: int32
+  recall:
+    type: number
+    format: float
+  precision:
+    type: number
+    format: float
+  falsePositiveRate:
+    type: number
+    format: float
+  f1Score:
+    type: number
+    format: float
+  recallAt1:
+    type: number
+    format: float
+  precisionAt1:
+    type: number
+    format: float
+  falsePositiveRateAt1:
+    type: number
+    format: float
+  f1ScoreAt1:
+    type: number
+    format: float
+  truePositiveCount:
+    type: integer
+    format: int64
+  falsePositiveCount:
+    type: integer
+    format: int64
+  falseNegativeCount:
+    type: integer
+    format: int64
+  trueNegativeCount:
+    type: integer
+    format: int64

--- a/kfp/dsl/type_schemas/confusion_matrix.yaml
+++ b/kfp/dsl/type_schemas/confusion_matrix.yaml
@@ -1,0 +1,23 @@
+title: system.ConfusionMatrix
+type: object
+properties:
+  annotationSpecs:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Optional.
+        displayName:
+          type: string
+  rows:
+    type: array
+    items:
+      type: object
+      properties:
+        row:
+          type: array
+          items:
+            type: integer
+            format: int64

--- a/kfp/dsl/type_schemas/dataset.yaml
+++ b/kfp/dsl/type_schemas/dataset.yaml
@@ -1,0 +1,7 @@
+title: system.Dataset
+type: object
+properties:
+  payload_format:
+    type: string
+  container_format:
+    type: string

--- a/kfp/dsl/type_schemas/metrics.yaml
+++ b/kfp/dsl/type_schemas/metrics.yaml
@@ -1,0 +1,15 @@
+title: system.Metrics
+type: object
+properties:
+  accuracy:
+    type: number
+  precision:
+    type: number
+  recall:
+    type: number
+  f1score:
+    type: number
+  mean_absolute_error:
+    type: number
+  mean_squared_error:
+    type: number

--- a/kfp/dsl/type_schemas/model.yaml
+++ b/kfp/dsl/type_schemas/model.yaml
@@ -1,0 +1,7 @@
+title: system.Model
+type: object
+properties:
+  framework:
+    type: string
+  framework_version:
+    type: string

--- a/kfp/dsl/type_schemas/sliced_classification_metrics.yaml
+++ b/kfp/dsl/type_schemas/sliced_classification_metrics.yaml
@@ -1,0 +1,94 @@
+title: system.SlicedClassificationMetrics
+type: object
+properties:
+  evaluationSlices:
+    type: array
+    items:
+      type: object
+      properties:
+        slice:
+          type: string
+        sliceClassificationMetrics:
+          type: object
+          properties:
+            auPrc:
+              type: number
+              format: float
+            auPrc:
+              type: number
+              format: float
+            auRoc:
+              type: number
+              format: float
+            logLoss:
+              type: number
+              format: float
+            confidenceMetrics:
+              type: array
+              items:
+                type: object
+                properties:
+                  confidenceThreshold:
+                    type: number
+                    format: float
+                  maxPredictions:
+                    type: integer
+                    format: int32
+                  recall:
+                    type: number
+                    format: float
+                  precision:
+                    type: number
+                    format: float
+                  falsePositiveRate:
+                    type: number
+                    format: float
+                  f1Score:
+                    type: number
+                    format: float
+                  recallAt1:
+                    type: number
+                    format: float
+                  precisionAt1:
+                    type: number
+                    format: float
+                  falsePositiveRateAt1:
+                    type: number
+                    format: float
+                  f1ScoreAt1:
+                    type: number
+                    format: float
+                  truePositiveCount:
+                    type: integer
+                    format: int64
+                  falsePositiveCount:
+                    type: integer
+                    format: int64
+                  falseNegativeCount:
+                    type: integer
+                    format: int64
+                  trueNegativeCount:
+                    type: integer
+                    format: int64
+            confusionMatrix:
+              type: object
+              properties:
+                annotationSpecs:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      displayName:
+                        type: string
+                rows:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      row:
+                        type: array
+                        items:
+                          type: integer
+                          format: int64

--- a/kfp/dsl/types.py
+++ b/kfp/dsl/types.py
@@ -1,0 +1,258 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for input/output types in Pipeline DSL.
+
+Feature stage:
+[Beta](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#beta).
+"""
+from typing import Dict, Union
+import warnings
+
+
+def _is_parameter_type(type_name: str) -> bool:
+    """Check if a type is a parameter type (primitive) vs artifact type.
+
+    Parameter types are: String, str, Integer, int, Float, float, Bool, bool,
+    Dict, dict, List, list, and JsonObject.
+    """
+    if not type_name:
+        return False
+    type_lower = str(type_name).lower()
+    return type_lower in (
+        'string', 'str', 'integer', 'int', 'float', 'double',
+        'bool', 'boolean', 'dict', 'list', 'jsonobject'
+    )
+
+class BaseType:
+    """BaseType is a base type for all scalar and artifact types."""
+
+    def to_dict(self) -> Union[Dict, str]:
+        """to_dict serializes the type instance into a python dictionary or
+        string."""
+        return {
+            type(self).__name__: self.__dict__
+        } if self.__dict__ else type(self).__name__
+
+
+# Primitive Types
+class Integer(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "integer"}
+
+
+class String(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "string"}
+
+
+class Float(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "number"}
+
+
+class Bool(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "boolean"}
+
+
+class List(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "array"}
+
+
+class Dict(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {
+            "type": "object",
+        }
+
+
+# GCP Types
+class GCSPath(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {
+            "type": "string",
+            "pattern": "^gs://.*$"
+        }
+
+
+class GCRPath(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {
+            "type": "string",
+            "pattern": "^.*gcr\\.io/.*$"
+        }
+
+
+class GCPRegion(BaseType):
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "string"}
+
+
+class GCPProjectID(BaseType):
+    """MetaGCPProjectID: GCP project id"""
+
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "string"}
+
+
+# General Types
+class LocalPath(BaseType):
+    #TODO: add restriction to path
+    def __init__(self):
+        self.openapi_schema_validator = {"type": "string"}
+
+
+class InconsistentTypeException(Exception):
+    """InconsistencyTypeException is raised when two types are not
+    consistent."""
+    pass
+
+
+class InconsistentTypeWarning(Warning):
+    """InconsistentTypeWarning is issued when two types are not consistent."""
+    pass
+
+
+TypeSpecType = Union[str, Dict]
+
+
+def verify_type_compatibility(given_type: TypeSpecType,
+                              expected_type: TypeSpecType,
+                              error_message_prefix: str = ""):
+    """verify_type_compatibility verifies that the given argument type is
+    compatible with the expected input type.
+
+    Args:
+            given_type (str/dict): The type of the argument passed to the
+              input
+            expected_type (str/dict): The declared type of the input
+    """
+    # Missing types are treated as being compatible with missing types.
+    if given_type is None or expected_type is None:
+        return True
+
+    # Generic artifacts resulted from missing type or explicit "Artifact" type
+    # is compatible with any artifact types.
+    # However, generic artifacts resulted from arbitrary unknown types do not
+    # have such "compatible" feature.
+    if not _is_parameter_type(
+            str(expected_type)) and str(given_type).lower() == "artifact":
+        return True
+    if not _is_parameter_type(
+            str(given_type)) and str(expected_type).lower() == "artifact":
+        return True
+
+    types_are_compatible = check_types(given_type, expected_type)
+
+    if not types_are_compatible:
+        error_text = error_message_prefix + (
+            'Argument type "{}" is incompatible with the input type "{}"'
+        ).format(str(given_type), str(expected_type))
+        import kfp
+        if kfp.TYPE_CHECK:
+            raise InconsistentTypeException(error_text)
+        else:
+            warnings.warn(InconsistentTypeWarning(error_text))
+    return types_are_compatible
+
+
+def check_types(checked_type, expected_type):
+    """check_types checks the type consistency.
+
+    For each of the attribute in checked_type, there is the same attribute
+    in expected_type with the same value.
+    However, expected_type could contain more attributes that checked_type
+    does not contain.
+    Args:
+            checked_type (BaseType/str/dict): it describes a type from the
+              upstream component output
+            expected_type (BaseType/str/dict): it describes a type from the
+              downstream component input
+    """
+    if isinstance(checked_type, BaseType):
+        checked_type = checked_type.to_dict()
+    if isinstance(checked_type, str):
+        checked_type = {checked_type: {}}
+    if isinstance(expected_type, BaseType):
+        expected_type = expected_type.to_dict()
+    if isinstance(expected_type, str):
+        expected_type = {expected_type: {}}
+    return _check_dict_types(checked_type, expected_type)
+
+
+def _check_valid_type_dict(payload):
+    """_check_valid_type_dict checks whether a dict is a correct serialization
+    of a type.
+
+    Args: payload(dict)
+    """
+    if not isinstance(payload, dict) or len(payload) != 1:
+        return False
+    for type_name in payload:
+        if not isinstance(payload[type_name], dict):
+            return False
+        property_types = (int, str, float, bool)
+        property_value_types = (int, str, float, bool, dict)
+        for property_name in payload[type_name]:
+            if not isinstance(property_name, property_types) or not isinstance(
+                    payload[type_name][property_name], property_value_types):
+                return False
+    return True
+
+
+def _check_dict_types(checked_type, expected_type):
+    """_check_dict_types checks the type consistency.
+
+    Args:
+    checked_type (dict): A dict that describes a type from the upstream
+      component output
+    expected_type (dict): A dict that describes a type from the downstream
+      component input
+    """
+    if not checked_type or not expected_type:
+        # If the type is empty, it matches any types
+        return True
+    checked_type_name, _ = list(checked_type.items())[0]
+    expected_type_name, _ = list(expected_type.items())[0]
+    if checked_type_name == "" or expected_type_name == "":
+        # If the type name is empty, it matches any types
+        return True
+    if checked_type_name != expected_type_name:
+        print("type name " + str(checked_type_name) +
+              " is different from expected: " + str(expected_type_name))
+        return False
+    type_name = checked_type_name
+    for type_property in checked_type[type_name]:
+        if type_property not in expected_type[type_name]:
+            print(type_name + " has a property " + str(type_property) +
+                  " that the latter does not.")
+            return False
+        if checked_type[type_name][type_property] != expected_type[type_name][
+                type_property]:
+            print(type_name + " has a property " + str(type_property) +
+                  " with value: " +
+                  str(checked_type[type_name][type_property]) + " and " +
+                  str(expected_type[type_name][type_property]))
+            return False
+    return True

--- a/kfp/gcp.py
+++ b/kfp/gcp.py
@@ -1,0 +1,146 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extension module for KFP on GCP deployment."""
+
+from kubernetes.client import V1Toleration, V1Affinity, V1NodeAffinity, \
+  V1NodeSelector, V1NodeSelectorTerm, V1NodeSelectorRequirement, V1PreferredSchedulingTerm
+
+
+def use_gcp_secret(secret_name='user-gcp-sa',
+                   secret_file_path_in_volume=None,
+                   volume_name=None,
+                   secret_volume_mount_path='/secret/gcp-credentials'):
+    """An operator that configures the container to use GCP service account by
+    service account key stored in a Kubernetes secret.
+
+    For cluster setup and alternatives to using service account key, check https://www.kubeflow.org/docs/gke/authentication-pipelines/.
+    """
+
+    # permitted values for secret_name = ['admin-gcp-sa', 'user-gcp-sa']
+    if secret_file_path_in_volume is None:
+        secret_file_path_in_volume = '/' + secret_name + '.json'
+
+    if volume_name is None:
+        volume_name = 'gcp-credentials-' + secret_name
+
+    else:
+        import warnings
+        warnings.warn(
+            'The volume_name parameter is deprecated and will be removed in next release. The volume names are now generated automatically.',
+            DeprecationWarning)
+
+    def _use_gcp_secret(task):
+        from kubernetes import client as k8s_client
+        task = task.add_volume(
+            k8s_client.V1Volume(
+                name=volume_name,
+                secret=k8s_client.V1SecretVolumeSource(
+                    secret_name=secret_name,)))
+        task.container \
+            .add_volume_mount(
+                    k8s_client.V1VolumeMount(
+                        name=volume_name,
+                        mount_path=secret_volume_mount_path,
+                    )
+                ) \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='GOOGLE_APPLICATION_CREDENTIALS',
+                    value=secret_volume_mount_path + secret_file_path_in_volume,
+                )
+            ) \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE',
+                    value=secret_volume_mount_path + secret_file_path_in_volume,
+                )
+            ) # Set GCloud Credentials by using the env var override.
+        # TODO: Is there a better way for GCloud to pick up the credential?
+        return task
+
+    return _use_gcp_secret
+
+
+def use_tpu(tpu_cores: int, tpu_resource: str, tf_version: str):
+    """An operator that configures GCP TPU spec in a container op.
+
+    Args:
+      tpu_cores: Required. The number of cores of TPU resource.
+        For example, the value can be '8', '32', '128', etc.
+        Check more details at: https://cloud.google.com/tpu/docs/kubernetes-engine-setup#pod-spec.
+      tpu_resource: Required. The resource name of the TPU resource.
+        For example, the value can be 'v2', 'preemptible-v1', 'v3' or 'preemptible-v3'.
+        Check more details at: https://cloud.google.com/tpu/docs/kubernetes-engine-setup#pod-spec.
+      tf_version: Required. The TensorFlow version that the TPU nodes use.
+        For example, the value can be '1.12', '1.11', '1.9' or '1.8'.
+        Check more details at: https://cloud.google.com/tpu/docs/supported-versions.
+    """
+
+    def _set_tpu_spec(task):
+        task.add_pod_annotation('tf-version.cloud-tpus.google.com', tf_version)
+        task.container.add_resource_limit(
+            'cloud-tpus.google.com/{}'.format(tpu_resource), str(tpu_cores))
+        return task
+
+    return _set_tpu_spec
+
+
+def use_preemptible_nodepool(toleration: V1Toleration = V1Toleration(
+    effect='NoSchedule', key='preemptible', operator='Equal', value='true'),
+                             hard_constraint: bool = False):
+    """An operator that configures the GKE preemptible in a container op.
+
+    Args:
+      toleration: toleration to pods, default is the preemptible label.
+      hard_constraint: the constraint of scheduling the pods on preemptible
+          nodepools is hard. (Default: False)
+    """
+
+    def _set_preemptible(task):
+        task.add_toleration(toleration)
+        node_selector_term = V1NodeSelectorTerm(match_expressions=[
+            V1NodeSelectorRequirement(
+                key='cloud.google.com/gke-preemptible',
+                operator='In',
+                values=['true'])
+        ])
+        if hard_constraint:
+            node_affinity = V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                    node_selector_terms=[node_selector_term]))
+        else:
+            node_affinity = V1NodeAffinity(
+                preferred_during_scheduling_ignored_during_execution=[
+                    V1PreferredSchedulingTerm(
+                        preference=node_selector_term, weight=50)
+                ])
+        affinity = V1Affinity(node_affinity=node_affinity)
+        task.add_affinity(affinity=affinity)
+        return task
+
+    return _set_preemptible
+
+
+def add_gpu_toleration(toleration: V1Toleration = V1Toleration(
+    effect='NoSchedule', key='nvidia.com/gpu', operator='Equal', value='true')):
+    """An operator that configures the GKE GPU nodes in a container op.
+
+    Args:
+      toleration: toleration to pods, default is the nvidia.com/gpu label.
+    """
+
+    def _set_toleration(task):
+        task.add_toleration(toleration)
+
+    return _set_toleration

--- a/kfp/notebook/__init__.py
+++ b/kfp/notebook/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import _magic

--- a/kfp/notebook/_magic.py
+++ b/kfp/notebook/_magic.py
@@ -1,0 +1,60 @@
+# Copyright 2018 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+from deprecated.sphinx import deprecated
+
+from ..compiler import build_docker_image
+
+
+@deprecated(
+    version='0.1.32',
+    reason='The %%docker magic is deprecated. Use `kfp.containers.build_image_from_working_dir` instead.'
+)
+def docker(line, cell):
+    """cell magic for %%docker."""
+
+    if len(line.split()) < 2:
+        raise ValueError(
+            "usage: %%docker [gcr.io/project/image:tag] [gs://staging-bucket] [600] [kubeflow]\n\
+                      arg1(required): target image tag\n\
+                      arg2(required): staging gcs bucket\n\
+                      arg3(optional): timeout in seconds, default(600)\n\
+                      arg4(optional): namespace, default(kubeflow)")
+    if not cell.strip():
+        raise ValueError("Please fill in a dockerfile content in the cell.")
+
+    fields = line.split()
+
+    with tempfile.NamedTemporaryFile(mode='wt', delete=False) as f:
+        f.write(cell)
+
+    build_docker_image(
+        fields[1],
+        fields[0],
+        f.name,
+        timeout=int(fields[2]) if len(fields) >= 3 else 600,
+        namespace=fields[3] if len(fields) >= 4 else 'kubeflow')
+    os.remove(f.name)
+
+
+try:
+    import IPython
+    docker = IPython.core.magic.register_cell_magic(docker)
+except ImportError:
+    pass
+except NameError:
+    pass

--- a/kfp/onprem.py
+++ b/kfp/onprem.py
@@ -1,0 +1,133 @@
+from typing import Dict, Optional
+from kfp import dsl
+
+
+def mount_pvc(pvc_name='pipeline-claim',
+              volume_name='pipeline',
+              volume_mount_path='/mnt/pipeline'):
+    """Modifier function to apply to a Container Op to simplify volume, volume
+    mount addition and enable better reuse of volumes, volume claims across
+    container ops.
+
+    Example:
+        ::
+
+            train = train_op(...)
+            train.apply(mount_pvc('claim-name', 'pipeline', '/mnt/pipeline'))
+    """
+
+    def _mount_pvc(task):
+        from kubernetes import client as k8s_client
+        # there can be other ops in a pipeline (e.g. ResourceOp, VolumeOp)
+        # refer to #3906
+        if not hasattr(task, "add_volume") or not hasattr(
+                task, "add_volume_mount"):
+            return task
+        local_pvc = k8s_client.V1PersistentVolumeClaimVolumeSource(
+            claim_name=pvc_name)
+        return (task.add_volume(
+            k8s_client.V1Volume(
+                name=volume_name,
+                persistent_volume_claim=local_pvc)).add_volume_mount(
+                    k8s_client.V1VolumeMount(
+                        mount_path=volume_mount_path, name=volume_name)))
+
+    return _mount_pvc
+
+
+def use_k8s_secret(
+    secret_name: str = 'k8s-secret',
+    k8s_secret_key_to_env: Optional[Dict] = None,
+):
+    """An operator that configures the container to use k8s credentials.
+
+    k8s_secret_key_to_env specifies a mapping from the name of the keys in the k8s secret to the name of the
+    environment variables where the values will be added.
+
+    The secret needs to be deployed manually a priori.
+
+    Example:
+        ::
+
+            train = train_op(...)
+            train.apply(use_k8s_secret(secret_name='s3-secret',
+            k8s_secret_key_to_env={'secret_key': 'AWS_SECRET_ACCESS_KEY'}))
+
+        This will load the value in secret 's3-secret' at key 'secret_key' and source it as the environment variable
+        'AWS_SECRET_ACCESS_KEY'. I.e. it will produce the following section on the pod:
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3-secret
+              key: secret_key
+    """
+
+    k8s_secret_key_to_env = k8s_secret_key_to_env or {}
+
+    def _use_k8s_secret(task):
+        from kubernetes import client as k8s_client
+        for secret_key, env_var in k8s_secret_key_to_env.items():
+            task.container \
+                .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name=env_var,
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=secret_key
+                        )
+                    )
+                )
+            )
+        return task
+
+    return _use_k8s_secret
+
+
+def add_default_resource_spec(
+    memory_limit: Optional[str] = None,
+    cpu_limit: Optional[str] = None,
+    memory_request: Optional[str] = None,
+    cpu_request: Optional[str] = None,
+):
+    """Add default resource requests and limits.
+
+    For resource units, refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes.
+
+    Args:
+      memory_limit: optional, memory limit. Format can be 512Mi, 2Gi etc.
+      cpu_limit: optional, cpu limit. Format can be 0.5, 500m etc.
+      memory_request: optional, defaults to memory limit.
+      cpu_request: optional, defaults to cpu limit.
+    """
+    if not memory_request:
+        memory_request = memory_limit
+    if not cpu_request:
+        cpu_request = cpu_limit
+
+    def _add_default_resource_spec(task):
+        # Skip tasks which are not container ops.
+        if not isinstance(task, dsl.ContainerOp):
+            return task
+        _apply_default_resource(task, 'cpu', cpu_request, cpu_limit)
+        _apply_default_resource(task, 'memory', memory_request, memory_limit)
+        return task
+
+    return _add_default_resource_spec
+
+
+def _apply_default_resource(task: dsl.ContainerOp, resource_name: str,
+                            default_request: Optional[str],
+                            default_limit: Optional[str]):
+    if task.container.get_resource_limit(resource_name):
+        # Do nothing.
+        # Limit is set, request will default to limit if not set (Kubernetes default behavior),
+        # so we do not need to further apply defaults.
+        return
+
+    if default_limit:
+        task.container.add_resource_limit(resource_name, default_limit)
+    if default_request:
+        if not task.container.get_resource_request(resource_name):
+            task.container.add_resource_request(resource_name, default_request)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,32 @@ classifiers = [
 
 dependencies = [
     "mlflow (==2.22.0)",
-    "kfp (==1.8.22)",
+    # kfp 1.8.24 is vendored under top-level `kfp/` (see NOTICE) to remove
+    # its hard pin on pydantic<2 from the public dep tree. Transitive runtime
+    # deps from kfp are listed below.
+    "kfp-pipeline-spec >=0.1.16,<0.2.0",
+    "kfp-server-api >=1.1.2,<2.0.0",
+    "absl-py >=0.9,<2",
+    "click >=7.1.2,<9",
+    "cloudpickle >=2.0.0,<3",
+    "Deprecated >=1.2.7,<2",
+    "docstring-parser >=0.7.3,<1",
+    "fire >=0.3.1,<1",
+    "google-api-core >=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    "google-api-python-client >=1.7.8,<2",
+    "google-auth >=1.6.1,<3",
+    "google-cloud-storage >=2.2.1,<3",
+    "jsonschema >=3.0.1,<5",
+    "protobuf >=3.13.0,<4",
+    "requests-toolbelt >=0.8.0,<1",
+    "strip-hints >=0.1.8,<1",
+    "tabulate >=0.8.6,<1",
+    "typer >=0.3.2,<1.0",
+    "uritemplate >=3.0.1,<4",
+    "urllib3 <3.0.0",
     "pyyaml (>=6.0.2,<7)",
-    "pydantic (<2.0.0)",
+    "pydantic >=2.0.0,<3.0.0",
+    "pydantic-settings >=2.0.0",
     "scikit-learn (==1.7.0)",
     "tenacity",
     "kubernetes",
@@ -60,7 +83,7 @@ Documentation = "https://hiro-microdatacenters-bv.github.io/cogflow"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["cogflow","cogflow*"]
+include = ["cogflow", "cogflow*", "kfp", "kfp*"]
 
 [tool.setuptools.package-data]
 "cogflow" = [
@@ -70,9 +93,13 @@ include = ["cogflow","cogflow*"]
   "config.py",
   "LICENSE.md"
 ]
+"kfp" = [
+  "**/*.yaml",
+  "**/*.json",
+]
 
 [tool.setuptools]
-license-files = ["LICENSE.md"]
+license-files = ["LICENSE.md", "NOTICE", "kfp/LICENSE"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
## Summary

Cogflow's `kfp==1.8.22` dependency forces `pydantic<2` transitively. This blocks installs alongside Cog-Engine and other downstreams that have moved to pydantic 2 (resolver fails with `cogflow depends on pydantic<2.0.0 and you require pydantic>=2.11.7`).

This PR vendors **kfp 1.8.24** (Apache-2.0) as a top-level package inside cogflow's wheel. Downstream behavior is unchanged: `import kfp` works exactly as it would after `pip install kfp`, but the install no longer carries kfp's `pydantic<2` pin.

## Why kfp 2.x migration is not the answer

kfp 2.x breaks Kubeflow 1.8 cluster compatibility and the team's FL pipelines. Until that migration becomes feasible, vendoring kfp 1.8 inside cogflow is the cleanest path to unblock pydantic 2 in Cog-Engine and other consumers.

## Why kfp 1.8.24 has no pydantic code

Inspected the wheel: `grep -rE "pydantic" kfp/` returns zero hits. The `pydantic>=1.8.2,<2` line in upstream kfp's `setup.py` is leftover from earlier 1.8.x versions that had `kfp/v2/components/experimental/structures.py`. That module was removed by 1.8.24, but the dep wasn't cleaned up. Vendoring 1.8.24 means we ship code that doesn't import pydantic at all; we just don't propagate the stale pin.

## What "vendoring" means here (Shape B)

- `kfp/` lives at the **top level** of cogflow's wheel
- After `pip install cogflow`, `site-packages/kfp/` is created exactly as if `pip install kfp==1.8.24` had been run
- `import kfp` works regardless of import order — no `import cogflow` required first, no sys.modules tricks, no `.pth` files
- Cogflow effectively becomes the canonical kfp provider in any env it's installed in (acceptable for HIRO's stack; cogflow is the only intended kfp consumer)

## Changes

- **Add `kfp/`** at repo root (97 files, ~1 MB) — verbatim from kfp 1.8.24 PyPI wheel, plus Apache-2.0 LICENSE
- **Add `NOTICE`** at repo root attributing the vendored source per Apache-2.0
- **`pyproject.toml`**:
  - Package both `cogflow` and `kfp` in the wheel (`include = ["cogflow*", "kfp*"]`)
  - Drop `kfp==1.8.22` dep
  - Add kfp's runtime transitive deps (minus pydantic): `kfp-pipeline-spec`, `kfp-server-api`, `absl-py`, `click`, `cloudpickle`, `Deprecated`, `docstring-parser`, `fire`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-cloud-storage`, `jsonschema`, `protobuf<4`, `requests-toolbelt`, `strip-hints`, `tabulate`, `typer`, `uritemplate`, `urllib3<3`
  - Switch pydantic constraint to `pydantic>=2.0.0,<3.0.0` + add `pydantic-settings>=2.0.0`
- **`cogflow/config.py`**:
  - Use `pydantic_settings.BaseSettings` (with v1 fallback for graceful degradation)
  - Add type annotation to `COMPONENTS_BUCKET_NAME` for pydantic 2 strictness
- **Bump version** to `2.0.1b2`

## Verification

```
$ python3 -m build --wheel
Successfully built cogflow-2.0.1b2-py3-none-any.whl  (289 KB)

$ unzip -p dist/cogflow-2.0.1b2-py3-none-any.whl cogflow-2.0.1b2.dist-info/top_level.txt
cogflow
kfp

# Clean pydantic-2 venv:
$ pip install "pydantic>=2.11.7,<3" "pydantic-settings>=2.0.0"
$ pip install --no-deps dist/cogflow-2.0.1b2-py3-none-any.whl

$ python -c "import kfp, cogflow; print(kfp.__version__, kfp.__file__)"
1.8.24 /tmp/cogflowtest/lib/python3.10/site-packages/kfp/__init__.py

$ python -c "from cogflow import models, datasets, pipelines, serving; print('OK')"
OK
```

## Trade-offs

- **Cogflow owns `kfp` in any env it's installed in.** If a downstream wants a different kfp version, they can't have it without uninstalling cogflow. Acceptable: cogflow is the only intended kfp consumer in HIRO's stack.
- **Wheel size grows from ~50 KB → 289 KB.** Acceptable.
- **Manual re-vendor on kfp 1.8.25+.** Acceptable: kfp 1.8.x is essentially frozen; new releases are rare.

## Test plan

- [ ] CI green (cogflow's own test suite — note pre-existing `cogflow.utils` import failure exists at v2.0.1b1 baseline too, unrelated to this change)
- [ ] After this lands and is published as `2.0.1b2`, retry Cog-Engine PR #266 with `cogflow==2.0.1b2` pinned in `requirements.txt` — should resolve cleanly under pydantic 2

## Not in scope

- Fixing the pre-existing `cogflow.utils` test import issue (separate)
- Publishing `2.0.1b2` to PyPI (release workflow handles on tag push)
- Cog-Engine PR #266 changes (will follow once this is published)