### PR TITLE
release: install cogflow from build-job artifact, not PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,14 +164,40 @@ jobs:
           echo "Tags: $TAGS"
           echo "Platforms: $PLATFORMS"
 
-      - name: Set up Python
+      # Build context always has a ``dist/`` directory. On the tag-push
+      # path we populate it with the wheel that ``build`` already uploaded
+      # as an artifact — no PyPI round-trip, no CDN race. On the
+      # workflow_dispatch path the ``build`` job was skipped (different
+      # ``if`` gate) so no artifact exists; the Dockerfile falls back to
+      # ``pip install cogflow==$VERSION`` from PyPI and the wait step
+      # below handles any lingering propagation.
+      - name: Prepare wheel directory in build context
+        run: mkdir -p docker_image_variants/latest/dist
+
+      - name: Download cogflow wheel from build artifact (tag-push path)
+        if: github.event_name == 'push'
+        uses: actions/download-artifact@v5
+        with:
+          name: cogflow-${{ needs.build.outputs.version }}
+          path: ./docker_image_variants/latest/dist/
+
+      - name: Set up Python (dispatch-only, for PyPI wait)
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
-      - name: Wait for PyPI simple index to list the version
+      - name: Wait for PyPI simple index (dispatch-only)
+        # Tag-push doesn't hit PyPI at all during the image build — the
+        # wheel comes from the artifact downloaded above — so the wait
+        # is only needed on workflow_dispatch, where we rebuild the
+        # image for a version that's already published on PyPI.
+        # ``workflow_dispatch`` targets stable/long-published versions,
+        # so propagation is usually a non-issue, but keep the poll as
+        # a safety net in case someone triggers it seconds after upload.
+        if: github.event_name == 'workflow_dispatch'
         env:
-          VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           python3 - <<'PY'
           import os, sys, time
@@ -179,17 +205,7 @@ jobs:
           from urllib.error import URLError
 
           version = os.environ["VERSION"]
-          # Check the SIMPLE index (what pip actually uses during install),
-          # not the JSON metadata API. The two are cached separately and the
-          # simple index lags: a version can appear in JSON minutes before
-          # pip can see it. Confirming against the simple index prevents
-          # the docker build from racing with PyPI CDN propagation.
           url = "https://pypi.org/simple/cogflow/"
-          # Match any distribution file for this exact version:
-          #   - wheels (any tag):  "cogflow-<v>-*.whl"      -> prefix "cogflow-<v>-"
-          #   - sdists:            "cogflow-<v>.tar.gz" / .zip -> prefix "cogflow-<v>."
-          # Matching prefixes (not specific filenames) covers future platform-tagged
-          # wheels without needing workflow changes.
           needles = (f"cogflow-{version}-", f"cogflow-{version}.")
 
           attempts = 12  # ~4 minutes total

--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -23,16 +23,30 @@ ARG COGFLOW_VERSION=1.11.15
 # creates the directory first. Dev builds without the workflow can
 # just ``mkdir -p dist`` in the build context or use the PyPI fallback.
 COPY dist/ /tmp/cogflow-dist/
-# POSIX-sh portable glob check — ``compgen`` is bash-only and
-# ``python:3.10-slim``'s ``/bin/sh`` is dash. ``ls ... 2>/dev/null``
-# returns the matching filenames on success or an empty string on
-# no-match; ``-n`` tests for non-empty.
-RUN if [ -n "$(ls /tmp/cogflow-dist/cogflow-*.whl 2>/dev/null)" ]; then \
-        echo "Installing cogflow from local wheel(s)"; \
-        ls /tmp/cogflow-dist/cogflow-*.whl; \
-        pip3 install --ignore-installed /tmp/cogflow-dist/cogflow-*.whl; \
+# Match wheels by the exact ``COGFLOW_VERSION`` so a stale wheel from
+# a different version left in the build context (e.g. a dev who ran
+# ``python -m build`` earlier) can't silently install the wrong
+# cogflow and contradict the build arg. ``find`` is POSIX-sh portable
+# (``python:3.10-slim``'s ``/bin/sh`` is dash, no ``compgen``).
+#
+# Invariants:
+#   exactly 1 matching wheel → install it
+#   more than 1 matching wheel → hard fail (ambiguous build context)
+#   zero matches → fall back to ``pip install cogflow==$VERSION``
+#                  from PyPI (workflow_dispatch / local no-artifact path)
+RUN wheel_match="cogflow-${COGFLOW_VERSION}-*.whl"; \
+    wheel_count="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" | wc -l)"; \
+    if [ "${wheel_count}" -eq 1 ]; then \
+        wheel_path="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}")"; \
+        echo "Installing cogflow from local wheel: ${wheel_path}"; \
+        pip3 install --ignore-installed "${wheel_path}"; \
+    elif [ "${wheel_count}" -gt 1 ]; then \
+        echo "Ambiguous build context: expected exactly one ${wheel_match}, found ${wheel_count}" >&2; \
+        find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" >&2; \
+        rm -rf /tmp/cogflow-dist; \
+        exit 1; \
     else \
-        echo "No local wheel found; installing cogflow==${COGFLOW_VERSION} from PyPI"; \
+        echo "No local wheel matching ${wheel_match}; installing cogflow==${COGFLOW_VERSION} from PyPI"; \
         pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}; \
     fi \
     && rm -rf /tmp/cogflow-dist

