### PR TITLE
release: publish cogflow docker image for linux/amd64 + linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,13 @@ jobs:
           sys.exit(1)
           PY
 
+      - name: Set up QEMU
+        # Needed for cross-platform builds: the runner is linux/amd64,
+        # so emulation is required to produce the linux/arm64 layer.
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -208,6 +215,12 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./docker_image_variants/latest
+          # Explicit multi-arch publish. Without this the action defaults
+          # to the runner's native arch (amd64) only — and because v5
+          # wraps the result in a multi-arch manifest index, downstream
+          # `--platform linux/arm64` consumers get a strict "platform not
+          # found" error instead of a silent amd64 fallback.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |


### PR DESCRIPTION
## Why

Every cogflow image tag on Docker Hub has been amd64-only:
- \`build-push-action@v5\` has no \`platforms:\` arg, and the workflow installs no QEMU, so the build targets only the runner's native \`linux/amd64\`.
- But v5 wraps the output in a multi-arch manifest **index** by default. Downstream consumers requesting \`linux/arm64\` get a hard failure instead of a silent amd64 fallback.

Observed downstream:
\`\`\`
ERROR: failed to resolve source metadata for
docker.io/hiroregistry/cogflow:latest-beta:
no match for platform in manifest: not found
\`\`\`

The older \`:latest\` tag appears to work for arm64 consumers only by accident — it was published by a previous action version as a plain single-manifest image, which buildx tolerates with a silent amd64 fallback. Neither tag actually contains arm64 binaries today.

This affects Cog-Engine CD: its Dockerfile now uses \`FROM hiroregistry/cogflow:\${COGFLOW_IMAGE}\` and its CD does a multi-arch build (\`linux/amd64,linux/arm64\`). The \`:latest-beta\` base breaks arm64; the \`:latest\` base "works" only by manifest-format luck.

## What this PR changes

\`.github/workflows/release.yml\`:

1. New \`Set up QEMU\` step before buildx — emulation for arm64 on the amd64 runner.
2. New \`platforms: linux/amd64,linux/arm64\` arg on \`docker/build-push-action@v5\`.

\`\`\`diff
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       ...
       - name: Build and push cogflow:latest image
         uses: docker/build-push-action@v5
         with:
           context: ./docker_image_variants/latest
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: \${{ steps.tags.outputs.tags }}
\`\`\`

## Expected impact

- **Release time:** +3–5 min per run. QEMU emulates arm64 for the \`shap==0.44.*\`/\`xgboost\`/\`protobuf==3.20.1\` pip installs in \`docker_image_variants/latest/Dockerfile\`. All three have arm64 wheels, so no source builds — just emulated wheel installs.
- **Smoke-test step** (\`docker pull\` + \`docker run --rm\`) keeps working: the multi-arch index resolves to amd64 on the runner.
- **Retroactive:** existing \`:latest\` and \`:latest-beta\` tags are not updated. The next release tag carries both arches.

## Scope

Only the automated \`:latest\` / \`:latest-beta\` variant. \`fl\`, \`lite\`, \`tensor\`, \`torch\` remain manual builds (memory: PR #76 era), so this PR doesn't touch them.