### PR TITLE
serve_llm: one-call LLM deploy with MLflow-backed catalog registration

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -681,6 +681,109 @@ class AsyncServingManager:
             )
 
 
+    async def serve_llm(
+        self,
+        *,
+        storage_uri: Optional[str] = None,
+        hf_model_id: Optional[str] = None,
+        isvc_name: Optional[str] = None,
+        served_model_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        max_model_len: Optional[int] = None,
+        dtype: Optional[str] = None,
+        tensor_parallel_size: Optional[int] = None,
+        trust_remote_code: bool = False,
+        gpu_memory_utilization: Optional[float] = None,
+        max_num_seqs: Optional[int] = None,
+        resources: Optional[Dict[str, Dict[str, str]]] = None,
+        tolerations: Optional[List[Dict[str, Any]]] = None,
+        node_selector: Optional[Dict[str, str]] = None,
+        min_replicas: int = 1,
+        max_replicas: int = 1,
+        hf_secret_name: Optional[str] = None,
+        annotations: Optional[Dict[str, str]] = None,
+        user_id: Optional[str] = None,
+        extra_tags: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Async variant of :meth:`ServingManager.serve_llm`.
+
+        The catalog-registration step (MLflow run + POST /models/log) is
+        synchronous — MLflow's tracking client and the catalog HTTP call
+        both block — so we keep it sync and only make the ISVC create
+        async via :meth:`deploy_llm`. That preserves the sync/async
+        behavioural parity with the existing ``deploy_llm`` pair.
+
+        See the sync version's docstring for rules and return shape.
+        """
+        sync_manager_cls = _get_serving_manager_class()
+
+        # Steps 1 + 2: resolve URI / shorthand and derive names (same
+        # helpers as the sync path — keeps behaviour identical).
+        if storage_uri is None and hf_model_id is None:
+            # Use sync manager's typed validation error for parity.
+            raise CogflowValidationError(
+                "async_serve_llm requires either hf_model_id or storage_uri"
+            )
+        if storage_uri is None:
+            storage_uri = f"hf://{hf_model_id}"
+        elif hf_model_id is None and storage_uri.startswith("hf://"):
+            hf_model_id = sync_manager_cls._extract_hf_model_id(storage_uri)
+
+        isvc_name, served_model_name = sync_manager_cls.derive_llm_names(
+            hf_model_id=hf_model_id,
+            served_model_name=served_model_name,
+            isvc_name=isvc_name,
+        )
+
+        # Step 3: catalog registration — sync, lazy-imported (same
+        # rationale as the sync path). Uses the real submodule path
+        # rather than ``cogflow.models`` (a _LazyLoader attribute that
+        # isn't resolvable via ``from … import …``).
+        from cogflow.core import models as cogflow_models
+
+        run_id = cogflow_models.register_llm_catalog_entry(
+            served_model_name=served_model_name,
+            hf_model_id=hf_model_id,
+            user_id=user_id,
+            extra_tags=extra_tags,
+        )
+
+        # Step 4: merge annotations.
+        merged_annotations: Dict[str, str] = dict(annotations or {})
+        merged_annotations.setdefault("model_type", "llm")
+        merged_annotations["model_id"] = common.normalize_uuid(run_id)
+        if hf_model_id:
+            merged_annotations.setdefault("hf_model_id", hf_model_id)
+
+        # Step 5: actual ISVC create (async).
+        isvc_response = await self.deploy_llm(
+            storage_uri=storage_uri,
+            isvc_name=isvc_name,
+            served_model_name=served_model_name,
+            namespace=namespace,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            tensor_parallel_size=tensor_parallel_size,
+            trust_remote_code=trust_remote_code,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            resources=resources,
+            tolerations=tolerations,
+            node_selector=node_selector,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            hf_secret_name=hf_secret_name,
+            annotations=merged_annotations,
+        )
+
+        return {
+            "run_id": run_id,
+            "isvc_name": isvc_name,
+            "served_model_name": served_model_name,
+            "isvc": isvc_response,
+        }
+
+
 # Create singleton and expose async methods at module level
 _async_serving = AsyncServingManager()
 
@@ -693,3 +796,4 @@ async_update_isvc = _async_serving.update_isvc
 async_restart_isvc = _async_serving.restart_isvc
 async_create_isvc = _async_serving.create_isvc
 async_deploy_llm = _async_serving.deploy_llm
+async_serve_llm = _async_serving.serve_llm

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -726,8 +726,18 @@ class AsyncServingManager:
             )
         if storage_uri is None:
             storage_uri = f"hf://{hf_model_id}"
-        elif hf_model_id is None and storage_uri.startswith("hf://"):
-            hf_model_id = sync_manager_cls._extract_hf_model_id(storage_uri)
+        elif storage_uri.startswith("hf://"):
+            # See the sync serve_llm for the mismatch rationale — keep
+            # both paths behaviourally identical.
+            extracted = sync_manager_cls._extract_hf_model_id(storage_uri)
+            if hf_model_id is None:
+                hf_model_id = extracted
+            elif hf_model_id != extracted:
+                raise CogflowValidationError(
+                    f"hf_model_id={hf_model_id!r} does not match the id "
+                    f"encoded in storage_uri={storage_uri!r} "
+                    f"(extracted={extracted!r})"
+                )
 
         isvc_name, served_model_name = sync_manager_cls.derive_llm_names(
             hf_model_id=hf_model_id,
@@ -748,12 +758,13 @@ class AsyncServingManager:
             extra_tags=extra_tags,
         )
 
-        # Step 4: merge annotations.
+        # Step 4: merge annotations. Identity keys are authoritative
+        # — see sync serve_llm for rationale.
         merged_annotations: Dict[str, str] = dict(annotations or {})
-        merged_annotations.setdefault("model_type", "llm")
+        merged_annotations["model_type"] = "llm"
         merged_annotations["model_id"] = common.normalize_uuid(run_id)
         if hf_model_id:
-            merged_annotations.setdefault("hf_model_id", hf_model_id)
+            merged_annotations["hf_model_id"] = hf_model_id
 
         # Step 5: actual ISVC create (async).
         isvc_response = await self.deploy_llm(

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -724,10 +724,22 @@ class AsyncServingManager:
             raise CogflowValidationError(
                 "async_serve_llm requires either hf_model_id or storage_uri"
             )
-        # See sync serve_llm — strip an accidental ``hf://`` prefix on
-        # ``hf_model_id`` so we don't build ``hf://hf://…`` downstream.
+        # See sync serve_llm — single-layer strip; validator rejects
+        # deeper nesting.
         if hf_model_id is not None and hf_model_id.startswith("hf://"):
             hf_model_id = hf_model_id[len("hf://") :]
+        # Reject non-HF storage_uri paired with hf_model_id — same
+        # rationale as the sync path.
+        if (
+            storage_uri is not None
+            and not storage_uri.startswith("hf://")
+            and hf_model_id is not None
+        ):
+            raise CogflowValidationError(
+                f"hf_model_id={hf_model_id!r} was supplied alongside a "
+                f"non-HF storage_uri={storage_uri!r}; HuggingFace metadata "
+                f"only applies to hf:// sources"
+            )
         if storage_uri is None:
             # Normalize / validate via the same helper the hf:// URI
             # path uses — see sync serve_llm for rationale.

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -724,6 +724,10 @@ class AsyncServingManager:
             raise CogflowValidationError(
                 "async_serve_llm requires either hf_model_id or storage_uri"
             )
+        # See sync serve_llm — strip an accidental ``hf://`` prefix on
+        # ``hf_model_id`` so we don't build ``hf://hf://…`` downstream.
+        if hf_model_id is not None and hf_model_id.startswith("hf://"):
+            hf_model_id = hf_model_id[len("hf://") :]
         if storage_uri is None:
             # Normalize / validate via the same helper the hf:// URI
             # path uses — see sync serve_llm for rationale.

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -725,19 +725,30 @@ class AsyncServingManager:
                 "async_serve_llm requires either hf_model_id or storage_uri"
             )
         if storage_uri is None:
+            # Normalize / validate via the same helper the hf:// URI
+            # path uses — see sync serve_llm for rationale.
+            hf_model_id = sync_manager_cls._extract_hf_model_id(
+                f"hf://{hf_model_id}"
+            )
             storage_uri = f"hf://{hf_model_id}"
         elif storage_uri.startswith("hf://"):
             # See the sync serve_llm for the mismatch rationale — keep
-            # both paths behaviourally identical.
+            # both paths behaviourally identical (including normalizing
+            # both sides before the equality check).
             extracted = sync_manager_cls._extract_hf_model_id(storage_uri)
             if hf_model_id is None:
                 hf_model_id = extracted
-            elif hf_model_id != extracted:
-                raise CogflowValidationError(
-                    f"hf_model_id={hf_model_id!r} does not match the id "
-                    f"encoded in storage_uri={storage_uri!r} "
-                    f"(extracted={extracted!r})"
+            else:
+                normalized = sync_manager_cls._extract_hf_model_id(
+                    f"hf://{hf_model_id}"
                 )
+                if normalized != extracted:
+                    raise CogflowValidationError(
+                        f"hf_model_id={hf_model_id!r} does not match the id "
+                        f"encoded in storage_uri={storage_uri!r} "
+                        f"(extracted={extracted!r})"
+                    )
+                hf_model_id = normalized
 
         isvc_name, served_model_name = sync_manager_cls.derive_llm_names(
             hf_model_id=hf_model_id,

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -872,6 +872,23 @@ class ModelManager:
         """
         self._warn_if_unhealthy("registering LLM catalog entry")
 
+        # Self-defensive normalization: ``serve_llm`` already runs the
+        # id through this validator, but direct callers (notebook users
+        # of ``cogflow.models.register_llm_catalog_entry``) shouldn't
+        # have to. Strip an accidental ``hf://`` prefix first, then run
+        # through the same ``_extract_hf_model_id`` helper the serving
+        # path uses so whitespace / stray slashes / empty input are
+        # rejected up-front — no orphan MLflow run, no orphan catalog
+        # row on bad input.
+        if hf_model_id is not None:
+            if hf_model_id.startswith("hf://"):
+                hf_model_id = hf_model_id[len("hf://") :]
+            from cogflow.core.serving import ServingManager as _ServingManager
+
+            hf_model_id = _ServingManager._extract_hf_model_id(
+                f"hf://{hf_model_id}"
+            )
+
         description = (
             f"LLM served from HuggingFace: {hf_model_id}"
             if hf_model_id

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -823,6 +823,130 @@ class ModelManager:
                 re_raise=True,
             )
 
+    def register_llm_catalog_entry(
+        self,
+        *,
+        served_model_name: str,
+        hf_model_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        extra_tags: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create an MLflow run for an LLM and register its catalog entry
+        with the CogFlow backend.
+
+        HF-sourced LLMs have no MLflow artifact to log; we open a run
+        purely to establish the catalog identity (``model_info.id ==
+        MLflow run_id``, the same invariant every other registration
+        path respects) and to carry metadata tags.
+
+        Mirrors the ``log_model`` → ``/models/log`` pattern:
+
+        - Opens and closes an MLflow run; sets ``type=llm``,
+          ``source=huggingface`` (or ``mlflow`` if no HF id is given),
+          ``hf_model_id``, ``mlflow.note.content``, plus any caller-
+          supplied ``extra_tags``.
+        - Best-effort POST to ``{API_PATH}{LOG_MODEL}``: failures are
+          logged as warnings and do **not** raise — matches
+          ``log_model``'s behaviour so a transient CogFlow backend
+          outage can't abort an LLM deploy that otherwise succeeded.
+
+        Args:
+            served_model_name: Logical model name (vLLM ``--model_name``).
+                Also becomes the catalog row's ``name``.
+            hf_model_id: HuggingFace Hub id (e.g. ``"Qwen/Qwen2.5-Coder-7B-Instruct"``),
+                or ``None`` for MLflow-backed LLMs.
+            user_id: Override for the ``kubeflow-userid`` / catalog
+                ``register_user_id``. Falls back to
+                ``common.get_current_user()`` (reads the Kubeflow
+                namespace's ``owner`` annotation) which is what notebook
+                consumers want.
+            extra_tags: Additional MLflow tags to set on the run.
+
+        Returns:
+            The MLflow ``run_id`` — which is also the catalog row's
+            primary key.
+
+        Raises:
+            CogflowModelError: If opening the MLflow run itself fails.
+                Backend POST failures are *not* raised (warn-only).
+        """
+        self._warn_if_unhealthy("registering LLM catalog entry")
+
+        description = (
+            f"LLM served from HuggingFace: {hf_model_id}"
+            if hf_model_id
+            else "LLM served from MLflow-backed checkpoint"
+        )
+
+        try:
+            with self.start_run(run_name=f"register-{served_model_name}") as run_info:
+                self.set_tag("type", "llm")
+                self.set_tag("source", "huggingface" if hf_model_id else "mlflow")
+                if hf_model_id:
+                    self.set_tag("hf_model_id", hf_model_id)
+                self.set_tag("mlflow.note.content", description)
+                if extra_tags:
+                    for k, v in extra_tags.items():
+                        self.set_tag(k, v)
+            run_id = run_info.info.run_id
+            start_time_ms = run_info.info.start_time
+            logger.info(
+                "Opened MLflow run %s for LLM '%s' (hf_model_id=%s)",
+                run_id,
+                served_model_name,
+                hf_model_id,
+            )
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Register LLM catalog entry '{served_model_name}'",
+                raise_as=CogflowModelError,
+                re_raise=True,
+            )
+
+        # Best-effort POST to the CogFlow backend — same pattern as
+        # log_model. If the catalog service is unreachable we still want
+        # the deploy to proceed; the warning surfaces in logs.
+        try:
+            resolved_user = user_id or common.get_current_user()
+            model_dict: Dict[str, Any] = {
+                "model_id": common.normalize_uuid(run_id),
+                "model_name": served_model_name,
+                # HF-sourced LLMs aren't MLflow-registered, so there's no
+                # registered-model version number to report. Use 1 as a
+                # placeholder; the catalog's response schema already
+                # treats version as Optional on the read path.
+                "model_version": 1,
+                "register_date": datetime.fromtimestamp(
+                    start_time_ms / 1000
+                ).isoformat(),
+                "type": "llm",
+                "description": description,
+                "user_id": resolved_user,
+            }
+            if hf_model_id:
+                # Old catalog schemas (<= the ModelLogBase that predates
+                # this field) ignore unknown keys; newer ones will persist
+                # the hf_model_id column. Forward-compatible.
+                model_dict["hf_model_id"] = hf_model_id
+
+            url = f"{config.API_PATH}{config.LOG_MODEL}"
+            headers = {"kubeflow-userid": resolved_user}
+            network.make_post_request(url=url, data=model_dict, headers=headers)
+            logger.info(
+                "Registered LLM catalog entry via CogFlow backend: %s (run_id=%s)",
+                url,
+                run_id,
+            )
+        except Exception as post_err:
+            logger.warning(
+                "Failed to post LLM catalog entry to CogFlow backend "
+                "(deploy proceeds regardless): %s",
+                str(post_err),
+            )
+
+        return run_id
+
     def search_model_versions(self, filter_string: Optional[str] = None):
         """
         Search for model versions in the MLflow Model Registry.

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -880,14 +880,20 @@ class ModelManager:
 
         try:
             with self.start_run(run_name=f"register-{served_model_name}") as run_info:
+                # Apply caller ``extra_tags`` FIRST so the reserved
+                # identity tags below always win on a collision — catalog
+                # consumers and downstream tooling rely on them being
+                # authoritative. A caller passing
+                # ``extra_tags={"type": "foo"}`` must not be able to
+                # desync the run from the catalog entry.
+                if extra_tags:
+                    for k, v in extra_tags.items():
+                        self.set_tag(k, v)
                 self.set_tag("type", "llm")
                 self.set_tag("source", "huggingface" if hf_model_id else "mlflow")
                 if hf_model_id:
                     self.set_tag("hf_model_id", hf_model_id)
                 self.set_tag("mlflow.note.content", description)
-                if extra_tags:
-                    for k, v in extra_tags.items():
-                        self.set_tag(k, v)
             run_id = run_info.info.run_id
             start_time_ms = run_info.info.start_time
             logger.info(
@@ -913,10 +919,12 @@ class ModelManager:
                 "model_id": common.normalize_uuid(run_id),
                 "model_name": served_model_name,
                 # HF-sourced LLMs aren't MLflow-registered, so there's no
-                # registered-model version number to report. Use 1 as a
-                # placeholder; the catalog's response schema already
-                # treats version as Optional on the read path.
-                "model_version": 1,
+                # registered-model version number to report. Use 0 as
+                # the sentinel for "unknown registry version" — matches
+                # the fallback ``log_model`` already uses for classical
+                # artifacts when ``model_details.get("model_version")``
+                # is missing or falsy.
+                "model_version": 0,
                 "register_date": datetime.fromtimestamp(
                     start_time_ms / 1000
                 ).isoformat(),

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1065,8 +1065,21 @@ class ServingManager:
             )
         if storage_uri is None:
             storage_uri = f"hf://{hf_model_id}"
-        elif hf_model_id is None and storage_uri.startswith("hf://"):
-            hf_model_id = ServingManager._extract_hf_model_id(storage_uri)
+        elif storage_uri.startswith("hf://"):
+            # When the caller supplies both, reject mismatches up-front —
+            # otherwise we'd catalog/tag one model while deploying
+            # another. When only ``storage_uri`` is set, back-derive
+            # ``hf_model_id`` so downstream tags/annotations reflect the
+            # actual deployed model.
+            extracted = ServingManager._extract_hf_model_id(storage_uri)
+            if hf_model_id is None:
+                hf_model_id = extracted
+            elif hf_model_id != extracted:
+                raise CogflowValidationError(
+                    f"hf_model_id={hf_model_id!r} does not match the id "
+                    f"encoded in storage_uri={storage_uri!r} "
+                    f"(extracted={extracted!r})"
+                )
 
         # --- 2. Derive names.
         isvc_name, served_model_name = ServingManager.derive_llm_names(
@@ -1094,11 +1107,15 @@ class ServingManager:
         # --- 4. Merge the run_id / model_type / hf_model_id annotations
         # onto whatever the caller supplied so consumers (Cog-Engine UI,
         # direct kubectl inspectors) see the catalog link on the ISVC.
+        # Identity annotations are authoritative — overwrite any
+        # caller-supplied values rather than defaulting — so the ISVC
+        # metadata never drifts from the catalog entry. Unrelated
+        # caller annotations (``my-custom=…``) still pass through.
         merged_annotations: Dict[str, str] = dict(annotations or {})
-        merged_annotations.setdefault("model_type", "llm")
+        merged_annotations["model_type"] = "llm"
         merged_annotations["model_id"] = common.normalize_uuid(run_id)
         if hf_model_id:
-            merged_annotations.setdefault("hf_model_id", hf_model_id)
+            merged_annotations["hf_model_id"] = hf_model_id
 
         # --- 5. Actually create the ISVC.
         isvc_response = self.deploy_llm(

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -598,11 +598,14 @@ class ServingManager:
         """Return the HF model id from an ``hf://`` URI, or ``None`` if
         the URI isn't an HF source.
 
-        Raises ``CogflowValidationError`` if the URI is shaped like
-        ``hf://`` but the id is empty or contains whitespace — catches
-        malformed input early so the error message is specific
-        ("invalid HF model id") regardless of whether the caller also
-        omitted ``isvc_name`` / ``served_model_name``.
+        Raises ``CogflowValidationError`` when the URI is shaped like
+        ``hf://`` but the extracted id is invalid — empty, contains
+        whitespace, or carries an embedded scheme (``://``). The
+        embedded-scheme check catches double-prefixed input like
+        ``hf://hf://org/name`` where stripping only one ``hf://``
+        would leave ``hf://org/name`` as the "id" and vLLM would
+        then receive a bogus ``--model_id`` arg. Real HF ids are
+        ``org/name`` or ``name`` — they never contain ``://``.
         """
         if not storage_uri.startswith("hf://"):
             return None
@@ -610,6 +613,12 @@ class ServingManager:
         if not hf_id or any(ch.isspace() for ch in hf_id):
             raise CogflowValidationError(
                 f"storage_uri={storage_uri!r} has an invalid HF model id; "
+                f"expected 'hf://<org>/<model>' (or 'hf://<model>')"
+            )
+        if "://" in hf_id:
+            raise CogflowValidationError(
+                f"storage_uri={storage_uri!r} has an invalid HF model id "
+                f"(extracted {hf_id!r} contains an embedded scheme); "
                 f"expected 'hf://<org>/<model>' (or 'hf://<model>')"
             )
         return hf_id
@@ -1064,13 +1073,24 @@ class ServingManager:
                 "serve_llm requires either hf_model_id or storage_uri"
             )
         # Tolerate an ``hf_model_id`` that a caller accidentally prefixed
-        # with ``hf://`` — otherwise ``f"hf://{hf_model_id}"`` below would
-        # produce a bogus double-scheme ``hf://hf://…`` URI that
-        # ``_extract_hf_model_id`` would happily accept (it only strips
-        # one ``hf://`` and doesn't reject embedded schemes). One strip
-        # here covers both the bare-id path and the mismatch check.
+        # with ``hf://`` (single layer only — ``_extract_hf_model_id``
+        # rejects deeper ``hf://hf://…`` nesting at the validator layer
+        # below, so there's no need to strip a loop here).
         if hf_model_id is not None and hf_model_id.startswith("hf://"):
             hf_model_id = hf_model_id[len("hf://") :]
+        # Reject inconsistent (s3://, file://, …) storage with an
+        # ``hf_model_id`` — we'd catalog/tag HuggingFace while deploying
+        # a non-HF artifact. MLflow-backed LLMs use ``storage_uri`` alone.
+        if (
+            storage_uri is not None
+            and not storage_uri.startswith("hf://")
+            and hf_model_id is not None
+        ):
+            raise CogflowValidationError(
+                f"hf_model_id={hf_model_id!r} was supplied alongside a "
+                f"non-HF storage_uri={storage_uri!r}; HuggingFace metadata "
+                f"only applies to hf:// sources"
+            )
         if storage_uri is None:
             # Route a bare ``hf_model_id`` through the same validator /
             # normalizer the ``hf://`` URI path uses so whitespace, stray

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1064,22 +1064,35 @@ class ServingManager:
                 "serve_llm requires either hf_model_id or storage_uri"
             )
         if storage_uri is None:
+            # Route a bare ``hf_model_id`` through the same validator /
+            # normalizer the ``hf://`` URI path uses so whitespace, stray
+            # slashes, and empty input are rejected up-front — *before*
+            # we open an MLflow run or POST to the catalog. Previously
+            # an invalid id only surfaced deep inside deploy_llm and
+            # left an orphan run + catalog entry behind.
+            hf_model_id = ServingManager._extract_hf_model_id(f"hf://{hf_model_id}")
             storage_uri = f"hf://{hf_model_id}"
         elif storage_uri.startswith("hf://"):
             # When the caller supplies both, reject mismatches up-front —
             # otherwise we'd catalog/tag one model while deploying
             # another. When only ``storage_uri`` is set, back-derive
             # ``hf_model_id`` so downstream tags/annotations reflect the
-            # actual deployed model.
+            # actual deployed model. Normalize both sides so e.g.
+            # ``"Org/Name/"`` compares equal to ``"Org/Name"``.
             extracted = ServingManager._extract_hf_model_id(storage_uri)
             if hf_model_id is None:
                 hf_model_id = extracted
-            elif hf_model_id != extracted:
-                raise CogflowValidationError(
-                    f"hf_model_id={hf_model_id!r} does not match the id "
-                    f"encoded in storage_uri={storage_uri!r} "
-                    f"(extracted={extracted!r})"
+            else:
+                normalized = ServingManager._extract_hf_model_id(
+                    f"hf://{hf_model_id}"
                 )
+                if normalized != extracted:
+                    raise CogflowValidationError(
+                        f"hf_model_id={hf_model_id!r} does not match the id "
+                        f"encoded in storage_uri={storage_uri!r} "
+                        f"(extracted={extracted!r})"
+                    )
+                hf_model_id = normalized
 
         # --- 2. Derive names.
         isvc_name, served_model_name = ServingManager.derive_llm_names(

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -991,6 +991,143 @@ class ServingManager:
                 re_raise=True,
             )
 
+    def serve_llm(
+        self,
+        *,
+        storage_uri: Optional[str] = None,
+        hf_model_id: Optional[str] = None,
+        isvc_name: Optional[str] = None,
+        served_model_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        # vLLM runtime args (whitelist)
+        max_model_len: Optional[int] = None,
+        dtype: Optional[str] = None,
+        tensor_parallel_size: Optional[int] = None,
+        trust_remote_code: bool = False,
+        gpu_memory_utilization: Optional[float] = None,
+        max_num_seqs: Optional[int] = None,
+        # scheduling / scaling
+        resources: Optional[Dict[str, Dict[str, str]]] = None,
+        tolerations: Optional[List[Dict[str, Any]]] = None,
+        node_selector: Optional[Dict[str, str]] = None,
+        min_replicas: int = 1,
+        max_replicas: int = 1,
+        # auth
+        hf_secret_name: Optional[str] = None,
+        annotations: Optional[Dict[str, str]] = None,
+        # catalog
+        user_id: Optional[str] = None,
+        extra_tags: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """High-level LLM serving: MLflow-backed catalog registration
+        **plus** KServe InferenceService create, in one call.
+
+        This is the entry point notebook users should reach for — analogous
+        to ``cogflow.log_model`` for classical artifacts. It:
+
+        1. Resolves ``storage_uri`` (``hf://{hf_model_id}`` shorthand is
+           accepted) and derives ``isvc_name`` / ``served_model_name`` via
+           :meth:`ServingManager.derive_llm_names`.
+        2. Opens an MLflow run, tags it with LLM metadata, and posts a
+           catalog entry to the CogFlow backend (best-effort, like
+           ``log_model``). The MLflow run_id becomes the catalog row's
+           primary key — the uniform invariant every other registration
+           path already respects, so ``get_run(model_id)`` works on LLM
+           rows without any type-branching on the consumer side.
+        3. Calls :meth:`deploy_llm` to create the KServe ISVC, injecting
+           ``model_id=run_id`` / ``model_type=llm`` / ``hf_model_id``
+           annotations on top of whatever the caller passed.
+
+        For the thin, ISVC-only path (no catalog), call :meth:`deploy_llm`
+        directly — ``serve_llm`` is strictly additive over it.
+
+        Returns:
+            Dict with ``run_id``, ``isvc_name``, ``served_model_name``,
+            and ``isvc`` (the KServe custom-object create response). The
+            ``run_id`` doubles as the CogFlow ``model_info.id`` for
+            subsequent catalog lookups.
+
+        Raises:
+            CogflowValidationError: neither ``storage_uri`` nor
+                ``hf_model_id`` supplied; malformed ``hf://`` URI;
+                invalid derived name.
+            CogflowModelError: MLflow run creation failed.
+            CogflowServingError / CogflowConnectionError: ISVC create
+                failed (same as :meth:`deploy_llm`).
+        """
+        # --- 1. Resolve storage_uri / hf_model_id into a consistent pair.
+        # Accept either the shorthand or the full ``hf://`` URI; derive
+        # the other end so downstream steps (tagging, annotations, deploy)
+        # see a consistent view regardless of which the caller supplied.
+        if storage_uri is None and hf_model_id is None:
+            raise CogflowValidationError(
+                "serve_llm requires either hf_model_id or storage_uri"
+            )
+        if storage_uri is None:
+            storage_uri = f"hf://{hf_model_id}"
+        elif hf_model_id is None and storage_uri.startswith("hf://"):
+            hf_model_id = ServingManager._extract_hf_model_id(storage_uri)
+
+        # --- 2. Derive names.
+        isvc_name, served_model_name = ServingManager.derive_llm_names(
+            hf_model_id=hf_model_id,
+            served_model_name=served_model_name,
+            isvc_name=isvc_name,
+        )
+
+        # --- 3. Catalog registration (MLflow run + best-effort POST).
+        # Lazy import mirrors the existing pattern in ``_get_model_helpers``
+        # / ``_get_dataset_manager`` to avoid a circular import at module
+        # load time (serving imports models which imports serving for
+        # the LLM serving runtime metadata). Uses the real submodule path
+        # rather than ``cogflow.models`` (a _LazyLoader attribute that
+        # isn't resolvable via ``from … import …``).
+        from cogflow.core import models as cogflow_models
+
+        run_id = cogflow_models.register_llm_catalog_entry(
+            served_model_name=served_model_name,
+            hf_model_id=hf_model_id,
+            user_id=user_id,
+            extra_tags=extra_tags,
+        )
+
+        # --- 4. Merge the run_id / model_type / hf_model_id annotations
+        # onto whatever the caller supplied so consumers (Cog-Engine UI,
+        # direct kubectl inspectors) see the catalog link on the ISVC.
+        merged_annotations: Dict[str, str] = dict(annotations or {})
+        merged_annotations.setdefault("model_type", "llm")
+        merged_annotations["model_id"] = common.normalize_uuid(run_id)
+        if hf_model_id:
+            merged_annotations.setdefault("hf_model_id", hf_model_id)
+
+        # --- 5. Actually create the ISVC.
+        isvc_response = self.deploy_llm(
+            storage_uri=storage_uri,
+            isvc_name=isvc_name,
+            served_model_name=served_model_name,
+            namespace=namespace,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            tensor_parallel_size=tensor_parallel_size,
+            trust_remote_code=trust_remote_code,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            resources=resources,
+            tolerations=tolerations,
+            node_selector=node_selector,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            hf_secret_name=hf_secret_name,
+            annotations=merged_annotations,
+        )
+
+        return {
+            "run_id": run_id,
+            "isvc_name": isvc_name,
+            "served_model_name": served_model_name,
+            "isvc": isvc_response,
+        }
+
     @staticmethod
     def _process_isvc(isvc: dict) -> Dict[str, Any]:
         """
@@ -1612,6 +1749,7 @@ for attr_name in dir(ServingManager):
 from .async_serving import (  # noqa: E402
     async_deploy_model,
     async_deploy_llm,
+    async_serve_llm,
     async_update_model,
     async_delete_isvc,
     async_list_models,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1063,6 +1063,14 @@ class ServingManager:
             raise CogflowValidationError(
                 "serve_llm requires either hf_model_id or storage_uri"
             )
+        # Tolerate an ``hf_model_id`` that a caller accidentally prefixed
+        # with ``hf://`` — otherwise ``f"hf://{hf_model_id}"`` below would
+        # produce a bogus double-scheme ``hf://hf://…`` URI that
+        # ``_extract_hf_model_id`` would happily accept (it only strips
+        # one ``hf://`` and doesn't reject embedded schemes). One strip
+        # here covers both the bare-id path and the mismatch check.
+        if hf_model_id is not None and hf_model_id.startswith("hf://"):
+            hf_model_id = hf_model_id[len("hf://") :]
         if storage_uri is None:
             # Route a bare ``hf_model_id`` through the same validator /
             # normalizer the ``hf://`` URI path uses so whitespace, stray

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,40 @@
 import pytest
 
+# Neutralize the MLflow tracking-server health check at conftest-import
+# time so tests don't depend on a reachable MLflow server.
+#
+# ``cogflow.core.models`` builds a module-level ``_models = ModelManager()``
+# singleton, and ``ModelManager.__init__`` calls
+# ``network.make_health_check_request`` — a real HTTP call to whatever
+# MLflow URI is configured. An autouse fixture runs per-test, which is
+# too late: the first ``import cogflow.core.models`` anywhere in the
+# test session already triggered the call.
+#
+# Approach:
+#   1. Swap ``network.make_health_check_request`` for a no-op.
+#   2. Force-import ``cogflow.core.models`` now so its singleton builds
+#      harmlessly against the stub.
+#   3. Restore the real function so ``tests/test_network.py`` (and any
+#      future direct users of the helper) still see the genuine
+#      behaviour.
+# Subsequent ``import cogflow.core.models`` calls are no-ops because
+# it's already in ``sys.modules``.
+import cogflow.utils.network as _cogflow_network  # noqa: E402
+
+_original_health_check = _cogflow_network.make_health_check_request
+
+
+def _stub_health_check(*_args, **_kwargs):  # pragma: no cover - helper
+    """No-op stand-in for ``network.make_health_check_request``."""
+    return None
+
+
+_cogflow_network.make_health_check_request = _stub_health_check
+try:
+    import cogflow.core.models  # noqa: E402,F401  — builds _models safely
+finally:
+    _cogflow_network.make_health_check_request = _original_health_check
+
 
 @pytest.fixture(autouse=True)
 def mock_current_user(mocker):

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -261,6 +261,7 @@ def test_async_module_exports():
     assert callable(async_serving_module.async_restart_isvc)
     assert callable(async_serving_module.async_create_isvc)
     assert callable(async_serving_module.async_deploy_llm)
+    assert callable(async_serving_module.async_serve_llm)
 
 
 # ---------------------------------------------------------------------
@@ -302,3 +303,39 @@ async def test_async_deploy_llm_emits_expected_spec(async_serving, fake_async_ap
     assert predictor["tolerations"][0]["key"] == "storage-type"
     # Defaults applied
     assert model["resources"]["requests"]["nvidia.com/gpu"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_async_serve_llm_registers_and_deploys(
+    async_serving, fake_async_api, monkeypatch
+):
+    """async_serve_llm should register the catalog entry (sync, via
+    register_llm_catalog_entry) and then create the KServe ISVC async.
+    Annotations on the resulting ISVC must include model_id=run_id —
+    the uniform invariant that keeps GET /models/{id} working for LLM
+    rows without any type branching."""
+    import cogflow.core.models as core_models_module
+
+    fake_run_id = "deadbeef0000deadbeef0000deadbeef"
+    register_mock = MagicMock(return_value=fake_run_id)
+    monkeypatch.setattr(
+        core_models_module,
+        "register_llm_catalog_entry",
+        register_mock,
+        raising=True,
+    )
+
+    result = await async_serving.serve_llm(hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    register_mock.assert_called_once()
+    assert result["run_id"] == fake_run_id
+    assert result["served_model_name"] == "Qwen2.5-Coder-7B-Instruct"
+    assert result["isvc_name"] == "qwen2-5-coder-7b-instruct"
+
+    creates = [c for c in fake_async_api.calls if c[0] == "create"]
+    assert len(creates) == 1
+    body = creates[0][1]["body"]
+    annotations = body["metadata"]["annotations"]
+    assert annotations["model_id"] == common.normalize_uuid(fake_run_id)
+    assert annotations["model_type"] == "llm"
+    assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -834,6 +834,257 @@ def test_deploy_llm_s3_without_served_model_name_raises(serving):
         serving.deploy_llm(storage_uri="s3://mlflow/0/abc/artifacts/model")
 
 
+# ---------------------------------------------------------------------
+# SERVE_LLM (high-level wrapper: MLflow run + catalog POST + deploy_llm)
+# ---------------------------------------------------------------------
+
+
+def _patch_llm_catalog(monkeypatch, serving_module, *, run_id: str):
+    """Stub out ``cogflow.models.register_llm_catalog_entry`` so serve_llm
+    tests never hit a real MLflow server or the CogFlow backend. Returns
+    the MagicMock so tests can assert call args.
+    """
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module  # real submodule path
+
+    mock = MagicMock(return_value=run_id)
+    monkeypatch.setattr(
+        cogflow_models_module,
+        "register_llm_catalog_entry",
+        mock,
+        raising=True,
+    )
+    return mock
+
+
+def test_serve_llm_end_to_end_happy_path(serving, serving_module, monkeypatch):
+    """serve_llm with only hf_model_id should: register via
+    register_llm_catalog_entry, inject model_id=run_id into ISVC
+    annotations, and return a structured dict with run_id + names +
+    isvc response."""
+    fake_run_id = "abcdef01234567890123456789abcdef"
+    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    result = serving.serve_llm(hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    # Catalog registration called with derived name + HF id.
+    register_mock.assert_called_once()
+    reg_kwargs = register_mock.call_args.kwargs
+    assert reg_kwargs["served_model_name"] == "Qwen2.5-Coder-7B-Instruct"
+    assert reg_kwargs["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+
+    # Return shape.
+    assert result["run_id"] == fake_run_id
+    assert result["served_model_name"] == "Qwen2.5-Coder-7B-Instruct"
+    assert result["isvc_name"] == "qwen2-5-coder-7b-instruct"
+    assert "isvc" in result
+
+    # Annotations on the ISVC: model_id == run_id (the invariant), plus
+    # model_type and hf_model_id. ``serve_llm`` normalizes the run_id into
+    # canonical UUID form to match what ``log_model`` already does.
+    create_body = _deploy_llm_create_call(fake_api)
+    meta_annotations = create_body["metadata"]["annotations"]
+    assert meta_annotations["model_id"] == common.normalize_uuid(fake_run_id)
+    assert meta_annotations["model_type"] == "llm"
+    assert meta_annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+
+
+def test_serve_llm_storage_uri_hf_shorthand_populates_hf_model_id(
+    serving, serving_module, monkeypatch
+):
+    """Passing ``storage_uri='hf://org/name'`` instead of ``hf_model_id``
+    still tags and annotates with the HF id — the wrapper extracts it."""
+    fake_run_id = "1234567890abcdef1234567890abcdef"
+    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(storage_uri="hf://meta-llama/Llama-3.1-8B-Instruct")
+
+    reg_kwargs = register_mock.call_args.kwargs
+    assert reg_kwargs["hf_model_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+
+    annotations = _deploy_llm_create_call(fake_api)["metadata"]["annotations"]
+    assert annotations["hf_model_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+
+
+def test_serve_llm_preserves_caller_annotations(serving, serving_module, monkeypatch):
+    """Caller-supplied annotations are merged with the catalog-identity
+    ones; serve_llm should not clobber them (except for model_id, which
+    is always the authoritative run_id)."""
+    fake_run_id = "deadbeefdeadbeefdeadbeefdeadbeef"
+    _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(
+        hf_model_id="gpt2",
+        annotations={"model_type": "llm", "my-custom": "value", "model_id": "IGNORED"},
+    )
+
+    annotations = _deploy_llm_create_call(fake_api)["metadata"]["annotations"]
+    assert annotations["my-custom"] == "value"
+    # model_id is overwritten by the authoritative (normalized) run_id,
+    # not the caller's value.
+    assert annotations["model_id"] == common.normalize_uuid(fake_run_id)
+
+
+def test_serve_llm_requires_source(serving, serving_module, monkeypatch):
+    """Neither storage_uri nor hf_model_id → CogflowValidationError."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    _patch_llm_catalog(monkeypatch, serving_module, run_id="never-used")
+
+    with pytest.raises(CogflowValidationError, match="storage_uri"):
+        serving.serve_llm()
+
+
+def test_serve_llm_returns_isvc_name_from_caller(serving, serving_module, monkeypatch):
+    """Explicit isvc_name wins over the derived slug on the serve_llm path."""
+    _patch_llm_catalog(monkeypatch, serving_module, run_id="f" * 32)
+
+    result = serving.serve_llm(
+        hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",
+        isvc_name="my-explicit-isvc",
+    )
+
+    assert result["isvc_name"] == "my-explicit-isvc"
+
+
+def test_register_llm_catalog_entry_posts_to_cogapi(serving_module, monkeypatch):
+    """Exercises ``ModelManager.register_llm_catalog_entry`` itself:
+    opens an MLflow run, sets LLM tags, POSTs to {API_PATH}/models/log
+    with the run_id as model_id. POST failures are swallowed (warn-only),
+    matching the log_model pattern."""
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module  # real submodule path
+    import cogflow.core.models as core_models_module
+
+    fake_run_id = "cafebabecafebabecafebabecafebabe"
+    fake_run_info = MagicMock()
+    fake_run_info.info.run_id = fake_run_id
+    fake_run_info.info.start_time = 1_700_000_000_000  # ms
+
+    run_ctx = MagicMock()
+    run_ctx.__enter__.return_value = fake_run_info
+    run_ctx.__exit__.return_value = False
+
+    start_run_mock = MagicMock(return_value=run_ctx)
+    set_tag_mock = MagicMock()
+    post_mock = MagicMock()
+    get_user_mock = MagicMock(return_value="user@example.com")
+
+    # Swap out the singleton's bound methods so register_llm_catalog_entry
+    # hits the stubs instead of MLflow / kubernetes.
+    monkeypatch.setattr(
+        cogflow_models_module, "start_run", start_run_mock, raising=True
+    )
+    monkeypatch.setattr(cogflow_models_module, "set_tag", set_tag_mock, raising=True)
+    # The module-level ``_models`` singleton's own methods are what
+    # register_llm_catalog_entry calls through ``self`` — rebind them to
+    # the same stubs so the entry point sees the patches consistently.
+    monkeypatch.setattr(
+        core_models_module._models, "start_run", start_run_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module._models, "set_tag", set_tag_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module._models, "_warn_if_unhealthy", lambda _ctx: None
+    )
+    monkeypatch.setattr(
+        core_models_module.network, "make_post_request", post_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module.common, "get_current_user", get_user_mock, raising=True
+    )
+
+    run_id = cogflow_models_module.register_llm_catalog_entry(
+        served_model_name="Qwen2.5-Coder-7B-Instruct",
+        hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",
+    )
+
+    assert run_id == fake_run_id
+    # Tags set in order we care about: type, source, hf_model_id, note.
+    tag_keys = [call.args[0] for call in set_tag_mock.call_args_list]
+    assert "type" in tag_keys
+    assert "source" in tag_keys
+    assert "hf_model_id" in tag_keys
+    assert "mlflow.note.content" in tag_keys
+
+    # POST was made with model_id=run_id (normalized to canonical UUID
+    # form, matching log_model's existing behaviour) and type=llm.
+    post_mock.assert_called_once()
+    post_kwargs = post_mock.call_args.kwargs
+    payload = post_kwargs["data"]
+    assert payload["model_id"] == common.normalize_uuid(run_id)
+    assert payload["type"] == "llm"
+    assert payload["model_name"] == "Qwen2.5-Coder-7B-Instruct"
+    assert payload["user_id"] == "user@example.com"
+    assert payload["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    assert post_kwargs["headers"]["kubeflow-userid"] == "user@example.com"
+
+
+def test_register_llm_catalog_entry_swallows_post_failure(
+    serving_module, monkeypatch, caplog
+):
+    """A CogFlow-backend POST failure must NOT abort the registration —
+    matches the log_model pattern. Returns the run_id regardless so the
+    caller can still create the ISVC."""
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module  # real submodule path
+    import cogflow.core.models as core_models_module
+
+    fake_run_id = "0123456789abcdef0123456789abcdef"
+    fake_run_info = MagicMock()
+    fake_run_info.info.run_id = fake_run_id
+    fake_run_info.info.start_time = 1_700_000_000_000
+
+    run_ctx = MagicMock()
+    run_ctx.__enter__.return_value = fake_run_info
+    run_ctx.__exit__.return_value = False
+
+    start_run_mock = MagicMock(return_value=run_ctx)
+    set_tag_mock = MagicMock()
+
+    def failing_post(**_kwargs):
+        raise RuntimeError("cogapi unreachable")
+
+    monkeypatch.setattr(
+        cogflow_models_module, "start_run", start_run_mock, raising=True
+    )
+    monkeypatch.setattr(cogflow_models_module, "set_tag", set_tag_mock, raising=True)
+    monkeypatch.setattr(
+        core_models_module._models, "start_run", start_run_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module._models, "set_tag", set_tag_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module._models, "_warn_if_unhealthy", lambda _ctx: None
+    )
+    monkeypatch.setattr(
+        core_models_module.network, "make_post_request", failing_post, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module.common,
+        "get_current_user",
+        lambda: "user@example.com",
+        raising=True,
+    )
+
+    # Should NOT raise.
+    run_id = cogflow_models_module.register_llm_catalog_entry(
+        served_model_name="gpt2",
+        hf_model_id="gpt2",
+        user_id="explicit-user",
+    )
+
+    assert run_id == fake_run_id
+
+
 def test_serving_module_reexports_async_deploy_llm():
     """cogflow.serving must expose async_deploy_llm alongside the other
     async_* helpers. Consumers (e.g. Cog-Engine) reach it via

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -981,6 +981,30 @@ def test_serve_llm_normalizes_dirty_hf_model_id(serving, serving_module, monkeyp
     assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
 
 
+def test_serve_llm_strips_accidental_hf_scheme_prefix(
+    serving, serving_module, monkeypatch
+):
+    """A caller passing ``hf_model_id="hf://Org/Name"`` (accidentally
+    double-schemed) should not produce a ``hf://hf://…`` URI. Strip the
+    leading ``hf://`` from the bare id before building the URI."""
+    fake_run_id = "c" * 32
+    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(hf_model_id="hf://Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    assert (
+        register_mock.call_args.kwargs["hf_model_id"]
+        == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    )
+    annotations = _deploy_llm_create_call(fake_api)["metadata"]["annotations"]
+    assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    # The deploy's args must carry the canonical ``--model_id`` — not the
+    # double-schemed form — so vLLM actually pulls the right model.
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in args
+
+
 def test_serve_llm_invalid_hf_model_id_rejected_before_catalog(
     serving, serving_module, monkeypatch
 ):

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -910,9 +910,12 @@ def test_serve_llm_storage_uri_hf_shorthand_populates_hf_model_id(
 
 
 def test_serve_llm_preserves_caller_annotations(serving, serving_module, monkeypatch):
-    """Caller-supplied annotations are merged with the catalog-identity
-    ones; serve_llm should not clobber them (except for model_id, which
-    is always the authoritative run_id)."""
+    """Caller-supplied *unrelated* annotations are merged with the
+    catalog-identity ones; the three identity keys (``model_type``,
+    ``model_id``, ``hf_model_id``) are authoritatively set by
+    ``serve_llm`` — see
+    ``test_serve_llm_identity_annotations_are_authoritative`` for that
+    coverage."""
     fake_run_id = "deadbeefdeadbeefdeadbeefdeadbeef"
     _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
     _, fake_api, _ = serving_module
@@ -927,6 +930,105 @@ def test_serve_llm_preserves_caller_annotations(serving, serving_module, monkeyp
     # model_id is overwritten by the authoritative (normalized) run_id,
     # not the caller's value.
     assert annotations["model_id"] == common.normalize_uuid(fake_run_id)
+
+
+def test_serve_llm_identity_annotations_are_authoritative(
+    serving, serving_module, monkeypatch
+):
+    """Caller-supplied ``model_type`` and ``hf_model_id`` annotations must
+    NOT win over the values derived from the actual deploy. Otherwise
+    the ISVC metadata could drift from the catalog entry.
+    """
+    fake_run_id = "11111111111111111111111111111111"
+    _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(
+        hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",
+        annotations={
+            "model_type": "not-llm-actually",
+            "hf_model_id": "bogus/id",
+            "keep-this": "yes",
+        },
+    )
+
+    annotations = _deploy_llm_create_call(fake_api)["metadata"]["annotations"]
+    assert annotations["model_type"] == "llm"
+    assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    # Unrelated caller annotations are still preserved.
+    assert annotations["keep-this"] == "yes"
+
+
+def test_serve_llm_storage_uri_hf_id_mismatch_raises(serving, serving_module, monkeypatch):
+    """Passing both ``storage_uri='hf://A'`` and ``hf_model_id='B'`` is
+    a configuration bug — we'd deploy one model and catalog another.
+    Reject up-front with a typed error."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    _patch_llm_catalog(monkeypatch, serving_module, run_id="never-used")
+
+    with pytest.raises(CogflowValidationError, match="does not match"):
+        serving.serve_llm(
+            storage_uri="hf://Qwen/Qwen2.5-Coder-7B-Instruct",
+            hf_model_id="meta-llama/Llama-3.1-8B-Instruct",
+        )
+
+
+def test_register_llm_catalog_entry_extra_tags_cannot_override_reserved(
+    serving_module, monkeypatch
+):
+    """``extra_tags`` must not override the reserved identity tags —
+    reserved wins so the MLflow run stays consistent with the catalog
+    entry. We check this via the order of ``set_tag`` calls: reserved
+    keys appear AFTER any extra_tags entry for the same key."""
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module
+
+    fake_run_info = MagicMock()
+    fake_run_info.info.run_id = "2" * 32
+    fake_run_info.info.start_time = 1_700_000_000_000
+
+    run_ctx = MagicMock()
+    run_ctx.__enter__.return_value = fake_run_info
+    run_ctx.__exit__.return_value = False
+
+    start_run_mock = MagicMock(return_value=run_ctx)
+    set_tag_mock = MagicMock()
+    post_mock = MagicMock()
+
+    monkeypatch.setattr(
+        cogflow_models_module._models, "start_run", start_run_mock, raising=True
+    )
+    monkeypatch.setattr(
+        cogflow_models_module._models, "set_tag", set_tag_mock, raising=True
+    )
+    monkeypatch.setattr(
+        cogflow_models_module._models, "_warn_if_unhealthy", lambda _ctx: None
+    )
+    monkeypatch.setattr(
+        cogflow_models_module.network, "make_post_request", post_mock, raising=True
+    )
+    monkeypatch.setattr(
+        cogflow_models_module.common,
+        "get_current_user",
+        lambda: "user@example.com",
+        raising=True,
+    )
+
+    cogflow_models_module.register_llm_catalog_entry(
+        served_model_name="gpt2",
+        hf_model_id="gpt2",
+        extra_tags={"type": "hacker", "custom-tag": "kept"},
+    )
+
+    # Build an ordered list of tags as set on the run.
+    tag_calls = [(call.args[0], call.args[1]) for call in set_tag_mock.call_args_list]
+    # ``custom-tag`` survives.
+    assert ("custom-tag", "kept") in tag_calls
+    # ``type`` was attempted with 'hacker' first, then overwritten with 'llm'.
+    type_values = [v for k, v in tag_calls if k == "type"]
+    assert type_values[-1] == "llm"
 
 
 def test_serve_llm_requires_source(serving, serving_module, monkeypatch):

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -839,10 +839,14 @@ def test_deploy_llm_s3_without_served_model_name_raises(serving):
 # ---------------------------------------------------------------------
 
 
-def _patch_llm_catalog(monkeypatch, serving_module, *, run_id: str):
-    """Stub out ``cogflow.models.register_llm_catalog_entry`` so serve_llm
-    tests never hit a real MLflow server or the CogFlow backend. Returns
-    the MagicMock so tests can assert call args.
+def _patch_llm_catalog(monkeypatch, *, run_id: str):
+    """Stub out ``cogflow.core.models.register_llm_catalog_entry`` so
+    serve_llm tests never hit a real MLflow server or the CogFlow
+    backend. Returns the MagicMock so tests can assert call args.
+
+    The MLflow tracking-server health check that ``ModelManager.__init__``
+    runs at module-import time is stubbed globally in ``conftest.py``,
+    so importing ``cogflow.core.models`` here is side-effect-free.
     """
     from unittest.mock import MagicMock
 
@@ -864,7 +868,7 @@ def test_serve_llm_end_to_end_happy_path(serving, serving_module, monkeypatch):
     annotations, and return a structured dict with run_id + names +
     isvc response."""
     fake_run_id = "abcdef01234567890123456789abcdef"
-    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    register_mock = _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     result = serving.serve_llm(hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct")
@@ -897,7 +901,7 @@ def test_serve_llm_storage_uri_hf_shorthand_populates_hf_model_id(
     """Passing ``storage_uri='hf://org/name'`` instead of ``hf_model_id``
     still tags and annotates with the HF id — the wrapper extracts it."""
     fake_run_id = "1234567890abcdef1234567890abcdef"
-    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    register_mock = _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     serving.serve_llm(storage_uri="hf://meta-llama/Llama-3.1-8B-Instruct")
@@ -917,7 +921,7 @@ def test_serve_llm_preserves_caller_annotations(serving, serving_module, monkeyp
     ``test_serve_llm_identity_annotations_are_authoritative`` for that
     coverage."""
     fake_run_id = "deadbeefdeadbeefdeadbeefdeadbeef"
-    _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     serving.serve_llm(
@@ -940,7 +944,7 @@ def test_serve_llm_identity_annotations_are_authoritative(
     the ISVC metadata could drift from the catalog entry.
     """
     fake_run_id = "11111111111111111111111111111111"
-    _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     serving.serve_llm(
@@ -966,7 +970,7 @@ def test_serve_llm_normalizes_dirty_hf_model_id(serving, serving_module, monkeyp
     form. Prevents an orphan run from slipping through when
     ``deploy_llm`` would reject the URI later."""
     fake_run_id = "abababababababababababababababab"
-    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    register_mock = _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     serving.serve_llm(hf_model_id="/Qwen/Qwen2.5-Coder-7B-Instruct/")
@@ -988,7 +992,7 @@ def test_serve_llm_strips_accidental_hf_scheme_prefix(
     double-schemed) should not produce a ``hf://hf://…`` URI. Strip the
     leading ``hf://`` from the bare id before building the URI."""
     fake_run_id = "c" * 32
-    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    register_mock = _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
     _, fake_api, _ = serving_module
 
     serving.serve_llm(hf_model_id="hf://Qwen/Qwen2.5-Coder-7B-Instruct")
@@ -1013,9 +1017,7 @@ def test_serve_llm_invalid_hf_model_id_rejected_before_catalog(
     or catalog POST is issued — no side effects to clean up."""
     from cogflow.utils.exceptions import CogflowValidationError
 
-    register_mock = _patch_llm_catalog(
-        monkeypatch, serving_module, run_id="never-created"
-    )
+    register_mock = _patch_llm_catalog(monkeypatch, run_id="never-created")
 
     for bad in ("", "   ", "/"):
         with pytest.raises(CogflowValidationError, match="invalid HF model id"):
@@ -1031,7 +1033,7 @@ def test_serve_llm_storage_uri_hf_id_mismatch_raises(serving, serving_module, mo
     Reject up-front with a typed error."""
     from cogflow.utils.exceptions import CogflowValidationError
 
-    _patch_llm_catalog(monkeypatch, serving_module, run_id="never-used")
+    _patch_llm_catalog(monkeypatch, run_id="never-used")
 
     with pytest.raises(CogflowValidationError, match="does not match"):
         serving.serve_llm(
@@ -1101,7 +1103,7 @@ def test_serve_llm_requires_source(serving, serving_module, monkeypatch):
     """Neither storage_uri nor hf_model_id → CogflowValidationError."""
     from cogflow.utils.exceptions import CogflowValidationError
 
-    _patch_llm_catalog(monkeypatch, serving_module, run_id="never-used")
+    _patch_llm_catalog(monkeypatch, run_id="never-used")
 
     with pytest.raises(CogflowValidationError, match="storage_uri"):
         serving.serve_llm()
@@ -1109,7 +1111,7 @@ def test_serve_llm_requires_source(serving, serving_module, monkeypatch):
 
 def test_serve_llm_returns_isvc_name_from_caller(serving, serving_module, monkeypatch):
     """Explicit isvc_name wins over the derived slug on the serve_llm path."""
-    _patch_llm_catalog(monkeypatch, serving_module, run_id="f" * 32)
+    _patch_llm_catalog(monkeypatch, run_id="f" * 32)
 
     result = serving.serve_llm(
         hf_model_id="Qwen/Qwen2.5-Coder-7B-Instruct",

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -959,6 +959,48 @@ def test_serve_llm_identity_annotations_are_authoritative(
     assert annotations["keep-this"] == "yes"
 
 
+def test_serve_llm_normalizes_dirty_hf_model_id(serving, serving_module, monkeypatch):
+    """``hf_model_id`` with trailing/leading slashes is normalized via
+    ``_extract_hf_model_id`` *before* the catalog entry is opened, so
+    tags / annotations / the staged MLflow run all see the canonical
+    form. Prevents an orphan run from slipping through when
+    ``deploy_llm`` would reject the URI later."""
+    fake_run_id = "abababababababababababababababab"
+    register_mock = _patch_llm_catalog(monkeypatch, serving_module, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(hf_model_id="/Qwen/Qwen2.5-Coder-7B-Instruct/")
+
+    # Catalog registration saw the canonical id.
+    assert (
+        register_mock.call_args.kwargs["hf_model_id"]
+        == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    )
+    # ISVC annotation carries the canonical id too.
+    annotations = _deploy_llm_create_call(fake_api)["metadata"]["annotations"]
+    assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+
+
+def test_serve_llm_invalid_hf_model_id_rejected_before_catalog(
+    serving, serving_module, monkeypatch
+):
+    """An invalid bare ``hf_model_id`` (empty, whitespace, slash-only)
+    must raise CogflowValidationError BEFORE any MLflow run is opened
+    or catalog POST is issued — no side effects to clean up."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    register_mock = _patch_llm_catalog(
+        monkeypatch, serving_module, run_id="never-created"
+    )
+
+    for bad in ("", "   ", "/"):
+        with pytest.raises(CogflowValidationError, match="invalid HF model id"):
+            serving.serve_llm(hf_model_id=bad)
+
+    # register_llm_catalog_entry must NOT have been reached.
+    register_mock.assert_not_called()
+
+
 def test_serve_llm_storage_uri_hf_id_mismatch_raises(serving, serving_module, monkeypatch):
     """Passing both ``storage_uri='hf://A'`` and ``hf_model_id='B'`` is
     a configuration bug — we'd deploy one model and catalog another.

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -1009,6 +1009,80 @@ def test_serve_llm_strips_accidental_hf_scheme_prefix(
     assert "--model_id=Qwen/Qwen2.5-Coder-7B-Instruct" in args
 
 
+def test_serve_llm_rejects_double_hf_scheme_prefix(
+    serving, serving_module, monkeypatch
+):
+    """Tolerating one accidental ``hf://`` prefix is forgiveness; two or
+    more is a typo the user should see. Without rejection,
+    ``hf://hf://Org/Name`` would strip to ``hf://Org/Name`` and vLLM
+    would be handed an invalid ``--model_id``. Rejected at the validator
+    layer so every call path (bare id, storage_uri, direct
+    register_llm_catalog_entry) gets the protection."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    register_mock = _patch_llm_catalog(monkeypatch, run_id="never-created")
+
+    # Double-scheme via hf_model_id shorthand.
+    with pytest.raises(CogflowValidationError, match="embedded scheme"):
+        serving.serve_llm(hf_model_id="hf://hf://Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    # Double-scheme via storage_uri directly.
+    with pytest.raises(CogflowValidationError, match="embedded scheme"):
+        serving.serve_llm(storage_uri="hf://hf://Qwen/Qwen2.5-Coder-7B-Instruct")
+
+    # Any non-hf scheme smuggled inside an hf_model_id also rejected.
+    with pytest.raises(CogflowValidationError, match="embedded scheme"):
+        serving.serve_llm(hf_model_id="s3://bucket/key")
+
+    register_mock.assert_not_called()
+
+
+def test_serve_llm_rejects_hf_id_with_non_hf_storage_uri(
+    serving, serving_module, monkeypatch
+):
+    """Passing ``hf_model_id`` alongside a non-``hf://`` ``storage_uri``
+    would tag the catalog as HuggingFace-sourced while deploying from
+    (say) s3. Reject up-front so the catalog can't diverge from the
+    actual deployed artifact."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    register_mock = _patch_llm_catalog(monkeypatch, run_id="never-created")
+
+    with pytest.raises(CogflowValidationError, match="non-HF storage_uri"):
+        serving.serve_llm(
+            storage_uri="s3://mlflow/0/abc/artifacts/model",
+            hf_model_id="gpt2",
+        )
+    register_mock.assert_not_called()
+
+
+def test_extract_hf_model_id_rejects_embedded_scheme(serving_module):
+    """Direct unit coverage for ``_extract_hf_model_id`` — the DRY fix
+    point for embedded-scheme inputs. Every call site
+    (``_build_llm_predictor``, ``serve_llm``, async variants,
+    ``register_llm_catalog_entry``) routes through here, so a single
+    validator check protects them all."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    module_obj, _, _ = serving_module
+    for bad in (
+        "hf://hf://Org/Name",
+        "hf://s3://bucket/key",
+        "hf://file:///etc/passwd",
+    ):
+        with pytest.raises(CogflowValidationError, match="embedded scheme"):
+            module_obj.ServingManager._extract_hf_model_id(bad)
+
+    # Well-formed inputs still pass.
+    assert (
+        module_obj.ServingManager._extract_hf_model_id(
+            "hf://Qwen/Qwen2.5-Coder-7B-Instruct"
+        )
+        == "Qwen/Qwen2.5-Coder-7B-Instruct"
+    )
+    assert module_obj.ServingManager._extract_hf_model_id("hf://gpt2") == "gpt2"
+
+
 def test_serve_llm_invalid_hf_model_id_rejected_before_catalog(
     serving, serving_module, monkeypatch
 ):


### PR DESCRIPTION
## Summary
Add a high-level LLM entry point that combines MLflow-run creation, CogFlow catalog registration, and KServe ISVC create — so notebook users and Cog-Engine alike get catalogued LLMs from a single call. Symmetric with how `log_model` already handles classical artifacts.

## Why
Today, calling `cogflow.serving.deploy_llm(...)` from a notebook creates a KServe `InferenceService` but **never touches the CogFlow catalog** — the LLM doesn't appear in `GET /models`. Cog-Engine's `_deploy_llm` papers over this for its own API path by inserting a row locally, but uses `uuid4()` as the id and skips MLflow. That breaks the invariant `model_info.id == MLflow run_id` that every other registration path respects, so `GET /models/{id}` 500s on LLM rows (`cogflow_models.get_run(model_id)` has no run to return). Owning the logic in cogflow fixes both paths in one place.

## What's in

- **`ModelManager.register_llm_catalog_entry`** (`cogflow/core/models.py`) — opens an MLflow run, tags it with LLM metadata (`type=llm`, `source`, `hf_model_id`, `mlflow.note.content`, plus any `extra_tags`), best-effort POSTs to `{API_PATH}/models/log` with the run_id as the catalog primary key. Same warn-on-failure pattern as `log_model` — a transient catalog outage doesn't abort the deploy.
- **`ServingManager.serve_llm` / `AsyncServingManager.serve_llm`** (`cogflow/core/serving.py`, `cogflow/core/async_serving.py`) — resolves `hf_model_id` shorthand into a `hf://` URI (and vice versa), derives names via the existing `derive_llm_names`, calls `register_llm_catalog_entry`, merges `model_id` / `model_type` / `hf_model_id` annotations on top of whatever the caller supplied, then delegates to `deploy_llm`. Returns `{run_id, isvc_name, served_model_name, isvc}`.
- **Async path** keeps the catalog step synchronous (MLflow tracking and the catalog POST both block) and only awaits the ISVC create — same sync/async split the existing `deploy_llm` pair uses.
- **`deploy_llm` itself is unchanged** — kept as a low-level primitive for callers that want an ISVC without a catalog side-effect. `serve_llm` is strictly additive.

## Test plan
- [x] `pytest tests/test_serving.py tests/test_async_serving.py` — 53 pass (7 new).
- [x] Full suite: 237 passed, 1 skipped.
- [x] New tests:
  - `test_serve_llm_end_to_end_happy_path` — invariant check: `model_id` annotation on the ISVC equals the normalized run_id.
  - `test_serve_llm_storage_uri_hf_shorthand_populates_hf_model_id` — `storage_uri="hf://…"` backs into `hf_model_id` for tags/annotations.
  - `test_serve_llm_preserves_caller_annotations` — merge behaviour; `model_id` is always authoritative.
  - `test_serve_llm_requires_source` — `CogflowValidationError` when neither source is supplied.
  - `test_serve_llm_returns_isvc_name_from_caller` — explicit `isvc_name` beats the derived slug.
  - `test_register_llm_catalog_entry_posts_to_cogapi` — POST payload shape (normalized model_id, tags, headers).
  - `test_register_llm_catalog_entry_swallows_post_failure` — catalog POST failure doesn't raise (warn-only).
  - `test_async_serve_llm_registers_and_deploys` — async parity on the annotations invariant.

## Pairs with
Cog-Engine follow-up PR: switch `_deploy_llm` to call `async_serve_llm`, drop the manual `ModelInfoDB` insert, add a defensive fallback in `get_model_by_id` for legacy rows that predate this change.