### PR TITLE
async_serve_llm: offload catalog registration to worker thread

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -707,11 +707,14 @@ class AsyncServingManager:
     ) -> Dict[str, Any]:
         """Async variant of :meth:`ServingManager.serve_llm`.
 
-        The catalog-registration step (MLflow run + POST /models/log) is
-        synchronous — MLflow's tracking client and the catalog HTTP call
-        both block — so we keep it sync and only make the ISVC create
-        async via :meth:`deploy_llm`. That preserves the sync/async
-        behavioural parity with the existing ``deploy_llm`` pair.
+        The catalog-registration step (MLflow run + POST /models/log)
+        uses a blocking MLflow client and blocking ``requests.post``;
+        we offload it to a worker thread via ``asyncio.to_thread`` so
+        the event loop stays free. This matters when the caller is an
+        async HTTP endpoint on the same pod that also serves
+        ``POST /models/log`` — without the thread offload, the sync
+        POST would block the loop waiting for a response the loop can
+        no longer accept, deadlocking until the 15s timeout × 3 retries.
 
         See the sync version's docstring for rules and return shape.
         """
@@ -772,13 +775,18 @@ class AsyncServingManager:
             isvc_name=isvc_name,
         )
 
-        # Step 3: catalog registration — sync, lazy-imported (same
-        # rationale as the sync path). Uses the real submodule path
-        # rather than ``cogflow.models`` (a _LazyLoader attribute that
-        # isn't resolvable via ``from … import …``).
+        # Step 3: catalog registration — the underlying helper is sync
+        # (MLflow client + requests.post), so we run it on a worker
+        # thread to keep the event loop free. Without this, when the
+        # caller is cog-api itself, the POST /models/log callback lands
+        # on the same pod whose loop is blocked here, and we deadlock
+        # until the 15s × 3 retries give up. Lazy import against the
+        # real submodule path (``cogflow.models`` is a _LazyLoader
+        # attribute that isn't resolvable via ``from … import …``).
         from cogflow.core import models as cogflow_models
 
-        run_id = cogflow_models.register_llm_catalog_entry(
+        run_id = await asyncio.to_thread(
+            cogflow_models.register_llm_catalog_entry,
             served_model_name=served_model_name,
             hf_model_id=hf_model_id,
             user_id=user_id,


### PR DESCRIPTION
## Summary
Fixes the sync-in-async deadlock the production cogapi-dev cluster hit when calling `POST /apidev/models-serving` with an HF LLM. The chain:

```
cog-api POST /models-serving          (async FastAPI handler)
  └── await async_serve_llm(...)      (cogflow AsyncServingManager)
       ├── create ISVC                (async; succeeds)
       └── register_llm_catalog_entry (sync: MLflow + requests.post)
            └── POST {API_PATH}/models/log  ← blocks the event loop,
                                               15s × 3 retries, never
                                               accepted because the
                                               same pod's loop is the
                                               one blocked waiting on
                                               this very POST
```

The `async_serve_llm` docstring on this branch *already documents* the sync catalog step — the team was aware but deferred. This PR wraps the sync helper with `asyncio.to_thread(...)` so it runs on a worker thread; the event loop is free to accept the callback on the same pod; no deadlock.

Root cause symptoms the user reported match exactly: ISVC gets created, then timeout, then no catalog entry. That's the "ISVC done, catalog POST times out × 3 retries" shape of this specific deadlock.

### What this PR does NOT do
- Does not convert `register_llm_catalog_entry` itself to async (it still uses `requests.post` + MLflow sync client internally). That's a larger refactor.
- Does not change timeouts or retry counts.
- Does not touch the sync `serve_llm` path.

### Why `asyncio.to_thread` is enough
Python runs sync code on a thread; the event loop can service other tasks meanwhile, including the `/models/log` callback arriving at the same uvicorn worker. `asyncio.to_thread` is the stdlib-blessed way (3.9+) to call a blocking function from async code without blocking the loop.

## Test plan
- [ ] Merge.
- [ ] Release a cogflow version (2.0.1b11 or similar) built from refactor.
- [ ] Re-run the repro: `curl -X POST https://dashboard.cog.hiro-develop.nl/apidev/models-serving -d '{"isvc_name":"qwen25-coder","hf_model_id":"Qwen/Qwen2.5-Coder-7B-Instruct"}'` — confirm the call returns within seconds (not 45s+), and that `model_info` gets a new row.
- [ ] Optional unit test: call `async_serve_llm` from an async test with a mock cog-api that records the callback timing — assert the outer call returns while the callback is concurrent.