### PR TITLE
deploy_llm: route hf:// via --model_id arg, skip storageUri

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -9,7 +9,7 @@ and advanced functionality via submodules like `cogflow.models`, `cogflow.datase
 import sys
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b7"
+__version__ = "2.0.1b8"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -695,11 +695,18 @@ class ServingManager:
             max_num_seqs=max_num_seqs,
         )
         if is_hf_source:
+            # Strip the scheme and any decorative slashes. Reject early
+            # on empty/whitespace input so we don't emit
+            # ``--model_id=<junk>`` and leave the runtime to fail opaquely
+            # at pull time. Real HF ids never contain whitespace.
+            hf_id = storage_uri[len("hf://"):].strip().strip("/")
+            if not hf_id or any(ch.isspace() for ch in hf_id):
+                raise CogflowValidationError(
+                    f"storage_uri={storage_uri!r} has an invalid HF model id; "
+                    f"expected 'hf://<org>/<model>' (or 'hf://<model>')"
+                )
             # --model_id comes first for readability in the emitted YAML
-            runtime_args = [
-                f"--model_id={storage_uri[len('hf://'):]}",
-                *runtime_args,
-            ]
+            runtime_args = [f"--model_id={hf_id}", *runtime_args]
 
         model_block: Dict[str, Any] = {
             "modelFormat": {"name": "huggingface"},

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -665,20 +665,49 @@ class ServingManager:
                 f"<= max_replicas ({max_replicas})"
             )
 
+        # Source plumbing — HF Hub vs MLflow/MinIO routes through
+        # different KServe code paths:
+        #
+        #  hf://<org>/<model>  →  pass as ``--model_id=<id>`` argv to the
+        #                          HF runtime, which downloads it itself.
+        #                          Do NOT set ``storageUri``: that would
+        #                          route through KServe's storage-
+        #                          initializer, which injects
+        #                          ``POD_NAME``/``POD_NAMESPACE`` env
+        #                          vars via ``valueFrom.fieldRef``. In
+        #                          Serverless/Knative deployments those
+        #                          env shapes are rejected by the
+        #                          Knative admission webhook, so the
+        #                          predictor never reconciles.
+        #
+        #  s3://mlflow/...      →  set ``storageUri``; KServe's storage-
+        #                          initializer downloads to a local
+        #                          path and passes ``--model_dir=...``
+        #                          to the runtime.
+        is_hf_source = storage_uri.startswith("hf://")
+        runtime_args = ServingManager._build_llm_args(
+            served_model_name,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            tensor_parallel_size=tensor_parallel_size,
+            trust_remote_code=trust_remote_code,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+        )
+        if is_hf_source:
+            # --model_id comes first for readability in the emitted YAML
+            runtime_args = [
+                f"--model_id={storage_uri[len('hf://'):]}",
+                *runtime_args,
+            ]
+
         model_block: Dict[str, Any] = {
             "modelFormat": {"name": "huggingface"},
-            "storageUri": storage_uri,
-            "args": ServingManager._build_llm_args(
-                served_model_name,
-                max_model_len=max_model_len,
-                dtype=dtype,
-                tensor_parallel_size=tensor_parallel_size,
-                trust_remote_code=trust_remote_code,
-                gpu_memory_utilization=gpu_memory_utilization,
-                max_num_seqs=max_num_seqs,
-            ),
+            "args": runtime_args,
             "resources": ServingManager._merge_resources(resources),
         }
+        if not is_hf_source:
+            model_block["storageUri"] = storage_uri
 
         if hf_secret_name:
             model_block["env"] = [

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -294,7 +294,9 @@ async def test_async_deploy_llm_emits_expected_spec(async_serving, fake_async_ap
     assert body["metadata"]["annotations"]["model_type"] == "llm"
     assert "serviceAccountName" not in predictor
     assert model["modelFormat"] == {"name": "huggingface"}
-    assert model["storageUri"] == "hf://Qwen/Qwen2.5-Coder-7B-Instruct"
+    # HF source: --model_id arg instead of storageUri (see sync test).
+    assert "storageUri" not in model
+    assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in model["args"]
     assert "--model_name=qwen25-coder" in model["args"]
     assert "--max_model_len=4096" in model["args"]
     assert predictor["tolerations"][0]["key"] == "storage-type"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -503,14 +503,18 @@ def test_deploy_llm_hf_uri_emits_expected_spec(serving, serving_module):
     assert body["metadata"]["annotations"]["model_type"] == "llm"
     assert "serviceAccountName" not in predictor  # HF pull — no S3 SA
     assert model["modelFormat"] == {"name": "huggingface"}
-    assert model["storageUri"] == "hf://Qwen/Qwen2.5-Coder-7B-Instruct"
+    # HF source: pass the id via --model_id (runtime downloads from HF
+    # Hub). storageUri would route through KServe's storage-initializer,
+    # which injects fieldRef env vars Knative rejects.
+    assert "storageUri" not in model
+    assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in model["args"]
     assert "--model_name=qwen25-coder" in model["args"]
     assert "--max_model_len=4096" in model["args"]
     assert predictor["tolerations"][0]["key"] == "storage-type"
 
 
 def test_deploy_llm_s3_uri_sets_service_account(serving, serving_module):
-    """s3:// URI → serviceAccountName=kserve-controller-s3."""
+    """s3:// URI → uses storageUri + kserve-controller-s3 SA."""
     _, fake_api, _ = serving_module
 
     serving.deploy_llm(
@@ -519,8 +523,14 @@ def test_deploy_llm_s3_uri_sets_service_account(serving, serving_module):
         served_model_name="mlf-llm",
     )
 
-    predictor = _deploy_llm_create_call(fake_api)["spec"]["predictor"]
+    body = _deploy_llm_create_call(fake_api)
+    predictor = body["spec"]["predictor"]
+    model = predictor["model"]
     assert predictor["serviceAccountName"] == "kserve-controller-s3"
+    assert model["storageUri"] == "s3://mlflow/0/abc/artifacts/model"
+    # s3 path does NOT emit --model_id; the storage-initializer passes
+    # --model_dir to the runtime instead.
+    assert not any(a.startswith("--model_id=") for a in model["args"])
 
 
 def test_deploy_llm_default_resources(serving, serving_module):
@@ -658,11 +668,14 @@ def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
     )
 
     args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
-    # Underscored flags (model_name, max_model_len, dtype, trust_remote_code)
-    # land in KServe's HF runtime parser; hyphenated flags
-    # (tensor-parallel-size, gpu-memory-utilization, max-num-seqs) fall
-    # through to vLLM via parse_known_args. See _build_llm_args docstring.
+    # HF source prepends --model_id= so the runtime knows which model to
+    # pull. Underscored flags (model_name, max_model_len, dtype,
+    # trust_remote_code) land in KServe's HF runtime parser; hyphenated
+    # flags (tensor-parallel-size, gpu-memory-utilization, max-num-seqs)
+    # fall through to vLLM via parse_known_args. See _build_llm_args
+    # docstring for the split rationale.
     assert args == [
+        "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct",
         "--model_name=q",
         "--max_model_len=4096",
         "--dtype=bfloat16",

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -513,6 +513,31 @@ def test_deploy_llm_hf_uri_emits_expected_spec(serving, serving_module):
     assert predictor["tolerations"][0]["key"] == "storage-type"
 
 
+def test_deploy_llm_rejects_empty_hf_id(serving, serving_module):
+    """'hf://' with no model id should fail fast, not emit --model_id=."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    for bad in ("hf://", "hf:///", "hf://   ", "hf:// / / "):
+        with pytest.raises(CogflowValidationError, match="invalid HF model id"):
+            serving.deploy_llm(
+                storage_uri=bad,
+                isvc_name="bad",
+                served_model_name="bad",
+            )
+
+
+def test_deploy_llm_hf_uri_trims_decorative_slashes(serving, serving_module):
+    """Leading/trailing slashes on the HF id are stripped before emit."""
+    _, fake_api, _ = serving_module
+    serving.deploy_llm(
+        storage_uri="hf:///Qwen/Qwen2.5-Coder-7B-Instruct/",
+        isvc_name="q",
+        served_model_name="q",
+    )
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in args
+
+
 def test_deploy_llm_s3_uri_sets_service_account(serving, serving_module):
     """s3:// URI → uses storageUri + kserve-controller-s3 SA."""
     _, fake_api, _ = serving_module


### PR DESCRIPTION
## Why

When an LLM ISVC built by \`deploy_llm\` lands on a Knative-based KServe cluster (the default "Serverless" mode), it fails to reconcile:

\`\`\`
admission webhook "validation.webhook.serving.knative.dev" denied the request:
must not set the field(s):
  spec.template.spec.containers[0].env[2].valueFrom.fieldRef,
  spec.template.spec.containers[0].env[3].valueFrom.fieldRef
\`\`\`

The \`env[2]/env[3]\` are \`POD_NAME\` / \`POD_NAMESPACE\` injected by KServe's **storage-initializer**, which activates whenever \`storageUri\` is set on \`predictor.model\`. Knative forbids \`valueFrom.fieldRef\` on user containers.

A known-good shape on this cluster (Knative-accepted, already serving HF models) uses \`--model_id=<hf-id>\` as an **arg** instead of \`storageUri: hf://...\`, bypassing the storage-initializer entirely — the HF runtime fetches from HF Hub itself via \`huggingface_hub\`:

\`\`\`yaml
spec:
  predictor:
    model:
      modelFormat: { name: huggingface }
      args:
        - --model_id=sshleifer/tiny-distilroberta-base
        - --task=fill_mask
      # no storageUri
\`\`\`

## What changes

In \`_build_llm_predictor\`, split the source handling:

- \`hf://<org>/<model>\` → prepend \`--model_id=<id>\` to \`args\`, **omit** \`storageUri\`.
- \`s3://mlflow/...\` → keep \`storageUri\` (still needs storage-initializer; still pins \`serviceAccountName: kserve-controller-s3\`).

Everything else (whitelisted vLLM args, resources, tolerations, HF_TOKEN env, replica bounds) is unchanged.

## Tests (217 passed)

- \`test_deploy_llm_hf_uri_emits_expected_spec\` — asserts \`"storageUri" not in model\` and \`"--model_id=Qwen/..." in args\`.
- \`test_deploy_llm_s3_uri_sets_service_account\` — keeps \`storageUri\` assertion for S3 path and asserts no \`--model_id=\` arg.
- \`test_deploy_llm_whitelisted_args_order_and_flags\` — args list now starts with \`--model_id=\`.
- \`test_async_deploy_llm_emits_expected_spec\` — same HF-side assertions.

## Downstream

The Cog-Engine LLM serving path (\`ModelRegisterService._deploy_llm\`) is unchanged — it still passes \`storage_uri=f"hf://{hf_model_id}"\` to \`cogflow_serving.async_deploy_llm\`. All the logic flips inside cogflow.

## Version bump

2.0.1b7 → 2.0.1b8.