### PR TITLE
latest Dockerfile: pin shap==0.44.* (cp310 manylinux wheel)

### DIFF
--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -9,8 +9,11 @@ ARG COGFLOW_VERSION=1.11.15
 # Install specific version of cogflow
 RUN pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}
 
-# Install additional Python packages (shap, xgboost)
-RUN pip3 install --ignore-requires-python shap xgboost
+# Install additional Python packages (shap, xgboost).
+# shap pinned to 0.44.* which publishes cp310 manylinux wheels; newer shap
+# (0.47+) has a broken setup.py for the slim base and falls back to source
+# builds that need g++.
+RUN pip3 install "shap==0.44.*" xgboost
 
 # Install compatible protobuf version first
 RUN pip install --no-cache-dir protobuf==3.20.1


### PR DESCRIPTION
## Why

The `docker-publish` workflow for `v2.0.1b3` failed at:

```
RUN pip3 install --ignore-requires-python shap xgboost
...
error: command 'g++' failed: No such file or directory
Exception occurred during setup, Error building cuda module
```

Newer shap (0.47+) doesn't publish a py3.10 manylinux wheel, so pip falls back to a source build. `python:3.10-slim` has no C++ toolchain.

## Fix

Pin `shap==0.44.*`, which publishes cp310 manylinux wheels. The install becomes a binary drop-in, no compiler needed, slim base preserved (no size growth).

Also dropped `--ignore-requires-python` since 0.44.* supports 3.10 natively.

## How to re-exercise after merge

`2.0.1b3` is already on PyPI, so its tag can't be re-used (publish-pypi would reject the duplicate). Simplest path: bump to `2.0.1b4` and tag — that run will exercise `docker-publish` end-to-end.