### PR TITLE
Bump to 2.0.1b3

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b2"
+__version__ = "2.0.1b3"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [


### PR DESCRIPTION
Version-only bump. 2.0.1b2 was tagged before the docker-publish workflow merged, so its release didn't produce an image. This release exercises the new workflow to publish `hiroregistry/cogflow:2.0.1b3` and `hiroregistry/cogflow:latest-beta` — which Cog-Engine PR #266 needs as its CI container.

No code changes vs 2.0.1b2.