### PR TITLE
deploy_llm: derive isvc_name / served_model_name from hf_model_id

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -585,19 +585,18 @@ class AsyncServingManager:
         so there is a single source of truth for the ISVC shape; this method
         adds the async CRD create and the async K8s client plumbing.
 
-        ``isvc_name`` and ``served_model_name`` are optional for ``hf://``
-        sources — see :meth:`ServingManager.derive_llm_names`.
+        For ``hf://`` sources, ``served_model_name`` may be omitted and
+        is derived from the HF model id. ``isvc_name`` may be omitted for
+        any source and is derived from ``served_model_name`` — see
+        :meth:`ServingManager.derive_llm_names`.
         """
         sync_manager_cls = _get_serving_manager_class()
 
         # Keep sync/async paths in lockstep: both derive names the same
         # way, so a request that works via deploy_llm works via
-        # async_deploy_llm and vice-versa.
-        hf_model_id_hint: Optional[str] = None
-        if storage_uri.startswith("hf://"):
-            candidate = storage_uri[len("hf://") :].strip().strip("/")
-            if candidate:
-                hf_model_id_hint = candidate
+        # async_deploy_llm and vice-versa. Early URI validation keeps
+        # error ordering URI-first (see deploy_llm for rationale).
+        hf_model_id_hint = sync_manager_cls._extract_hf_model_id(storage_uri)
         isvc_name, served_model_name = sync_manager_cls.derive_llm_names(
             hf_model_id=hf_model_id_hint,
             served_model_name=served_model_name,

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -562,8 +562,8 @@ class AsyncServingManager:
         self,
         *,
         storage_uri: str,
-        isvc_name: str,
-        served_model_name: str,
+        isvc_name: Optional[str] = None,
+        served_model_name: Optional[str] = None,
         namespace: Optional[str] = None,
         max_model_len: Optional[int] = None,
         dtype: Optional[str] = None,
@@ -584,11 +584,29 @@ class AsyncServingManager:
         Spec-building is delegated to ``ServingManager._build_llm_predictor``
         so there is a single source of truth for the ISVC shape; this method
         adds the async CRD create and the async K8s client plumbing.
+
+        ``isvc_name`` and ``served_model_name`` are optional for ``hf://``
+        sources — see :meth:`ServingManager.derive_llm_names`.
         """
+        sync_manager_cls = _get_serving_manager_class()
+
+        # Keep sync/async paths in lockstep: both derive names the same
+        # way, so a request that works via deploy_llm works via
+        # async_deploy_llm and vice-versa.
+        hf_model_id_hint: Optional[str] = None
+        if storage_uri.startswith("hf://"):
+            candidate = storage_uri[len("hf://") :].strip().strip("/")
+            if candidate:
+                hf_model_id_hint = candidate
+        isvc_name, served_model_name = sync_manager_cls.derive_llm_names(
+            hf_model_id=hf_model_id_hint,
+            served_model_name=served_model_name,
+            isvc_name=isvc_name,
+        )
+
         namespace = namespace or common.get_namespace()
         api = await self._get_api()
 
