### PR TITLE
ServingManager: tolerate missing kube config at import time + bump 2.0.1b5

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b4"
+__version__ = "2.0.1b5"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -20,6 +20,7 @@ from typing import Optional, Dict, Any, List
 
 from kubernetes import client
 from kubernetes.client.exceptions import ApiException
+from kubernetes.config.config_exception import ConfigException
 
 from ..utils import common
 from ..config import config as cog_config
@@ -65,34 +66,47 @@ class ServingManager:
     PLURAL = "inferenceservices"
 
     def __init__(self):
-        """Initialize Kubernetes client.
+        """Initialize the Kubernetes client if cluster config is available.
 
-        Tolerant of missing kube config so `import cogflow.serving` does not
+        This initialization is tolerant of missing kube config so importing the
+        serving interface (for example, ``from cogflow import serving``) does not
         fail in environments without a cluster (CI, local dev, build agents).
-        Methods that talk to the cluster will raise CogflowConnectionError
-        until config becomes available.
+
+        If config cannot be loaded, ``self._api`` remains ``None`` and the
+        ``self.api`` property will retry on first access, raising
+        ``CogflowConnectionError`` if k8s is still unavailable.
         """
-        self.api = None
+        self._api = None
         try:
             _ensure_k8s_config_loaded()
-            self.api = client.CustomObjectsApi()
-        except Exception as exc:  # ConfigException, FileNotFoundError, etc.
+            self._api = client.CustomObjectsApi()
+        except (ConfigException, FileNotFoundError, OSError) as exc:
             logger.warning(
                 "Kubernetes config could not be loaded: %s. "
                 "ServingManager cluster operations will fail until config is available.",
                 exc,
             )
 
-    def _require_api(self):
-        """Raise CogflowConnectionError if Kubernetes is not configured."""
-        if self.api is None:
-            try:
-                _ensure_k8s_config_loaded()
-                self.api = client.CustomObjectsApi()
-            except Exception as exc:
-                raise CogflowConnectionError(
-                    f"Kubernetes config is not loaded: {exc}"
-                ) from exc
+    @property
+    def api(self):
+        """Lazily-validated Kubernetes CustomObjectsApi.
+
+        Returns the cached client if already initialized; otherwise retries
+        config load and raises ``CogflowConnectionError`` if it still fails.
+        Routing every existing ``self.api.<call>`` site through this property
+        means cluster operations get a clear, typed error instead of an
+        ``AttributeError`` on ``None.<call>``.
+        """
+        if self._api is not None:
+            return self._api
+        try:
+            _ensure_k8s_config_loaded()
+            self._api = client.CustomObjectsApi()
+        except (ConfigException, FileNotFoundError, OSError) as exc:
+            raise CogflowConnectionError(
+                f"Kubernetes config is not loaded: {exc}"
+            ) from exc
+        return self._api
 
     # -----------------------------------------------------------------
     # Lazy-load helpers (NO circular imports)

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -65,9 +65,34 @@ class ServingManager:
     PLURAL = "inferenceservices"
 
     def __init__(self):
-        """Initialize Kubernetes client"""
-        _ensure_k8s_config_loaded()
-        self.api = client.CustomObjectsApi()
+        """Initialize Kubernetes client.
+
+        Tolerant of missing kube config so `import cogflow.serving` does not
+        fail in environments without a cluster (CI, local dev, build agents).
+        Methods that talk to the cluster will raise CogflowConnectionError
+        until config becomes available.
+        """
+        self.api = None
+        try:
+            _ensure_k8s_config_loaded()
+            self.api = client.CustomObjectsApi()
+        except Exception as exc:  # ConfigException, FileNotFoundError, etc.
+            logger.warning(
+                "Kubernetes config could not be loaded: %s. "
+                "ServingManager cluster operations will fail until config is available.",
+                exc,
+            )
+
+    def _require_api(self):
+        """Raise CogflowConnectionError if Kubernetes is not configured."""
+        if self.api is None:
+            try:
+                _ensure_k8s_config_loaded()
+                self.api = client.CustomObjectsApi()
+            except Exception as exc:
+                raise CogflowConnectionError(
+                    f"Kubernetes config is not loaded: {exc}"
+                ) from exc
 
     # -----------------------------------------------------------------
     # Lazy-load helpers (NO circular imports)

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -427,3 +427,41 @@ def test_process_isvc(serving_module):
     assert result["status"] == "ready"
     assert result["traffic_percentage"] == 100
     assert result["latest_ready_revision"] == "r1"
+
+
+# ---------------------------------------------------------------------
+# Regression: missing kube config must not break import
+# ---------------------------------------------------------------------
+
+
+def test_servingmanager_init_tolerates_missing_kube_config(monkeypatch):
+    """Importing serving + constructing ServingManager must not raise when
+    kube config is unavailable. First cluster access must raise
+    CogflowConnectionError (not AttributeError)."""
+    import importlib
+
+    from kubernetes.config.config_exception import ConfigException
+
+    from cogflow.utils import common
+    from cogflow.utils.exceptions import CogflowConnectionError
+
+    if hasattr(common, "_k8s_loaded_flag"):
+        del common._k8s_loaded_flag
+
+    def raising_load():
+        raise ConfigException("Invalid kube-config file. No configuration found.")
+
+    monkeypatch.setattr(common, "load_k8s_config", raising_load, raising=True)
+
+    # Reload re-runs the module body, including `_serving = ServingManager()`.
+    # Pre-fix this raised; with the fix it must succeed.
+    import cogflow.core.serving as sm
+
+    importlib.reload(sm)
+
+    assert sm._serving is not None
+    assert sm._serving._api is None
+
+    # Accessing .api retries the load and surfaces the typed connection error.
+    with pytest.raises(CogflowConnectionError):
+        _ = sm._serving.api


### PR DESCRIPTION
## Why

`cogflow/core/serving.py` instantiates `ServingManager()` at module import time (line 1125), which calls `_ensure_k8s_config_loaded()` inside `__init__`. In any environment without a kubeconfig (CI runners, local dev outside a cluster, build agents), this raises `ConfigException` and breaks `from cogflow import serving` for everyone — even consumers that only mock or never call serving methods.

Caught in Cog-Engine PR #266's CI:

```
ConftestImportFailure: ConfigException: Invalid kube-config file. No configuration found.
... (traceback through:)
app/services/kfp_pipeline_service.py:18: from cogflow import serving as cogflow_serving
cogflow/core/serving.py:1125: _serving = ServingManager()
cogflow/core/serving.py:69: _ensure_k8s_config_loaded()
```

## Fix

Mirror the lenient pattern `ModelManager` already uses for an unreachable MLflow:
- catch the exception in `__init__`,
- log a warning,
- set `self.api = None`,
- let the import succeed.

Added `_require_api()` helper that re-attempts config load on first cluster call and raises `CogflowConnectionError` with context if still unavailable. Existing methods that use `self.api` directly will fail with `AttributeError` if k8s never becomes available — acceptable for now; threading `_require_api()` through every public method is a follow-up.

`AsyncServingManager` is already lazy (config load deferred to `_get_api()`), so no change needed there.

## Why not stub a kube-config in CI

A fake `KUBECONFIG` file in CI would unblock imports too, but it's the wrong fix:
- Every consumer has to do the dance — libraries shouldn't require infrastructure at import time
- A leaked test fixture in prod silently points at localhost
- Major Python k8s libs (`kopf`, `pykube`, FastAPI k8s extensions) all defer config loading to first-use; this PR matches that convention

## Version bump

`__version__` → `2.0.1b5`. After merge: tag `v2.0.1b5` will trigger the docker workflow and republish `hiroregistry/cogflow:latest-beta` with the fix.

## Test plan

- [ ] `from cogflow import serving` works in an env with no kubeconfig
- [ ] After merge + tag + image publish, Cog-Engine PR #266 CI runs to completion