### PR TITLE
release.yml: fix PyPI wait race + add workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,10 +170,12 @@ jobs:
           # pip can see it. Confirming against the simple index prevents
           # the docker build from racing with PyPI CDN propagation.
           url = "https://pypi.org/simple/cogflow/"
-          needles = (
-              f"cogflow-{version}.tar.gz",
-              f"cogflow-{version}-py3-none-any.whl",
-          )
+          # Match any distribution file for this exact version:
+          #   - wheels (any tag):  "cogflow-<v>-*.whl"      -> prefix "cogflow-<v>-"
+          #   - sdists:            "cogflow-<v>.tar.gz" / .zip -> prefix "cogflow-<v>."
+          # Matching prefixes (not specific filenames) covers future platform-tagged
+          # wheels without needing workflow changes.
+          needles = (f"cogflow-{version}-", f"cogflow-{version}.")
 
           attempts = 12  # ~4 minutes total
           for attempt in range(1, attempts + 1):
@@ -186,7 +188,8 @@ jobs:
               except URLError as exc:
                   print(f"simple-index request failed ({attempt}/{attempts}): {exc}")
               print(f"Waiting for simple index to list {version} ({attempt}/{attempts})...")
-              time.sleep(20)
+              if attempt < attempts:
+                  time.sleep(20)
 
           print(f"::error::cogflow=={version} not on simple index after ~4 min")
           sys.exit(1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,19 @@ on:
       - 'release/**'
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'cogflow version to build & publish the image for (must already be on PyPI, e.g. 2.0.1b4)'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   build:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -100,7 +107,14 @@ jobs:
 
   docker-publish:
     needs: [build, publish-pypi]
-    if: startsWith(github.ref, 'refs/tags/v') && needs.publish-pypi.result == 'success'
+    # Run on tag push (after publish-pypi success) OR manual dispatch with a version input.
+    # `always()` lets the job run even when `build`/`publish-pypi` were skipped by
+    # workflow_dispatch — we guard on the result condition explicitly.
+    if: |
+      always() && (
+        (startsWith(github.ref, 'refs/tags/v') && needs.publish-pypi.result == 'success')
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -110,7 +124,7 @@ jobs:
       - name: Determine channel and image tags
         id: tags
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
         run: |
           REGISTRY="hiroregistry/cogflow"
           if [[ "$VERSION" == *b* ]]; then
@@ -140,31 +154,41 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Wait for PyPI propagation
+      - name: Wait for PyPI simple index to list the version
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
         run: |
           python3 - <<'PY'
-          import json, os, sys, time
+          import os, sys, time
           from urllib.request import urlopen
           from urllib.error import URLError
 
           version = os.environ["VERSION"]
-          url = "https://pypi.org/pypi/cogflow/json"
+          # Check the SIMPLE index (what pip actually uses during install),
+          # not the JSON metadata API. The two are cached separately and the
+          # simple index lags: a version can appear in JSON minutes before
+          # pip can see it. Confirming against the simple index prevents
+          # the docker build from racing with PyPI CDN propagation.
+          url = "https://pypi.org/simple/cogflow/"
+          needles = (
+              f"cogflow-{version}.tar.gz",
+              f"cogflow-{version}-py3-none-any.whl",
+          )
 
-          for attempt in range(1, 6):
+          attempts = 12  # ~4 minutes total
+          for attempt in range(1, attempts + 1):
               try:
                   with urlopen(url, timeout=10) as resp:
-                      data = json.load(resp)
-                  if version in data.get("releases", {}):
-                      print(f"cogflow=={version} is available on PyPI")
+                      html = resp.read().decode("utf-8", errors="replace")
+                  if any(n in html for n in needles):
+                      print(f"cogflow=={version} visible on simple index")
                       sys.exit(0)
               except URLError as exc:
-                  print(f"PyPI request failed (attempt {attempt}/5): {exc}")
-              print(f"Waiting for PyPI propagation ({attempt}/5)...")
-              time.sleep(15)
+                  print(f"simple-index request failed ({attempt}/{attempts}): {exc}")
+              print(f"Waiting for simple index to list {version} ({attempt}/{attempts})...")
+              time.sleep(20)
 
-          print(f"::error::cogflow=={version} not found on PyPI after 75s")
+          print(f"::error::cogflow=={version} not on simple index after ~4 min")
           sys.exit(1)
           PY
 
@@ -184,7 +208,7 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
-            COGFLOW_VERSION=${{ needs.build.outputs.version }}
+            COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
 
       - name: Smoke test pushed image
         run: |


### PR DESCRIPTION
## Why

v2.0.1b4's release run hit a new failure in `docker-publish`:

```
pip3 install cogflow==2.0.1b4
ERROR: No matching distribution found for cogflow==2.0.1b4
(from versions: ..., 2.0.1b1, 2.0.1b2, 2.0.1b3)
```

But the workflow's wait step had already printed `cogflow==2.0.1b4 is available on PyPI`. Root cause: PyPI's JSON metadata API and simple index are cached separately, and the simple index (what `pip` actually uses) lags. The probe passed on JSON while pip inside Docker still couldn't see the version.

## Fix A — probe simple index (what pip uses)

Switched the Python wait step from `/pypi/cogflow/json` to `/simple/cogflow/`, grepping the HTML for `cogflow-<version>.tar.gz` or `cogflow-<version>-py3-none-any.whl`. Same endpoint pip uses, so the race is gone. Retry budget: 12×20s (~4 min), which comfortably covers observed CDN lag.

## Fix B — add `workflow_dispatch` with a version input

Today, if `docker-publish` fails after PyPI already accepted the version (like v2.0.1b4), the only recovery is to cut another version (v2.0.1b5) and re-tag. Wasteful churn.

Added `workflow_dispatch` input `version`. When dispatched, `build`/`publish-pypi`/`github-release` skip (already-released versions don't need re-publish), and `docker-publish` runs standalone against the provided version.

- `docker-publish.if` now: `always() && ((tag-push && pypi success) || workflow_dispatch)`
- Version source: `github.event.inputs.version || needs.build.outputs.version`

## Test plan

- [ ] Merge this PR
- [ ] Trigger: `gh workflow run release.yml -f version=2.0.1b4` (from the repo's Actions tab → Run workflow, or via CLI)
- [ ] Verify docker-publish builds `hiroregistry/cogflow:2.0.1b4` and `hiroregistry/cogflow:latest-beta`
- [ ] Smoke test runs `import cogflow, kfp` successfully
- [ ] Next real release (push of v2.0.1b5+) also exercises the new simple-index wait and passes