--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -1,8 +1,9 @@
-# syntax=docker/dockerfile:1
-# ``# syntax=docker/dockerfile:1`` enables the BuildKit Dockerfile
-# frontend (1.2+), which is what supports ``RUN --mount=type=bind``
-# below. docker/build-push-action@v6 already uses BuildKit; this
-# directive just pins the Dockerfile syntax version explicitly.
+# syntax=docker/dockerfile:1.4
+# ``# syntax=docker/dockerfile:1.4`` pins the BuildKit Dockerfile
+# frontend to the 1.4 minor line (bare ``1`` would float to whatever
+# is latest at build time). 1.4 is sufficient for
+# ``RUN --mount=type=bind`` used below. docker/build-push-action@v6
+# already uses BuildKit.
 
 # Use the official Python image as the base image
 FROM python:3.10-slim
@@ -48,25 +49,29 @@ ARG COGFLOW_VERSION=1.11.15
 # immutable — bloating the image by the wheel size.
 RUN --mount=type=bind,source=dist,target=/tmp/cogflow-dist \
     wheel_match="cogflow-${COGFLOW_VERSION}-*.whl"; \
-    wheel_count="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" | wc -l)"; \
+    wheel_paths="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}")"; \
+    if [ -n "${wheel_paths}" ]; then \
+        wheel_count="$(printf '%s\n' "${wheel_paths}" | wc -l)"; \
+    else \
+        wheel_count=0; \
+    fi; \
     if [ "${wheel_count}" -eq 1 ]; then \
-        wheel_path="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}")"; \
-        echo "Installing cogflow from local wheel: ${wheel_path}"; \
-        pip3 install --ignore-installed "${wheel_path}"; \
+        echo "Installing cogflow from local wheel: ${wheel_paths}"; \
+        pip3 install --no-cache-dir --ignore-installed "${wheel_paths}"; \
     elif [ "${wheel_count}" -gt 1 ]; then \
         echo "Ambiguous build context: expected exactly one ${wheel_match}, found ${wheel_count}" >&2; \
-        find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" >&2; \
+        printf '%s\n' "${wheel_paths}" >&2; \
         exit 1; \
     else \
         echo "No local wheel matching ${wheel_match}; installing cogflow==${COGFLOW_VERSION} from PyPI"; \
-        pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}; \
+        pip3 install --no-cache-dir --ignore-installed cogflow==${COGFLOW_VERSION}; \
     fi
 
 # Install additional Python packages (shap, xgboost).
 # shap pinned to 0.44.* which publishes cp310 manylinux wheels; newer shap
 # (0.47+) has a broken setup.py for the slim base and falls back to source
 # builds that need g++.
-RUN pip3 install "shap==0.44.*" xgboost
+RUN pip3 install --no-cache-dir "shap==0.44.*" xgboost
 
 # Install compatible protobuf version first
 RUN pip install --no-cache-dir protobuf==3.20.1

--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -6,8 +6,36 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 ARG COGFLOW_VERSION=1.11.15
 
