### PR TITLE
Add deploy_llm: KServe 0.15 huggingface-runtime ISVC builder

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -554,6 +554,116 @@ class AsyncServingManager:
             )
 
 
+    # -----------------------------------------------------------------
+    # LLM SERVING (async)
+    # -----------------------------------------------------------------
+
+    async def deploy_llm(
+        self,
+        *,
+        storage_uri: str,
+        isvc_name: str,
+        served_model_name: str,
+        namespace: Optional[str] = None,
+        max_model_len: Optional[int] = None,
+        dtype: Optional[str] = None,
+        tensor_parallel_size: Optional[int] = None,
+        trust_remote_code: bool = False,
+        gpu_memory_utilization: Optional[float] = None,
+        max_num_seqs: Optional[int] = None,
+        resources: Optional[Dict[str, Dict[str, str]]] = None,
+        tolerations: Optional[List[Dict[str, Any]]] = None,
+        node_selector: Optional[Dict[str, str]] = None,
+        min_replicas: int = 1,
+        max_replicas: int = 1,
+        hf_secret_name: Optional[str] = None,
+        annotations: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """Create a KServe HF-runtime InferenceService (async).
+
+        Spec-building is delegated to ``ServingManager._build_llm_predictor``
+        so there is a single source of truth for the ISVC shape; this method
+        adds the async CRD create and the async K8s client plumbing.
+        """
+        namespace = namespace or common.get_namespace()
+        api = await self._get_api()
+
+        sync_manager_cls = _get_serving_manager_class()
+        predictor_spec = sync_manager_cls._build_llm_predictor(
+            storage_uri=storage_uri,
+            served_model_name=served_model_name,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            tensor_parallel_size=tensor_parallel_size,
+            trust_remote_code=trust_remote_code,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            resources=resources,
+            tolerations=tolerations,
+            node_selector=node_selector,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            hf_secret_name=hf_secret_name,
+        )
+
+        metadata = async_client.V1ObjectMeta(
+            name=isvc_name,
+            namespace=namespace,
+            annotations=annotations or {},
+        )
+        body = {
+            "apiVersion": f"{self.GROUP}/{self.VERSION}",
+            "kind": "InferenceService",
+            "metadata": metadata.to_dict(),
+            "spec": {"predictor": predictor_spec},
+        }
+
+        try:
+            created = await api.create_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                body=body,
+            )
+            logger.info(
+                "LLM InferenceService '%s' created in namespace '%s'.",
+                isvc_name,
+                namespace,
+            )
+            return created
+        except ApiException as e:
+            if e.status == 409:
+                CogflowErrorHandler.handle_exception(
+                    e,
+                    context=(
+                        f"LLM InferenceService '{isvc_name}' already exists in "
+                        f"namespace '{namespace}'."
+                    ),
+                    raise_as=CogflowValidationError,
+                    re_raise=True,
+                )
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=(
+                    f"Create LLM InferenceService '{isvc_name}' in namespace "
+                    f"'{namespace}'"
+                ),
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=(
+                    f"Create LLM InferenceService '{isvc_name}' in namespace "
+                    f"'{namespace}'"
+                ),
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
+
 # Create singleton and expose async methods at module level
 _async_serving = AsyncServingManager()
 
@@ -565,3 +675,4 @@ async_get_isvc = _async_serving.get_isvc
 async_update_isvc = _async_serving.update_isvc
 async_restart_isvc = _async_serving.restart_isvc
 async_create_isvc = _async_serving.create_isvc
+async_deploy_llm = _async_serving.deploy_llm

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -645,6 +645,26 @@ class ServingManager:
         max_replicas: int,
         hf_secret_name: Optional[str],
     ) -> Dict[str, Any]:
