### PR TITLE
Auto-publish cogflow:latest image on tag push, channel-aware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,20 +135,38 @@ jobs:
           echo "Channel: $CHANNEL"
           echo "Tags: $TAGS"
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Wait for PyPI propagation
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          for i in 1 2 3 4 5; do
-            if pip index versions cogflow --pre 2>/dev/null | grep -qE "\b$VERSION\b"; then
-              echo "cogflow==$VERSION is available on PyPI"
-              exit 0
-            fi
-            echo "Waiting for PyPI propagation ($i/5)..."
-            sleep 15
-          done
-          echo "::error::cogflow==$VERSION not found on PyPI after 75s"
-          exit 1
+          python3 - <<'PY'
+          import json, os, sys, time
+          from urllib.request import urlopen
+          from urllib.error import URLError
+
+          version = os.environ["VERSION"]
+          url = "https://pypi.org/pypi/cogflow/json"
+
+          for attempt in range(1, 6):
+              try:
+                  with urlopen(url, timeout=10) as resp:
+                      data = json.load(resp)
+                  if version in data.get("releases", {}):
+                      print(f"cogflow=={version} is available on PyPI")
+                      sys.exit(0)
+              except URLError as exc:
+                  print(f"PyPI request failed (attempt {attempt}/5): {exc}")
+              print(f"Waiting for PyPI propagation ({attempt}/5)...")
+              time.sleep(15)
+
+          print(f"::error::cogflow=={version} not found on PyPI after 75s")
+          sys.exit(1)
+          PY
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,79 @@ jobs:
           files: dist/*
           prerelease: ${{ needs.build.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
+
+  docker-publish:
+    needs: [build, publish-pypi]
+    if: startsWith(github.ref, 'refs/tags/v') && needs.publish-pypi.result == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Determine channel and image tags
+        id: tags
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          REGISTRY="hiroregistry/cogflow"
+          if [[ "$VERSION" == *b* ]]; then
+            CHANNEL="beta"
+          elif [[ "$VERSION" == *rc* ]]; then
+            CHANNEL="rc"
+          elif [[ "$VERSION" == *a* ]]; then
+            CHANNEL="alpha"
+          else
+            CHANNEL="stable"
+          fi
+          if [[ "$CHANNEL" == "stable" ]]; then
+            TAGS="$REGISTRY:$VERSION,$REGISTRY:latest"
+          else
+            TAGS="$REGISTRY:$VERSION,$REGISTRY:latest-$CHANNEL"
+          fi
+          {
+            echo "tags=$TAGS"
+            echo "channel=$CHANNEL"
+            echo "version_tag=$REGISTRY:$VERSION"
+          } >> "$GITHUB_OUTPUT"
+          echo "Channel: $CHANNEL"
+          echo "Tags: $TAGS"
+
+      - name: Wait for PyPI propagation
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for i in 1 2 3 4 5; do
+            if pip index versions cogflow --pre 2>/dev/null | grep -qE "\b$VERSION\b"; then
+              echo "cogflow==$VERSION is available on PyPI"
+              exit 0
+            fi
+            echo "Waiting for PyPI propagation ($i/5)..."
+            sleep 15
+          done
+          echo "::error::cogflow==$VERSION not found on PyPI after 75s"
+          exit 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push cogflow:latest image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker_image_variants/latest
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            COGFLOW_VERSION=${{ needs.build.outputs.version }}
+
+      - name: Smoke test pushed image
+        run: |
+          docker pull "${{ steps.tags.outputs.version_tag }}"
+          docker run --rm "${{ steps.tags.outputs.version_tag }}" \
+            python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"


### PR DESCRIPTION
## Summary

Adds a `docker-publish` job to `.github/workflows/release.yml` that builds and pushes the `cogflow:latest` Docker image to `hiroregistry/cogflow` on every `v*` tag, with tags derived from the release channel:

| Version example | Channel | Tags pushed |
|---|---|---|
| `2.0.1b2` | beta | `:2.0.1b2`, `:latest-beta` |
| `2.0.1rc1` | rc | `:2.0.1rc1`, `:latest-rc` |
| `2.0.1a1` | alpha | `:2.0.1a1`, `:latest-alpha` |
| `2.0.1` | stable | `:2.0.1`, `:latest` |

## Why

- Downstream consumers (Cog-Engine, etc.) pin their CI container to `hiroregistry/cogflow:latest-<channel>`. Today images are built and pushed manually, which is error-prone and blocks release PRs.
- `:latest-beta` lets Cog-Engine's `develop` CI track cogflow pre-releases without chasing version numbers, while `:latest` stays reserved for stable.

## Behavior

- Runs only on `refs/tags/v*` pushes, **after** `publish-pypi` succeeds
- Waits up to 75s polling `pip index versions cogflow --pre` for the new version (PyPI's JSON index lags the upload by ~30s)
- Builds `docker_image_variants/latest/Dockerfile` with `--build-arg COGFLOW_VERSION=<version>`
- Smoke-tests the pushed image: `docker run ... python3 -c 'import cogflow, kfp'`

## Scope notes

- **Only the `latest` variant** is published (per your direction). `fl`, `lite`, `tensor`, `torch` remain manual until we decide to automate them — the matrix pattern is easy to add later.
- **Dockerfile defaults left untouched** (still `ARG COGFLOW_VERSION=1.11.15`). The workflow always passes an explicit `--build-arg` so the default only matters for local `docker build` without an arg.
- **Secrets required**: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (confirmed present in repo secrets).

## Test plan

- [ ] Merge to `refactor`
- [ ] On next `v*` tag push (or re-tag of an existing release), verify:
  - [ ] `docker-publish` job runs and succeeds
  - [ ] `hiroregistry/cogflow:<version>` and the appropriate `:latest-<channel>` are pushed
  - [ ] Smoke test passes (`import cogflow, kfp` inside the pushed image)
- [ ] First real use: next cogflow pre-release will populate `:latest-beta`; Cog-Engine PR #266 then switches its CI container to that tag