-# Install specific version of cogflow
-RUN pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}
+# Prefer a locally-available wheel when present; fall back to PyPI.
+#
+# Release workflow (tag-push): the ``build`` job ships a wheel as an
+# artifact; ``docker-publish`` downloads it into ``./dist/`` and the
+# wheel-install branch runs. That side-steps PyPI entirely, so the
+# image can't race the CDN propagation of a freshly-uploaded version.
+#
+# Release workflow (workflow_dispatch): no artifact exists; ``./dist/``
+# is created empty by the workflow and this step falls back to
+# ``pip install cogflow==$VERSION`` from PyPI (the version is already
+# long-published in this code path, so no race).
+#
+# Local ``docker build`` with no ``./dist/`` directory: the COPY of
+# the empty/absent directory would fail, so the workflow always
+# creates the directory first. Dev builds without the workflow can
+# just ``mkdir -p dist`` in the build context or use the PyPI fallback.
+COPY dist/ /tmp/cogflow-dist/
+# POSIX-sh portable glob check — ``compgen`` is bash-only and
+# ``python:3.10-slim``'s ``/bin/sh`` is dash. ``ls ... 2>/dev/null``
+# returns the matching filenames on success or an empty string on
+# no-match; ``-n`` tests for non-empty.
+RUN if [ -n "$(ls /tmp/cogflow-dist/cogflow-*.whl 2>/dev/null)" ]; then \
+        echo "Installing cogflow from local wheel(s)"; \
+        ls /tmp/cogflow-dist/cogflow-*.whl; \
+        pip3 install --ignore-installed /tmp/cogflow-dist/cogflow-*.whl; \
+    else \
+        echo "No local wheel found; installing cogflow==${COGFLOW_VERSION} from PyPI"; \
+        pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}; \
+    fi \
+    && rm -rf /tmp/cogflow-dist
 
 # Install additional Python packages (shap, xgboost).
 # shap pinned to 0.44.* which publishes cp310 manylinux wheels; newer shap

--- a/docker_image_variants/latest/Dockerfile
+++ b/docker_image_variants/latest/Dockerfile
@@ -1,3 +1,9 @@
+# syntax=docker/dockerfile:1
+# ``# syntax=docker/dockerfile:1`` enables the BuildKit Dockerfile
+# frontend (1.2+), which is what supports ``RUN --mount=type=bind``
+# below. docker/build-push-action@v6 already uses BuildKit; this
+# directive just pins the Dockerfile syntax version explicitly.
+
 # Use the official Python image as the base image
 FROM python:3.10-slim
 
@@ -18,23 +24,30 @@ ARG COGFLOW_VERSION=1.11.15
 # ``pip install cogflow==$VERSION`` from PyPI (the version is already
 # long-published in this code path, so no race).
 #
-# Local ``docker build`` with no ``./dist/`` directory: the COPY of
-# the empty/absent directory would fail, so the workflow always
-# creates the directory first. Dev builds without the workflow can
-# just ``mkdir -p dist`` in the build context or use the PyPI fallback.
-COPY dist/ /tmp/cogflow-dist/
-# Match wheels by the exact ``COGFLOW_VERSION`` so a stale wheel from
-# a different version left in the build context (e.g. a dev who ran
-# ``python -m build`` earlier) can't silently install the wrong
-# cogflow and contradict the build arg. ``find`` is POSIX-sh portable
-# (``python:3.10-slim``'s ``/bin/sh`` is dash, no ``compgen``).
+# Local ``docker build`` with no ``./dist/`` directory: the bind
+# mount below fails. The release workflow always ``mkdir -p dist``s
+# before building, so both CI paths are covered; local dev can do
+# the same or just install from PyPI directly.
 #
-# Invariants:
-#   exactly 1 matching wheel → install it
-#   more than 1 matching wheel → hard fail (ambiguous build context)
-#   zero matches → fall back to ``pip install cogflow==$VERSION``
-#                  from PyPI (workflow_dispatch / local no-artifact path)
-RUN wheel_match="cogflow-${COGFLOW_VERSION}-*.whl"; \
+# Wheel matching:
+#
+# - Exact ``COGFLOW_VERSION`` match so a stale wheel from a different
+#   version in the build context (e.g. a dev who ran ``python -m build``
+#   earlier) can't silently install the wrong cogflow.
+# - ``find`` is POSIX-sh portable (slim base uses ``dash`` — no
+#   ``compgen``).
+# - Match-count branching:
+#     1   → install that wheel
+#     >1  → hard fail (ambiguous build context)
+#     0   → PyPI fallback
+#
+# BuildKit bind-mount (``--mount=type=bind``): mounts ``./dist/`` into
+# the RUN read-only for this step only, so wheel bytes NEVER land in
+# a committed image layer. Using ``COPY`` would bake them into an
+# earlier layer that a later ``rm`` can't reclaim — Docker layers are
+# immutable — bloating the image by the wheel size.
+RUN --mount=type=bind,source=dist,target=/tmp/cogflow-dist \
+    wheel_match="cogflow-${COGFLOW_VERSION}-*.whl"; \
     wheel_count="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" | wc -l)"; \
     if [ "${wheel_count}" -eq 1 ]; then \
         wheel_path="$(find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}")"; \