+        # Replica bounds must be internally consistent before we hand the
+        # ISVC to KServe — otherwise the CRD is rejected at admission (or
+        # silently misbehaves if admission is permissive). Validate here
+        # so both sync (deploy_llm) and async (async_deploy_llm) paths
+        # surface a clear CogflowValidationError instead of leaking a
+        # K8s API error upstream.
+        if min_replicas < 0:
+            raise CogflowValidationError(
+                f"min_replicas must be >= 0, got {min_replicas}"
+            )
+        if max_replicas < 1:
+            raise CogflowValidationError(
+                f"max_replicas must be >= 1, got {max_replicas}"
+            )
+        if min_replicas > max_replicas:
+            raise CogflowValidationError(
+                f"min_replicas ({min_replicas}) must be "
+                f"<= max_replicas ({max_replicas})"
+            )
+
         model_block: Dict[str, Any] = {
             "modelFormat": {"name": "huggingface"},
             "storageUri": storage_uri,
@@ -727,24 +747,27 @@ class ServingManager:
             namespace,
             storage_uri,
         )
-        try:
-            predictor_spec = ServingManager._build_llm_predictor(
-                storage_uri=storage_uri,
-                served_model_name=served_model_name,
-                max_model_len=max_model_len,
-                dtype=dtype,
-                tensor_parallel_size=tensor_parallel_size,
-                trust_remote_code=trust_remote_code,
-                gpu_memory_utilization=gpu_memory_utilization,
-                max_num_seqs=max_num_seqs,
-                resources=resources,
-                tolerations=tolerations,
-                node_selector=node_selector,
-                min_replicas=min_replicas,
-                max_replicas=max_replicas,
-                hf_secret_name=hf_secret_name,
-            )
+        # Replica / field validation happens before the try/except so a
+        # bad input surfaces the typed CogflowValidationError unchanged,
+        # not wrapped as a generic CogflowServingError.
+        predictor_spec = ServingManager._build_llm_predictor(
+            storage_uri=storage_uri,
+            served_model_name=served_model_name,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            tensor_parallel_size=tensor_parallel_size,
+            trust_remote_code=trust_remote_code,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            resources=resources,
+            tolerations=tolerations,
+            node_selector=node_selector,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            hf_secret_name=hf_secret_name,
+        )
 
