### PR TITLE
Bump to 2.0.1b4

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b3"
+__version__ = "2.0.1b4"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [


### PR DESCRIPTION
Version-only bump. 2.0.1b3's docker-publish failed at shap install (pre-existing Dockerfile issue). PR #79 pinned shap==0.44.*; this release will exercise the fixed workflow and publish `hiroregistry/cogflow:2.0.1b4` and `hiroregistry/cogflow:latest-beta`.

No code changes.