-        sync_manager_cls = _get_serving_manager_class()
         predictor_spec = sync_manager_cls._build_llm_predictor(
             storage_uri=storage_uri,
             served_model_name=served_model_name,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -586,10 +586,33 @@ class ServingManager:
                     merged[section].update(override[section])
         return merged
 
-    # DNS-1123 label: InferenceService names (and all k8s object names)
-    # must match this. Surface errors here with a typed exception rather
-    # than letting the K8s admission webhook return an opaque 422 later.
+    # Stricter DNS-1123 *label* check used for InferenceService names in
+    # this serving flow (KServe/Knative require it — Kubernetes itself
+    # accepts the looser DNS-1123 *subdomain* form for ``metadata.name``).
+    # Surfaces errors here with a typed exception rather than letting the
+    # K8s admission webhook return an opaque 422 later.
     _DNS1123_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+    @staticmethod
+    def _extract_hf_model_id(storage_uri: str) -> Optional[str]:
+        """Return the HF model id from an ``hf://`` URI, or ``None`` if
+        the URI isn't an HF source.
+
+        Raises ``CogflowValidationError`` if the URI is shaped like
+        ``hf://`` but the id is empty or contains whitespace — catches
+        malformed input early so the error message is specific
+        ("invalid HF model id") regardless of whether the caller also
+        omitted ``isvc_name`` / ``served_model_name``.
+        """
+        if not storage_uri.startswith("hf://"):
+            return None
+        hf_id = storage_uri[len("hf://") :].strip().strip("/")
+        if not hf_id or any(ch.isspace() for ch in hf_id):
+            raise CogflowValidationError(
+                f"storage_uri={storage_uri!r} has an invalid HF model id; "
+                f"expected 'hf://<org>/<model>' (or 'hf://<model>')"
+            )
+        return hf_id
 
     @staticmethod
     def _k8s_slugify(name: str) -> str:
@@ -621,7 +644,7 @@ class ServingManager:
         Rules:
 
         - ``served_model_name`` defaults to the part of ``hf_model_id``
-          after the first ``/`` — ``'Qwen/Qwen2.5-Coder-7B-Instruct'``
+          after the last ``/`` — ``'Qwen/Qwen2.5-Coder-7B-Instruct'``
           becomes ``'Qwen2.5-Coder-7B-Instruct'``. An ``hf_model_id`` with
           no slash is used as-is (HF supports bare org-less ids).
         - ``isvc_name`` defaults to a DNS-1123 slug of the resolved
@@ -767,7 +790,12 @@ class ServingManager:
         #                          initializer downloads to a local
         #                          path and passes ``--model_dir=...``
         #                          to the runtime.
-        is_hf_source = storage_uri.startswith("hf://")
+        # ``_extract_hf_model_id`` validates the ``hf://`` URI shape and
+        # returns ``None`` for non-HF sources. This is also called from
+        # ``deploy_llm`` so direct callers of this helper (tests, future
+        # SDK users) still get the same validation.
+        hf_id = ServingManager._extract_hf_model_id(storage_uri)
+        is_hf_source = hf_id is not None
         runtime_args = ServingManager._build_llm_args(
             served_model_name,
             max_model_len=max_model_len,
@@ -778,16 +806,6 @@ class ServingManager:
             max_num_seqs=max_num_seqs,
         )
         if is_hf_source:
-            # Strip the scheme and any decorative slashes. Reject early
-            # on empty/whitespace input so we don't emit
-            # ``--model_id=<junk>`` and leave the runtime to fail opaquely
-            # at pull time. Real HF ids never contain whitespace.
-            hf_id = storage_uri[len("hf://"):].strip().strip("/")
-            if not hf_id or any(ch.isspace() for ch in hf_id):
-                raise CogflowValidationError(
-                    f"storage_uri={storage_uri!r} has an invalid HF model id; "
-                    f"expected 'hf://<org>/<model>' (or 'hf://<model>')"
-                )
             # --model_id comes first for readability in the emitted YAML
             runtime_args = [f"--model_id={hf_id}", *runtime_args]
 
@@ -859,21 +877,22 @@ class ServingManager:
         HF-format checkpoint. Callers (e.g. Cog-Engine) are responsible for
         resolving the source.
 
-        ``isvc_name`` and ``served_model_name`` are optional for the
-        ``hf://`` path: when omitted, ``served_model_name`` defaults to the
-        part after the first ``/`` and ``isvc_name`` to its k8s slug.
-        See :meth:`derive_llm_names`. The ``s3://`` / MLflow path requires
-        an explicit ``served_model_name`` (cogflow can't see the catalog).
+        ``isvc_name`` may be omitted whenever ``served_model_name`` is
+        available; it is derived as a DNS-1123-safe slug of that name.
+        For the ``hf://`` path, ``served_model_name`` may also be omitted:
+        it defaults to the part after the last ``/`` of the HF model id,
+        and ``isvc_name`` then derives from that. See
+        :meth:`derive_llm_names`. The ``s3://`` / MLflow path still
+        requires an explicit ``served_model_name`` (cogflow has no
+        catalog visibility).
         """
-        # Only pass an ``hf_model_id`` hint to the derivation helper for
-        # ``hf://`` sources — ``_build_llm_predictor`` re-validates the URI
-        # format later, so we don't want this branch to reject inputs that
-        # are supposed to surface there.
-        hf_model_id_hint: Optional[str] = None
-        if storage_uri.startswith("hf://"):
-            candidate = storage_uri[len("hf://") :].strip().strip("/")
-            if candidate:
-                hf_model_id_hint = candidate
+        # Validate the ``hf://`` URI shape up-front so a malformed input
+        # surfaces as "invalid HF model id" regardless of whether the
+        # caller omitted names (otherwise the name-derivation step below
+        # would raise "served_model_name is required" first and obscure
+        # the real problem). ``_build_llm_predictor`` keeps the same
+        # check as a defensive guard for direct helper callers.
+        hf_model_id_hint = ServingManager._extract_hf_model_id(storage_uri)
         isvc_name, served_model_name = ServingManager.derive_llm_names(
             hf_model_id=hf_model_id_hint,
             served_model_name=served_model_name,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -14,9 +14,10 @@ No circular imports occur because we load them lazily.
 
 from __future__ import annotations
 
+import re
 import time
 from datetime import datetime
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 from kubernetes import client
 from kubernetes.client.exceptions import ApiException
@@ -585,6 +586,88 @@ class ServingManager:
                     merged[section].update(override[section])
         return merged
 
+    # DNS-1123 label: InferenceService names (and all k8s object names)
+    # must match this. Surface errors here with a typed exception rather
+    # than letting the K8s admission webhook return an opaque 422 later.
+    _DNS1123_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+    @staticmethod
+    def _k8s_slugify(name: str) -> str:
+        """Turn an arbitrary model name into a DNS-1123-compatible label.
+
+        Lowercases, replaces any run of non-``[a-z0-9]`` with a single
+        dash, strips leading/trailing dashes, and truncates to 63 chars
+        (the DNS-1123 label limit).
+
+        The result is not guaranteed to be DNS-1123-valid for adversarial
+        inputs (e.g. an all-punctuation string collapses to an empty
+        string); callers should validate via ``_DNS1123_LABEL_RE`` after.
+        """
+        slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+        if len(slug) > 63:
+            slug = slug[:63].rstrip("-")
+        return slug
+
+    @staticmethod
+    def derive_llm_names(
+        *,
+        hf_model_id: Optional[str] = None,
+        served_model_name: Optional[str] = None,
+        isvc_name: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        """Fill in ``(isvc_name, served_model_name)`` from ``hf_model_id``
+        when not supplied, and validate the final ``isvc_name``.
+
+        Rules:
+
+        - ``served_model_name`` defaults to the part of ``hf_model_id``
+          after the first ``/`` — ``'Qwen/Qwen2.5-Coder-7B-Instruct'``
+          becomes ``'Qwen2.5-Coder-7B-Instruct'``. An ``hf_model_id`` with
+          no slash is used as-is (HF supports bare org-less ids).
+        - ``isvc_name`` defaults to a DNS-1123 slug of the resolved
+          ``served_model_name`` (``Qwen2.5-Coder-7B-Instruct`` →
+          ``qwen2-5-coder-7b-instruct``).
+
+        Keeps the logic in cogflow so every caller (Cog-Engine today,
+        direct SDK users tomorrow) gets the same defaults instead of
+        reimplementing them.
+
+        Raises
+        ------
+        CogflowValidationError
+            If ``served_model_name`` can't be resolved (neither passed
+            in nor derivable from a non-empty ``hf_model_id``), or if the
+            final ``isvc_name`` is not a valid DNS-1123 label.
+        """
+        if not served_model_name:
+            if not hf_model_id:
+                raise CogflowValidationError(
+                    "served_model_name is required when hf_model_id is not "
+                    "provided (MLflow-backed LLM path must supply a name)"
+                )
+            slug_source = hf_model_id.strip().strip("/")
+            # hf_model_id like 'Qwen/Qwen2.5-Coder-7B-Instruct': the
+            # served model is the repo, not the org, so split once and
+            # take the tail. A bare id with no slash is used directly.
+            served_model_name = slug_source.rsplit("/", 1)[-1].strip()
+            if not served_model_name:
+                raise CogflowValidationError(
+                    f"could not derive served_model_name from hf_model_id="
+                    f"{hf_model_id!r}"
+                )
+
+        if not isvc_name:
+            isvc_name = ServingManager._k8s_slugify(served_model_name)
+
+        if not ServingManager._DNS1123_LABEL_RE.match(isvc_name):
+            raise CogflowValidationError(
+                f"isvc_name={isvc_name!r} is not a valid DNS-1123 label "
+                f"(^[a-z0-9]([-a-z0-9]*[a-z0-9])?$); pass an explicit "
+                f"isvc_name or a served_model_name that slugifies cleanly"
+            )
+
+        return isvc_name, served_model_name
+
     @staticmethod
     def _build_llm_args(
         served_model_name: str,
@@ -748,8 +831,8 @@ class ServingManager:
         self,
         *,
         storage_uri: str,
-        isvc_name: str,
-        served_model_name: str,
+        isvc_name: Optional[str] = None,
+        served_model_name: Optional[str] = None,
         namespace: Optional[str] = None,
         # vLLM runtime args (whitelist)
         max_model_len: Optional[int] = None,
@@ -775,7 +858,28 @@ class ServingManager:
         for a direct HF Hub pull or ``s3://mlflow/...`` for an MLflow-stored
         HF-format checkpoint. Callers (e.g. Cog-Engine) are responsible for
         resolving the source.
+
+        ``isvc_name`` and ``served_model_name`` are optional for the
+        ``hf://`` path: when omitted, ``served_model_name`` defaults to the
+        part after the first ``/`` and ``isvc_name`` to its k8s slug.
+        See :meth:`derive_llm_names`. The ``s3://`` / MLflow path requires
+        an explicit ``served_model_name`` (cogflow can't see the catalog).
         """
+        # Only pass an ``hf_model_id`` hint to the derivation helper for
+        # ``hf://`` sources — ``_build_llm_predictor`` re-validates the URI
+        # format later, so we don't want this branch to reject inputs that
+        # are supposed to surface there.
+        hf_model_id_hint: Optional[str] = None
+        if storage_uri.startswith("hf://"):
+            candidate = storage_uri[len("hf://") :].strip().strip("/")
+            if candidate:
+                hf_model_id_hint = candidate
+        isvc_name, served_model_name = ServingManager.derive_llm_names(
+            hf_model_id=hf_model_id_hint,
+            served_model_name=served_model_name,
+            isvc_name=isvc_name,
+        )
+
         namespace = namespace or common.get_namespace()
         logger.info(
             "Creating LLM InferenceService name=%s namespace=%s storage_uri=%s",

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -682,6 +682,14 @@ class ServingManager:
         if not isvc_name:
             isvc_name = ServingManager._k8s_slugify(served_model_name)
 
+        # DNS-1123 label: regex AND the 63-char length cap. Caller-supplied
+        # isvc_name could be regex-valid but too long; ``_k8s_slugify``
+        # already truncates, so this only rejects explicit inputs.
+        if len(isvc_name) > 63:
+            raise CogflowValidationError(
+                f"isvc_name={isvc_name!r} exceeds the DNS-1123 label "
+                f"length limit of 63 characters (got {len(isvc_name)})"
+            )
         if not ServingManager._DNS1123_LABEL_RE.match(isvc_name):
             raise CogflowValidationError(
                 f"isvc_name={isvc_name!r} is not a valid DNS-1123 label "

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -758,6 +758,21 @@ def test_derive_llm_names_mlflow_without_name_raises(serving_module):
         module_obj.ServingManager.derive_llm_names()
 
 
+def test_derive_llm_names_rejects_too_long_isvc_name(serving_module):
+    """Explicit isvc_name longer than 63 chars is DNS-1123-invalid even if
+    it matches the char-class regex — K8s/KServe admission would reject
+    it. Surface the length cap here with a typed exception."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    module_obj, _, _ = serving_module
+    too_long = "a" * 64
+    with pytest.raises(CogflowValidationError, match="63 characters"):
+        module_obj.ServingManager.derive_llm_names(
+            served_model_name="ok",
+            isvc_name=too_long,
+        )
+
+
 def test_derive_llm_names_rejects_non_dns1123_isvc(serving_module):
     """Explicit isvc_name must match the DNS-1123 label pattern."""
     from cogflow.utils.exceptions import CogflowValidationError

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -796,6 +796,21 @@ def test_deploy_llm_derives_isvc_from_served_model_name(serving, serving_module)
     assert body["metadata"]["name"] == "my-custom-name"
 
 
+def test_deploy_llm_malformed_hf_uri_raises_hf_error_not_name_error(serving):
+    """Malformed ``hf://`` URI with names omitted must surface the
+    specific "invalid HF model id" error from URI validation, not
+    the generic "served_model_name is required" from name derivation.
+
+    Regression: earlier the derivation step ran first and shadowed
+    the URI error when both the URI was bad and the names were None.
+    """
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    for bad in ("hf://", "hf:///", "hf://   "):
+        with pytest.raises(CogflowValidationError, match="invalid HF model id"):
+            serving.deploy_llm(storage_uri=bad)
+
+
 def test_deploy_llm_s3_without_served_model_name_raises(serving):
     """MLflow/s3 path can't derive a name — caller must supply one."""
     from cogflow.utils.exceptions import CogflowValidationError

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -711,6 +711,99 @@ def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
     ]
 
 
+# ---------------------------------------------------------------------
+# LLM name derivation (derive_llm_names + deploy_llm with omitted names)
+# ---------------------------------------------------------------------
+
+
+def test_derive_llm_names_uses_slug_after_slash(serving_module):
+    """hf_model_id='Org/Name' → served_model_name='Name',
+    isvc_name=<DNS-1123 slug of Name>."""
+    module_obj, _, _ = serving_module
+    isvc, smn = module_obj.ServingManager.derive_llm_names(
+        hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",
+    )
+    assert smn == "Qwen2.5-Coder-7B-Instruct"
+    assert isvc == "qwen2-5-coder-7b-instruct"
+
+
+def test_derive_llm_names_bare_hf_id_no_slash(serving_module):
+    """HF supports bare ids without an org segment — use as-is."""
+    module_obj, _, _ = serving_module
+    isvc, smn = module_obj.ServingManager.derive_llm_names(
+        hf_model_id="gpt2",
+    )
+    assert smn == "gpt2"
+    assert isvc == "gpt2"
+
+
+def test_derive_llm_names_respects_explicit_inputs(serving_module):
+    """Caller-supplied names beat HF-id derivation."""
+    module_obj, _, _ = serving_module
+    isvc, smn = module_obj.ServingManager.derive_llm_names(
+        hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",
+        served_model_name="my-model",
+        isvc_name="my-isvc",
+    )
+    assert smn == "my-model"
+    assert isvc == "my-isvc"
+
+
+def test_derive_llm_names_mlflow_without_name_raises(serving_module):
+    """No hf_model_id + no served_model_name → typed error."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    module_obj, _, _ = serving_module
+    with pytest.raises(CogflowValidationError, match="served_model_name is required"):
+        module_obj.ServingManager.derive_llm_names()
+
+
+def test_derive_llm_names_rejects_non_dns1123_isvc(serving_module):
+    """Explicit isvc_name must match the DNS-1123 label pattern."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    module_obj, _, _ = serving_module
+    with pytest.raises(CogflowValidationError, match="DNS-1123"):
+        module_obj.ServingManager.derive_llm_names(
+            served_model_name="ok",
+            isvc_name="Not_A_Valid_Name",
+        )
+
+
+def test_deploy_llm_derives_both_names_from_hf_uri(serving, serving_module):
+    """Omit both name args → cogflow derives them from the hf:// URI."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    body = _deploy_llm_create_call(fake_api)
+    assert body["metadata"]["name"] == "qwen2-5-coder-7b-instruct"
+    args = body["spec"]["predictor"]["model"]["args"]
+    assert "--model_name=Qwen2.5-Coder-7B-Instruct" in args
+    assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in args
+
+
+def test_deploy_llm_derives_isvc_from_served_model_name(serving, serving_module):
+    """Only served_model_name supplied → isvc_name defaults to its slug."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+        served_model_name="My.Custom_Name",
+    )
+
+    body = _deploy_llm_create_call(fake_api)
+    assert body["metadata"]["name"] == "my-custom-name"
+
+
+def test_deploy_llm_s3_without_served_model_name_raises(serving):
+    """MLflow/s3 path can't derive a name — caller must supply one."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="served_model_name is required"):
+        serving.deploy_llm(storage_uri="s3://mlflow/0/abc/artifacts/model")
+
+
 def test_serving_module_reexports_async_deploy_llm():
     """cogflow.serving must expose async_deploy_llm alongside the other
     async_* helpers. Consumers (e.g. Cog-Engine) reach it via


### PR DESCRIPTION
## Summary
- Makes `isvc_name` and `served_model_name` optional on the `hf://` path of `deploy_llm` (sync + async). cogflow now derives them from the HF model id when the caller omits them, so the minimal LLM deploy becomes `{storage_uri: "hf://org/name"}`.
- Adds `ServingManager.derive_llm_names` as the single source of truth for the defaults (`served_model_name` = part after the **last** `/`; `isvc_name` = DNS-1123 slug of that, capped at 63 chars) so every downstream caller — Cog-Engine today, direct SDK users tomorrow — gets the same behaviour.
- Explicit values still win; invalid `isvc_name` inputs (bad regex **or** > 63 chars) surface as `CogflowValidationError` before hitting the K8s admission webhook.
- The MLflow / `s3://` path still requires an explicit `served_model_name` (cogflow has no catalog visibility).

## Test plan
- [x] `pytest tests/test_serving.py` — 35 tests pass (9 new).
- [x] `pytest tests/test_async_serving.py` — 10 pass.
- [x] Full suite: 228 passed, 1 skipped.
- [x] No change to existing signatures' required fields for classical serving or for `hf://` calls that pass both names.

## Pairs with
Cog-Engine PR that relaxes `ModelDeploy.isvc_name` and routes the final resolution through `cogflow_serving.derive_llm_names`.