+        try:
             metadata = client.V1ObjectMeta(
                 name=isvc_name,
                 namespace=namespace,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1409,6 +1409,7 @@ for attr_name in dir(ServingManager):
 # Expose async methods from AsyncServingManager
 from .async_serving import (  # noqa: E402
     async_deploy_model,
+    async_deploy_llm,
     async_update_model,
     async_delete_isvc,
     async_list_models,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -596,19 +596,31 @@ class ServingManager:
         gpu_memory_utilization: Optional[float],
         max_num_seqs: Optional[int],
     ) -> List[str]:
-        """Whitelisted vLLM-runtime args passed into the HF runtime container.
+        """Whitelisted runtime args passed into the HF runtime container.
 
         Order is stable so the emitted ISVC is diff-friendly across reruns.
+
+        Naming note — the two conventions below are deliberate, not
+        accidental. KServe's huggingface runtime uses ``parse_known_args``
+        and consumes its own underscore-style flags first, then forwards
+        the remainder to the vLLM backend parser (hyphen-style).
+
+        - Underscore flags land in the KServe HF runtime parser
+          (``kserve/python/huggingfaceserver``): ``--model_name``,
+          ``--max_model_len``, ``--dtype``, ``--trust_remote_code``.
+        - Hyphen flags fall through to vLLM's CLI
+          (``--tensor-parallel-size``, ``--gpu-memory-utilization``,
+          ``--max-num-seqs``).
         """
         args: List[str] = [f"--model_name={served_model_name}"]
         if max_model_len is not None:
             args.append(f"--max_model_len={max_model_len}")
         if dtype is not None:
             args.append(f"--dtype={dtype}")
+        if trust_remote_code:
+            args.append("--trust_remote_code")
         if tensor_parallel_size is not None:
             args.append(f"--tensor-parallel-size={tensor_parallel_size}")
-        if trust_remote_code:
-            args.append("--trust-remote-code")
         if gpu_memory_utilization is not None:
             args.append(f"--gpu-memory-utilization={gpu_memory_utilization}")
         if max_num_seqs is not None:

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -559,6 +559,236 @@ class ServingManager:
                 re_raise=True,
             )
 
+    # -----------------------------------------------------------------
+    # LLM SERVING (KServe 0.15+ huggingface ClusterServingRuntime)
+    # -----------------------------------------------------------------
+
+    # Defaults match a small-to-mid 7B model on a single GPU. Callers can
+    # override per-field via the `resources` arg.
+    _LLM_DEFAULT_RESOURCES: Dict[str, Dict[str, str]] = {
+        "requests": {"cpu": "4", "memory": "7Gi", "nvidia.com/gpu": "1"},
+        "limits": {"cpu": "8", "memory": "8Gi", "nvidia.com/gpu": "1"},
+    }
+
+    @staticmethod
+    def _merge_resources(
+        override: Optional[Dict[str, Dict[str, str]]],
+    ) -> Dict[str, Dict[str, str]]:
+        """Per-field merge of caller overrides onto the default block."""
+        merged = {
+            "requests": dict(ServingManager._LLM_DEFAULT_RESOURCES["requests"]),
+            "limits": dict(ServingManager._LLM_DEFAULT_RESOURCES["limits"]),
+        }
+        if override:
+            for section in ("requests", "limits"):
+                if override.get(section):
+                    merged[section].update(override[section])
+        return merged
+
+    @staticmethod
+    def _build_llm_args(
+        served_model_name: str,
+        *,
+        max_model_len: Optional[int],
+        dtype: Optional[str],
+        tensor_parallel_size: Optional[int],
+        trust_remote_code: bool,
+        gpu_memory_utilization: Optional[float],
+        max_num_seqs: Optional[int],
+    ) -> List[str]:
+        """Whitelisted vLLM-runtime args passed into the HF runtime container.
+
+        Order is stable so the emitted ISVC is diff-friendly across reruns.
+        """
+        args: List[str] = [f"--model_name={served_model_name}"]
+        if max_model_len is not None:
+            args.append(f"--max_model_len={max_model_len}")
+        if dtype is not None:
+            args.append(f"--dtype={dtype}")
+        if tensor_parallel_size is not None:
+            args.append(f"--tensor-parallel-size={tensor_parallel_size}")
+        if trust_remote_code:
+            args.append("--trust-remote-code")
+        if gpu_memory_utilization is not None:
+            args.append(f"--gpu-memory-utilization={gpu_memory_utilization}")
+        if max_num_seqs is not None:
+            args.append(f"--max-num-seqs={max_num_seqs}")
+        return args
+
+    @staticmethod
+    def _build_llm_predictor(
+        *,
+        storage_uri: str,
+        served_model_name: str,
+        max_model_len: Optional[int],
+        dtype: Optional[str],
+        tensor_parallel_size: Optional[int],
+        trust_remote_code: bool,
+        gpu_memory_utilization: Optional[float],
+        max_num_seqs: Optional[int],
+        resources: Optional[Dict[str, Dict[str, str]]],
+        tolerations: Optional[List[Dict[str, Any]]],
+        node_selector: Optional[Dict[str, str]],
+        min_replicas: int,
+        max_replicas: int,
+        hf_secret_name: Optional[str],
+    ) -> Dict[str, Any]:
+        model_block: Dict[str, Any] = {
+            "modelFormat": {"name": "huggingface"},
+            "storageUri": storage_uri,
+            "args": ServingManager._build_llm_args(
+                served_model_name,
+                max_model_len=max_model_len,
+                dtype=dtype,
+                tensor_parallel_size=tensor_parallel_size,
+                trust_remote_code=trust_remote_code,
+                gpu_memory_utilization=gpu_memory_utilization,
+                max_num_seqs=max_num_seqs,
+            ),
+            "resources": ServingManager._merge_resources(resources),
+        }
+
+        if hf_secret_name:
+            model_block["env"] = [
+                {
+                    "name": "HF_TOKEN",
+                    "valueFrom": {
+                        "secretKeyRef": {"name": hf_secret_name, "key": "HF_TOKEN"}
+                    },
+                }
+            ]
+
+        predictor: Dict[str, Any] = {
+            "minReplicas": min_replicas,
+            "maxReplicas": max_replicas,
+            "model": model_block,
+        }
+
+        # S3-backed artifacts need the cluster-provisioned S3 SA.
+        # HF Hub pulls do not — omitting the SA keeps the pod token-free.
+        if storage_uri.startswith("s3://"):
+            predictor["serviceAccountName"] = "kserve-controller-s3"
+
+        if tolerations:
+            predictor["tolerations"] = tolerations
+        if node_selector:
+            predictor["nodeSelector"] = node_selector
+
+        return predictor
+
+    def deploy_llm(
+        self,
+        *,
+        storage_uri: str,
+        isvc_name: str,
+        served_model_name: str,
+        namespace: Optional[str] = None,
+        # vLLM runtime args (whitelist)
+        max_model_len: Optional[int] = None,
+        dtype: Optional[str] = None,
+        tensor_parallel_size: Optional[int] = None,
+        trust_remote_code: bool = False,
+        gpu_memory_utilization: Optional[float] = None,
+        max_num_seqs: Optional[int] = None,
+        # scheduling / scaling
+        resources: Optional[Dict[str, Dict[str, str]]] = None,
+        tolerations: Optional[List[Dict[str, Any]]] = None,
+        node_selector: Optional[Dict[str, str]] = None,
+        min_replicas: int = 1,
+        max_replicas: int = 1,
+        # auth
+        hf_secret_name: Optional[str] = None,
+        annotations: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """Create a KServe InferenceService backed by the built-in
+        ``huggingface`` ClusterServingRuntime (KServe 0.15+).
+
+        The ``storage_uri`` is used verbatim — pass ``hf://<org>/<model>``
+        for a direct HF Hub pull or ``s3://mlflow/...`` for an MLflow-stored
+        HF-format checkpoint. Callers (e.g. Cog-Engine) are responsible for
+        resolving the source.
+        """
+        namespace = namespace or common.get_namespace()
+        logger.info(
+            "Creating LLM InferenceService name=%s namespace=%s storage_uri=%s",
+            isvc_name,
+            namespace,
+            storage_uri,
+        )
+        try:
+            predictor_spec = ServingManager._build_llm_predictor(
+                storage_uri=storage_uri,
+                served_model_name=served_model_name,
+                max_model_len=max_model_len,
+                dtype=dtype,
+                tensor_parallel_size=tensor_parallel_size,
+                trust_remote_code=trust_remote_code,
+                gpu_memory_utilization=gpu_memory_utilization,
+                max_num_seqs=max_num_seqs,
+                resources=resources,
+                tolerations=tolerations,
+                node_selector=node_selector,
+                min_replicas=min_replicas,
+                max_replicas=max_replicas,
+                hf_secret_name=hf_secret_name,
+            )
+
+            metadata = client.V1ObjectMeta(
+                name=isvc_name,
+                namespace=namespace,
+                annotations=annotations or {},
+            )
+            body = {
+                "apiVersion": f"{self.GROUP}/{self.VERSION}",
+                "kind": "InferenceService",
+                "metadata": metadata.to_dict(),
+                "spec": {"predictor": predictor_spec},
+            }
+
+            created = self.api.create_namespaced_custom_object(
+                group=self.GROUP,
+                version=self.VERSION,
+                namespace=namespace,
+                plural=self.PLURAL,
+                body=body,
+            )
+            logger.info(
+                "LLM InferenceService '%s' created successfully in namespace '%s'.",
+                isvc_name,
+                namespace,
+            )
+            return created
+        except ApiException as e:
+            if e.status == 409:
+                CogflowErrorHandler.handle_exception(
+                    e,
+                    context=(
+                        f"LLM InferenceService '{isvc_name}' already exists in "
+                        f"namespace '{namespace}'."
+                    ),
+                    raise_as=CogflowValidationError,
+                    re_raise=True,
+                )
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=(
+                    f"Create LLM InferenceService '{isvc_name}' in namespace "
+                    f"'{namespace}'"
+                ),
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=(
+                    f"Create LLM InferenceService '{isvc_name}' in namespace "
+                    f"'{namespace}'"
+                ),
+                raise_as=CogflowServingError,
+                re_raise=True,
+            )
+
     @staticmethod
     def _process_isvc(isvc: dict) -> Dict[str, Any]:
         """

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -260,3 +260,43 @@ def test_async_module_exports():
     assert callable(async_serving_module.async_update_isvc)
     assert callable(async_serving_module.async_restart_isvc)
     assert callable(async_serving_module.async_create_isvc)
+    assert callable(async_serving_module.async_deploy_llm)
+
+
+# ---------------------------------------------------------------------
+# LLM SERVING (async deploy_llm)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_deploy_llm_emits_expected_spec(async_serving, fake_async_api):
+    """The async path delegates spec-building to the sync helper, so the
+    emitted ISVC must match what deploy_llm in serving.py produces."""
+    await async_serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="qwen25-coder",
+        served_model_name="qwen25-coder",
+        max_model_len=4096,
+        tolerations=[
+            {"key": "storage-type", "operator": "Equal",
+             "value": "local", "effect": "NoSchedule"}
+        ],
+        annotations={"model_type": "llm"},
+    )
+
+    creates = [c for c in fake_async_api.calls if c[0] == "create"]
+    assert len(creates) == 1
+    body = creates[0][1]["body"]
+    predictor = body["spec"]["predictor"]
+    model = predictor["model"]
+
+    assert body["metadata"]["name"] == "qwen25-coder"
+    assert body["metadata"]["annotations"]["model_type"] == "llm"
+    assert "serviceAccountName" not in predictor
+    assert model["modelFormat"] == {"name": "huggingface"}
+    assert model["storageUri"] == "hf://Qwen/Qwen2.5-Coder-7B-Instruct"
+    assert "--model_name=qwen25-coder" in model["args"]
+    assert "--max_model_len=4096" in model["args"]
+    assert predictor["tolerations"][0]["key"] == "storage-type"
+    # Defaults applied
+    assert model["resources"]["requests"]["nvidia.com/gpu"] == "1"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -617,23 +617,47 @@ def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
     )
 
     args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    # Underscored flags (model_name, max_model_len, dtype, trust_remote_code)