@@ -43,13 +56,11 @@ RUN wheel_match="cogflow-${COGFLOW_VERSION}-*.whl"; \
     elif [ "${wheel_count}" -gt 1 ]; then \
         echo "Ambiguous build context: expected exactly one ${wheel_match}, found ${wheel_count}" >&2; \
         find /tmp/cogflow-dist -maxdepth 1 -type f -name "${wheel_match}" >&2; \
-        rm -rf /tmp/cogflow-dist; \
         exit 1; \
     else \
         echo "No local wheel matching ${wheel_match}; installing cogflow==${COGFLOW_VERSION} from PyPI"; \
         pip3 install --ignore-installed cogflow==${COGFLOW_VERSION}; \
-    fi \
-    && rm -rf /tmp/cogflow-dist
+    fi
 
 # Install additional Python packages (shap, xgboost).
 # shap pinned to 0.44.* which publishes cp310 manylinux wheels; newer shap


### PR DESCRIPTION
## Summary
Root-cause fix for the 2.0.1b10 docker-publish failure: bypass PyPI on the tag-push path and install cogflow directly from the wheel the ``build`` job already uploaded as an artifact.

## Why
After PR #87 made pre-release builds amd64-only, total runtime dropped from ~17 min (with arm64 emulation) to ~3 min. The arm64 emulation had been acting as an **accidental propagation buffer** between the ``Wait for PyPI simple index`` step and the ``pip install`` inside the Docker build. With it gone, the race surfaced: the wait step checked one PyPI CDN edge that already had 2.0.1b10, pip inside buildx hit a different edge still serving the stale cache → ``No matching distribution``.

## Fix
**Tag-push path** — ``build`` uploads the wheel; ``docker-publish`` downloads it into ``./dist/``; the Dockerfile installs from the wheel via a BuildKit bind-mount. **No PyPI round-trip, no race, ~4 min faster** (no more 4-min poll loop).

**`workflow_dispatch` path** — no artifact (the ``build`` job is skipped on dispatch). ``./dist/`` stays empty, the Dockerfile falls back to ``pip install cogflow==$VERSION`` from PyPI, and the wait step runs. Dispatch targets already-published versions so propagation is rarely an issue.

## Changes

### `.github/workflows/release.yml`
- New ``Prepare wheel directory`` step (``mkdir -p docker_image_variants/latest/dist``) runs on every invocation so the bind mount below always has something to mount.
- New ``Download cogflow wheel from build artifact`` step, gated on ``github.event_name == 'push'``.
- ``Set up Python`` + ``Wait for PyPI simple index`` gated on ``github.event_name == 'workflow_dispatch'`` — tag-push skips both.

### `docker_image_variants/latest/Dockerfile`
- Added ``# syntax=docker/dockerfile:1`` at the top — the BuildKit ``--mount`` feature needs the frontend 1.2+.
- Switched from ``COPY dist/`` to ``RUN --mount=type=bind,source=dist,target=/tmp/cogflow-dist`` so the wheel bytes never land in a committed image layer (``COPY``-then-``rm`` can't reclaim layer space — layers are immutable).
- Wheel match pinned to ``cogflow-${COGFLOW_VERSION}-*.whl`` (was ``cogflow-*.whl``) so a stale wheel from a different version in the build context can't silently install the wrong cogflow.
- Match-count branching:
    - exactly 1 match → install that wheel
    - >1 match → hard fail (ambiguous build context)
    - 0 match → PyPI fallback (workflow_dispatch / local no-artifact path)
- ``find`` (not ``ls`` / ``compgen``) — POSIX-sh-portable, slim base uses ``dash``.

## Verification
- ``yaml.safe_load`` parses the workflow.
- Local ``DOCKER_BUILDKIT=1 docker build --build-arg COGFLOW_VERSION=2.0.1b10 docker_image_variants/latest`` with an empty ``dist/`` uses the PyPI fallback and produces a working image (``RUN python3 -c 'import cogflow'`` succeeds).
- Shell-logic sanity test exercised all four wheel-glob cases (empty, 1 match, >1 ambiguous, stale-different-version) with expected branches.
- Next tag-push will exercise the wheel-install path end-to-end.

## Dev-local caveat
A dev running ``docker build`` locally after ``python -m build`` will see the wheel match if and only if its version equals the ``COGFLOW_VERSION`` build arg — no more silent wrong-version installs.