+    # land in KServe's HF runtime parser; hyphenated flags
+    # (tensor-parallel-size, gpu-memory-utilization, max-num-seqs) fall
+    # through to vLLM via parse_known_args. See _build_llm_args docstring.
     assert args == [
         "--model_name=q",
         "--max_model_len=4096",
         "--dtype=bfloat16",
+        "--trust_remote_code",
         "--tensor-parallel-size=2",
-        "--trust-remote-code",
         "--gpu-memory-utilization=0.9",
         "--max-num-seqs=32",
     ]
 
 
 def test_serving_module_reexports_async_deploy_llm():
-    """cogflow.serving must expose async_deploy_llm at its public surface
-    alongside the other async_* helpers. Consumers (e.g. Cog-Engine) import
-    it as ``cogflow.serving.async_deploy_llm`` — regression guard for that.
-    """
-    import cogflow.core.serving as serving_module
+    """cogflow.serving must expose async_deploy_llm alongside the other
+    async_* helpers. Consumers (e.g. Cog-Engine) reach it via
+    ``from cogflow import serving as cogflow_serving`` through the
+    ``cogflow.__init__`` _LazyLoader.
 
-    assert hasattr(serving_module, "async_deploy_llm")
-    assert callable(serving_module.async_deploy_llm)
+    We check this in a fresh subprocess because pytest-mock's conftest
+    eagerly imports subpackages of ``cogflow`` before the test runs,
+    which defeats the _LazyLoader (``sys.modules['cogflow']`` ends up
+    as the plain package module, not the _LazyLoader stub). That's a
+    pre-existing cogflow-wide quirk, not a regression of this change —
+    the subprocess guarantees the only import machinery in play is the
+    one consumers actually see.
+    """
+    import subprocess
+    import sys
+
+    script = (
+        "from cogflow import serving as cogflow_serving; "
+        "assert hasattr(cogflow_serving, 'async_deploy_llm'); "
+        "assert callable(cogflow_serving.async_deploy_llm)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, (
+        f"Public API `cogflow.serving.async_deploy_llm` does not resolve.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -561,6 +561,47 @@ def test_deploy_llm_resource_override_is_per_field_merge(serving, serving_module
     assert res["limits"]["nvidia.com/gpu"] == "2"     # overridden
 
 
+def test_deploy_llm_rejects_inverted_replica_range(serving, serving_module):
+    """min_replicas > max_replicas should surface as CogflowValidationError
+    before hitting the K8s API (where it would produce an admission error
+    with less context).
+    """
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="min_replicas"):
+        serving.deploy_llm(
+            storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+            isvc_name="bad",
+            served_model_name="bad",
+            min_replicas=3,
+            max_replicas=1,
+        )
+
+
+def test_deploy_llm_rejects_negative_min_replicas(serving, serving_module):
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="min_replicas"):
+        serving.deploy_llm(
+            storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+            isvc_name="bad",
+            served_model_name="bad",
+            min_replicas=-1,
+        )
+
+
+def test_deploy_llm_rejects_zero_max_replicas(serving, serving_module):
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="max_replicas"):
+        serving.deploy_llm(
+            storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+            isvc_name="bad",
+            served_model_name="bad",
+            max_replicas=0,
+        )
+
+
 def test_deploy_llm_node_selector_and_replicas(serving, serving_module):
     _, fake_api, _ = serving_module
 
@@ -654,9 +695,20 @@ def test_serving_module_reexports_async_deploy_llm():
         "assert hasattr(cogflow_serving, 'async_deploy_llm'); "
         "assert callable(cogflow_serving.async_deploy_llm)"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True, check=False
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            "Timed out while verifying public API "
+            "`cogflow.serving.async_deploy_llm` in a subprocess.\n"
+            f"stdout:\n{exc.stdout or ''}\nstderr:\n{exc.stderr or ''}"
+        )
     assert result.returncode == 0, (
         f"Public API `cogflow.serving.async_deploy_llm` does not resolve.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -626,3 +626,14 @@ def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
         "--gpu-memory-utilization=0.9",
         "--max-num-seqs=32",
     ]
+
+
+def test_serving_module_reexports_async_deploy_llm():
+    """cogflow.serving must expose async_deploy_llm at its public surface
+    alongside the other async_* helpers. Consumers (e.g. Cog-Engine) import
+    it as ``cogflow.serving.async_deploy_llm`` — regression guard for that.
+    """
+    import cogflow.core.serving as serving_module
+
+    assert hasattr(serving_module, "async_deploy_llm")
+    assert callable(serving_module.async_deploy_llm)

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -465,3 +465,164 @@ def test_servingmanager_init_tolerates_missing_kube_config(monkeypatch):
     # Accessing .api retries the load and surfaces the typed connection error.
     with pytest.raises(CogflowConnectionError):
         _ = sm._serving.api
+
+
+# ---------------------------------------------------------------------
+# LLM SERVING (deploy_llm)
+# ---------------------------------------------------------------------
+
+
+def _deploy_llm_create_call(fake_api):
+    """Helper: extract the body of the single create call from the fake API."""
+    creates = [c for c in fake_api.calls if c[0] == "create"]
+    assert len(creates) == 1, f"expected 1 create call, got {len(creates)}"
+    return creates[0][1]["body"]
+
+
+def test_deploy_llm_hf_uri_emits_expected_spec(serving, serving_module):
+    """hf:// URI → no serviceAccountName; modelFormat=huggingface; tolerations + args pass through."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="qwen25-coder",
+        served_model_name="qwen25-coder",
+        max_model_len=4096,
+        tolerations=[
+            {"key": "storage-type", "operator": "Equal",
+             "value": "local", "effect": "NoSchedule"}
+        ],
+        annotations={"model_type": "llm", "hf_model_id": "Qwen/Qwen2.5-Coder-7B-Instruct"},
+    )
+
+    body = _deploy_llm_create_call(fake_api)
+    predictor = body["spec"]["predictor"]
+    model = predictor["model"]
+
+    assert body["metadata"]["name"] == "qwen25-coder"
+    assert body["metadata"]["annotations"]["model_type"] == "llm"
+    assert "serviceAccountName" not in predictor  # HF pull — no S3 SA
+    assert model["modelFormat"] == {"name": "huggingface"}
+    assert model["storageUri"] == "hf://Qwen/Qwen2.5-Coder-7B-Instruct"
+    assert "--model_name=qwen25-coder" in model["args"]
+    assert "--max_model_len=4096" in model["args"]
+    assert predictor["tolerations"][0]["key"] == "storage-type"
+
+
+def test_deploy_llm_s3_uri_sets_service_account(serving, serving_module):
+    """s3:// URI → serviceAccountName=kserve-controller-s3."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="s3://mlflow/0/abc/artifacts/model",
+        isvc_name="mlf-llm",
+        served_model_name="mlf-llm",
+    )
+
+    predictor = _deploy_llm_create_call(fake_api)["spec"]["predictor"]
+    assert predictor["serviceAccountName"] == "kserve-controller-s3"
+
+
+def test_deploy_llm_default_resources(serving, serving_module):
+    """No resources override → defaults: 4/7Gi/1gpu requests, 8/8Gi/1gpu limits."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+    )
+
+    res = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["resources"]
+    assert res["requests"] == {"cpu": "4", "memory": "7Gi", "nvidia.com/gpu": "1"}
+    assert res["limits"] == {"cpu": "8", "memory": "8Gi", "nvidia.com/gpu": "1"}
+
+
+def test_deploy_llm_resource_override_is_per_field_merge(serving, serving_module):
+    """Only the overridden keys change; other defaults survive."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        resources={
+            "requests": {"memory": "14Gi", "nvidia.com/gpu": "2"},
+            "limits": {"nvidia.com/gpu": "2"},
+        },
+    )
+
+    res = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["resources"]
+    assert res["requests"]["cpu"] == "4"              # default preserved
+    assert res["requests"]["memory"] == "14Gi"        # overridden
+    assert res["requests"]["nvidia.com/gpu"] == "2"   # overridden
+    assert res["limits"]["cpu"] == "8"                # default preserved
+    assert res["limits"]["memory"] == "8Gi"           # default preserved
+    assert res["limits"]["nvidia.com/gpu"] == "2"     # overridden
+
+
+def test_deploy_llm_node_selector_and_replicas(serving, serving_module):
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        node_selector={"gpu": "a100"},
+        min_replicas=2,
+        max_replicas=4,
+    )
+
+    predictor = _deploy_llm_create_call(fake_api)["spec"]["predictor"]
+    assert predictor["nodeSelector"] == {"gpu": "a100"}
+    assert predictor["minReplicas"] == 2
+    assert predictor["maxReplicas"] == 4
+
+
+def test_deploy_llm_with_hf_secret_adds_env(serving, serving_module):
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://meta-llama/Llama-3.1-8B-Instruct",
+        isvc_name="llama",
+        served_model_name="llama",
+        hf_secret_name="cog-llm-token-llama",
+    )
+
+    env = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["env"]
+    assert env == [
+        {
+            "name": "HF_TOKEN",
+            "valueFrom": {
+                "secretKeyRef": {"name": "cog-llm-token-llama", "key": "HF_TOKEN"}
+            },
+        }
+    ]
+
+
+def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
+    """Args appear in stable order; trust_remote_code is a bare flag."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        max_model_len=4096,
+        dtype="bfloat16",
+        tensor_parallel_size=2,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.9,
+        max_num_seqs=32,
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert args == [
+        "--model_name=q",
+        "--max_model_len=4096",
+        "--dtype=bfloat16",
+        "--tensor-parallel-size=2",
+        "--trust-remote-code",
+        "--gpu-memory-utilization=0.9",
+        "--max-num-seqs=32",
+    ]


### PR DESCRIPTION
## Why

Serving an LLM on KServe 0.15's built-in \`huggingface\` ClusterServingRuntime needs a different ISVC shape than cogflow's existing \`create_isvc\` / \`deploy_model\`:

- classical: \`predictor.model\` + optional transformer container, hardcoded \`serviceAccountName: kserve-controller-s3\`, fixed \`minReplicas=1\`.
- LLM: \`predictor.model.modelFormat: {name: huggingface}\` + vLLM runtime args, GPU resources, tolerations, optional \`HF_TOKEN\` env from a Secret, and S3 SA ONLY when the storage URI is s3://.

Existing cogflow code has no knobs for GPU/resources/tolerations/replicas/runtime args. Rather than overload \`deploy_model\`, this PR adds a dedicated LLM builder.

## What

New public entry points:

- \`cogflow.serving.deploy_llm(...)\` — sync builder; creates the ISVC CRD.
- \`cogflow.serving.async_deploy_llm(...)\` — async mirror. Delegates spec-building to the sync helper so both paths emit an identical body.

Accepted knobs (all keyword-only):

- \`storage_uri\` — \`hf://<org>/<model>\` or \`s3://mlflow/.../artifacts/...\`. Caller is responsible for source resolution.
- \`isvc_name\`, \`served_model_name\`, \`namespace\`.
- Whitelisted vLLM runtime args: \`max_model_len\`, \`dtype\`, \`tensor_parallel_size\`, \`trust_remote_code\`, \`gpu_memory_utilization\`, \`max_num_seqs\`. Other flags would require a schema update — explicit so nothing surprising is passed into production pods.
- \`resources\` — default \`{requests: {cpu:4, memory:7Gi, nvidia.com/gpu:1}, limits: {cpu:8, memory:8Gi, nvidia.com/gpu:1}}\` with per-field override merge.
- \`tolerations\`, \`node_selector\`, \`min_replicas\`, \`max_replicas\`.
- \`hf_secret_name\` — wires \`HF_TOKEN\` from a pre-existing K8s Secret via \`env[].valueFrom.secretKeyRef\`.
- \`annotations\` — free-form ISVC annotations (callers pass \`model_type=llm\` etc.).

## Conditional behavior worth calling out

- \`serviceAccountName: kserve-controller-s3\` is set **only** when the storage URI starts with \`s3://\`. HF Hub pulls don't need the S3 token.
- Stable args ordering so emitted YAML is diff-friendly across reruns.
- \`trust_remote_code\` emits a bare \`--trust-remote-code\` flag (no \`=\`), matching vLLM's CLI.

## Tests

- \`tests/test_serving.py\` — 7 new tests covering HF vs S3 SA handling, default resources, per-field override merge, tolerations/nodeSelector/replicas pass-through, HF secret env, and whitelisted-args order.
- \`tests/test_async_serving.py\` — 1 new async test pinning the emitted body matches the sync contract + the module-level export check.
- Full suite: **213 passed, 1 skipped** — no regressions.

Run:
\`\`\`
pytest tests/test_serving.py -k deploy_llm -v
pytest tests/test_async_serving.py -k deploy_llm -v
\`\`\`

## Downstream

Cog-Engine will consume \`cogflow.async_deploy_llm\` from a new branch (\`feature/llm-serving\`) that extends \`POST /models-serving\` with a \`serving_type\` discriminator. That PR will ship separately against this same \`refactor\` base.
