### PR TITLE
async_serve_llm: use httpx for /models/log callback

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -707,17 +707,18 @@ class AsyncServingManager:
     ) -> Dict[str, Any]:
         """Async variant of :meth:`ServingManager.serve_llm`.
 
-        The catalog-registration backend POST uses httpx via
+        Catalog registration uses
         :meth:`ModelManager.async_register_llm_catalog_entry`, so the
-        event loop stays free during the ``/models/log`` call. That
-        matters when the caller is an async HTTP endpoint on the same
-        pod that also serves ``/models/log`` — a blocking
-        ``requests.post`` in that position would deadlock (the loop
-        needed to accept the callback is the one blocked waiting on
-        it). The MLflow run-open/close step around it is still sync
-        (no first-party async MLflow), but that only briefly blocks
-        the loop and doesn't self-deadlock because MLflow server is a
-        separate service.
+        event loop stays free during the backend call. That matters
+        when the caller is an async HTTP endpoint that also hosts the
+        catalog endpoint — a blocking call in that position would
+        deadlock (the loop needed to accept the callback is the one
+        blocked waiting on it).
+
+        The tracking-run setup around the backend call is still
+        synchronous, but that only briefly blocks the loop and doesn't
+        self-deadlock because the tracking service is separate from
+        the caller.
 
         See the sync version's docstring for rules and return shape.
         """

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -707,11 +707,17 @@ class AsyncServingManager:
     ) -> Dict[str, Any]:
         """Async variant of :meth:`ServingManager.serve_llm`.
 
-        The catalog-registration step (MLflow run + POST /models/log) is
-        synchronous — MLflow's tracking client and the catalog HTTP call
-        both block — so we keep it sync and only make the ISVC create
-        async via :meth:`deploy_llm`. That preserves the sync/async
-        behavioural parity with the existing ``deploy_llm`` pair.
+        The catalog-registration backend POST uses httpx via
+        :meth:`ModelManager.async_register_llm_catalog_entry`, so the
+        event loop stays free during the ``/models/log`` call. That
+        matters when the caller is an async HTTP endpoint on the same
+        pod that also serves ``/models/log`` — a blocking
+        ``requests.post`` in that position would deadlock (the loop
+        needed to accept the callback is the one blocked waiting on
+        it). The MLflow run-open/close step around it is still sync
+        (no first-party async MLflow), but that only briefly blocks
+        the loop and doesn't self-deadlock because MLflow server is a
+        separate service.
 
         See the sync version's docstring for rules and return shape.
         """
@@ -772,13 +778,18 @@ class AsyncServingManager:
             isvc_name=isvc_name,
         )
 
-        # Step 3: catalog registration — sync, lazy-imported (same
-        # rationale as the sync path). Uses the real submodule path
-        # rather than ``cogflow.models`` (a _LazyLoader attribute that
-        # isn't resolvable via ``from … import …``).
+        # Step 3: catalog registration via the async helper. The
+        # backend POST is httpx-based so the event loop can accept the
+        # /models/log callback while the outer coroutine is awaiting
+        # it — that's what unblocks cog-api -> cogflow -> cog-api
+        # self-calls. MLflow's part stays sync inside the helper; it
+        # doesn't self-deadlock because MLflow server is a separate
+        # service. Lazy-imported against the real submodule path
+        # (``cogflow.models`` is a _LazyLoader attribute that isn't
+        # resolvable via ``from … import …``).
         from cogflow.core import models as cogflow_models
 
-        run_id = cogflow_models.register_llm_catalog_entry(
+        run_id = await cogflow_models.async_register_llm_catalog_entry(
             served_model_name=served_model_name,
             hf_model_id=hf_model_id,
             user_id=user_id,

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -953,48 +953,46 @@ class ModelManager:
         user_id: Optional[str] = None,
         extra_tags: Optional[Dict[str, str]] = None,
     ) -> str:
-        """Create an MLflow run for an LLM and register its catalog entry
-        with the CogFlow backend.
+        """Open a tracking run for an LLM and register its catalog entry.
 
-        HF-sourced LLMs have no MLflow artifact to log; we open a run
-        purely to establish the catalog identity (``model_info.id ==
-        MLflow run_id``, the same invariant every other registration
+        HuggingFace-sourced LLMs have no artifact to log; we open a run
+        purely to establish the catalog identity (the catalog row's id
+        is the run id — the same invariant every other registration
         path respects) and to carry metadata tags.
 
-        Mirrors the ``log_model`` → ``/models/log`` pattern:
+        Steps:
 
-        - Opens and closes an MLflow run; sets ``type=llm``,
-          ``source=huggingface`` (or ``mlflow`` if no HF id is given),
-          ``hf_model_id``, ``mlflow.note.content``, plus any caller-
-          supplied ``extra_tags``.
-        - Best-effort POST to ``{API_PATH}{LOG_MODEL}``: failures are
-          logged as warnings and do **not** raise — matches
-          ``log_model``'s behaviour so a transient CogFlow backend
+        - Open and close a tracking run; set ``type=llm``,
+          ``source=huggingface`` when an HF id is given (a fallback
+          source tag is used otherwise; the exact string is preserved
+          for catalog back-compat), ``hf_model_id`` when present, a
+          human description, plus any caller-supplied ``extra_tags``.
+        - Best-effort POST to the catalog service: failures are logged
+          as warnings and do **not** raise, so a transient backend
           outage can't abort an LLM deploy that otherwise succeeded.
 
         For callers already inside an async coroutine, prefer
-        :meth:`async_register_llm_catalog_entry` — the POST here is
-        blocking ``requests.post`` and will deadlock the event loop if
-        the target URL resolves back to the same uvicorn worker.
+        :meth:`async_register_llm_catalog_entry` — the backend POST
+        here is synchronous and will deadlock the event loop if the
+        target URL resolves back to the same process.
 
         Args:
-            served_model_name: Logical model name (vLLM ``--model_name``).
-                Also becomes the catalog row's ``name``.
-            hf_model_id: HuggingFace Hub id (e.g. ``"Qwen/Qwen2.5-Coder-7B-Instruct"``),
-                or ``None`` for MLflow-backed LLMs.
-            user_id: Override for the ``kubeflow-userid`` / catalog
-                ``register_user_id``. Falls back to
-                ``common.get_current_user()`` (reads the Kubeflow
-                namespace's ``owner`` annotation) which is what notebook
-                consumers want.
-            extra_tags: Additional MLflow tags to set on the run.
+            served_model_name: Logical model name. Also becomes the
+                catalog row's ``name``.
+            hf_model_id: HuggingFace Hub id (for example
+                ``"Qwen/Qwen2.5-Coder-7B-Instruct"``), or ``None`` for
+                checkpoint-backed LLMs.
+            user_id: Override for the catalog entry's owner. Falls back
+                to :func:`common.get_current_user` — which notebook
+                consumers usually want.
+            extra_tags: Additional tags to set on the tracking run.
 
         Returns:
-            The MLflow ``run_id`` — which is also the catalog row's
+            The tracking ``run_id`` — which is also the catalog row's
             primary key.
 
         Raises:
-            CogflowModelError: If opening the MLflow run itself fails.
+            CogflowModelError: If opening the tracking run itself fails.
                 Backend POST failures are *not* raised (warn-only).
         """
         run_id, start_time_ms, description, hf_model_id = (
@@ -1043,20 +1041,18 @@ class ModelManager:
     ) -> str:
         """Async variant of :meth:`register_llm_catalog_entry`.
 
-        Identical semantics, but the backend POST to ``{API_PATH}
-        {LOG_MODEL}`` uses :func:`network.make_async_post_request`
-        (httpx-backed) so the event loop stays free during the call.
-        This is what lets ``cog-api -> cogflow -> cog-api`` self-calls
-        terminate — when the POST target is the same uvicorn worker
-        that's running the outer coroutine, a sync ``requests.post``
-        deadlocks the loop, and the callback can't be accepted.
+        Identical semantics. The backend POST uses an async HTTP
+        client, so the event loop stays free during the call — which
+        is what lets a self-call (the caller being the same service
+        that also hosts the catalog endpoint) terminate. With the
+        synchronous variant, the POST would deadlock the loop and the
+        callback couldn't be accepted.
 
-        MLflow's tracking client is still sync (no first-party async
-        MLflow yet), so the run-open/close step blocks the loop
-        briefly. That's fine in practice: MLflow server is a separate
-        service, so the block never deadlocks — it just delays other
-        coroutines on the same worker for the duration of the run
-        setup/teardown.
+        The tracking-run open/close step is still synchronous (no
+        async tracking client in the ecosystem yet), so it blocks the
+        loop briefly. That's fine in practice — the tracking service
+        is separate from the caller, so this never deadlocks; it just
+        briefly delays other coroutines on the same process.
 
         Return value and exception semantics match the sync variant.
         """

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -823,52 +823,25 @@ class ModelManager:
                 re_raise=True,
             )
 
-    def register_llm_catalog_entry(
+    def _prepare_llm_catalog_run(
         self,
         *,
         served_model_name: str,
-        hf_model_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        extra_tags: Optional[Dict[str, str]] = None,
-    ) -> str:
-        """Create an MLflow run for an LLM and register its catalog entry
-        with the CogFlow backend.
+        hf_model_id: Optional[str],
+        extra_tags: Optional[Dict[str, str]],
+    ):
+        """Open the MLflow run that anchors an LLM catalog entry.
 
-        HF-sourced LLMs have no MLflow artifact to log; we open a run
-        purely to establish the catalog identity (``model_info.id ==
-        MLflow run_id``, the same invariant every other registration
-        path respects) and to carry metadata tags.
-
-        Mirrors the ``log_model`` → ``/models/log`` pattern:
-
-        - Opens and closes an MLflow run; sets ``type=llm``,
-          ``source=huggingface`` (or ``mlflow`` if no HF id is given),
-          ``hf_model_id``, ``mlflow.note.content``, plus any caller-
-          supplied ``extra_tags``.
-        - Best-effort POST to ``{API_PATH}{LOG_MODEL}``: failures are
-          logged as warnings and do **not** raise — matches
-          ``log_model``'s behaviour so a transient CogFlow backend
-          outage can't abort an LLM deploy that otherwise succeeded.
-
-        Args:
-            served_model_name: Logical model name (vLLM ``--model_name``).
-                Also becomes the catalog row's ``name``.
-            hf_model_id: HuggingFace Hub id (e.g. ``"Qwen/Qwen2.5-Coder-7B-Instruct"``),
-                or ``None`` for MLflow-backed LLMs.
-            user_id: Override for the ``kubeflow-userid`` / catalog
-                ``register_user_id``. Falls back to
-                ``common.get_current_user()`` (reads the Kubeflow
-                namespace's ``owner`` annotation) which is what notebook
-                consumers want.
-            extra_tags: Additional MLflow tags to set on the run.
+        Shared step between the sync and async registration paths
+        (:meth:`register_llm_catalog_entry` and
+        :meth:`async_register_llm_catalog_entry`). Everything here is
+        sync — MLflow's tracking client is sync, but its target is a
+        separate service (MLflow server), so it blocks the event loop
+        only briefly and does not self-deadlock.
 
         Returns:
-            The MLflow ``run_id`` — which is also the catalog row's
-            primary key.
-
-        Raises:
-            CogflowModelError: If opening the MLflow run itself fails.
-                Backend POST failures are *not* raised (warn-only).
+            Tuple of ``(run_id, start_time_ms, description,
+            normalized_hf_model_id)``.
         """
         self._warn_if_unhealthy("registering LLM catalog entry")
 
@@ -919,6 +892,7 @@ class ModelManager:
                 served_model_name,
                 hf_model_id,
             )
+            return run_id, start_time_ms, description, hf_model_id
         except Exception as e:
             CogflowErrorHandler.handle_exception(
                 e,
@@ -927,37 +901,186 @@ class ModelManager:
                 re_raise=True,
             )
 
-        # Best-effort POST to the CogFlow backend — same pattern as
-        # log_model. If the catalog service is unreachable we still want
-        # the deploy to proceed; the warning surfaces in logs.
-        try:
-            resolved_user = user_id or common.get_current_user()
-            model_dict: Dict[str, Any] = {
-                "model_id": common.normalize_uuid(run_id),
-                "model_name": served_model_name,
-                # HF-sourced LLMs aren't MLflow-registered, so there's no
-                # registered-model version number to report. Use 0 as
-                # the sentinel for "unknown registry version" — matches
-                # the fallback ``log_model`` already uses for classical
-                # artifacts when ``model_details.get("model_version")``
-                # is missing or falsy.
-                "model_version": 0,
-                "register_date": datetime.fromtimestamp(
-                    start_time_ms / 1000
-                ).isoformat(),
-                "type": "llm",
-                "description": description,
-                "user_id": resolved_user,
-            }
-            if hf_model_id:
-                # Old catalog schemas (<= the ModelLogBase that predates
-                # this field) ignore unknown keys; newer ones will persist
-                # the hf_model_id column. Forward-compatible.
-                model_dict["hf_model_id"] = hf_model_id
+    def _build_llm_catalog_payload(
+        self,
+        *,
+        run_id: str,
+        start_time_ms: int,
+        served_model_name: str,
+        hf_model_id: Optional[str],
+        description: str,
+        user_id: Optional[str],
+    ):
+        """Shape the ``POST /models/log`` payload for an LLM catalog entry.
 
-            url = f"{config.API_PATH}{config.LOG_MODEL}"
-            headers = {"kubeflow-userid": resolved_user}
+        Returns ``(url, model_dict, headers, resolved_user)`` so both
+        the sync and async registration methods can use the same body
+        without duplicating the resolution + dict-shaping logic.
+        """
+        resolved_user = user_id or common.get_current_user()
+        model_dict: Dict[str, Any] = {
+            "model_id": common.normalize_uuid(run_id),
+            "model_name": served_model_name,
+            # HF-sourced LLMs aren't MLflow-registered, so there's no
+            # registered-model version number to report. Use 0 as
+            # the sentinel for "unknown registry version" — matches
+            # the fallback ``log_model`` already uses for classical
+            # artifacts when ``model_details.get("model_version")``
+            # is missing or falsy.
+            "model_version": 0,
+            "register_date": datetime.fromtimestamp(
+                start_time_ms / 1000
+            ).isoformat(),
+            "type": "llm",
+            "description": description,
+            "user_id": resolved_user,
+        }
+        if hf_model_id:
+            # Old catalog schemas (<= the ModelLogBase that predates
+            # this field) ignore unknown keys; newer ones will persist
+            # the hf_model_id column. Forward-compatible.
+            model_dict["hf_model_id"] = hf_model_id
+
+        url = f"{config.API_PATH}{config.LOG_MODEL}"
+        headers = {"kubeflow-userid": resolved_user}
+        return url, model_dict, headers, resolved_user
+
+    def register_llm_catalog_entry(
+        self,
+        *,
+        served_model_name: str,
+        hf_model_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        extra_tags: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create an MLflow run for an LLM and register its catalog entry
+        with the CogFlow backend.
+
+        HF-sourced LLMs have no MLflow artifact to log; we open a run
+        purely to establish the catalog identity (``model_info.id ==
+        MLflow run_id``, the same invariant every other registration
+        path respects) and to carry metadata tags.
+
+        Mirrors the ``log_model`` → ``/models/log`` pattern:
+
+        - Opens and closes an MLflow run; sets ``type=llm``,
+          ``source=huggingface`` (or ``mlflow`` if no HF id is given),
+          ``hf_model_id``, ``mlflow.note.content``, plus any caller-
+          supplied ``extra_tags``.
+        - Best-effort POST to ``{API_PATH}{LOG_MODEL}``: failures are
+          logged as warnings and do **not** raise — matches
+          ``log_model``'s behaviour so a transient CogFlow backend
+          outage can't abort an LLM deploy that otherwise succeeded.
+
+        For callers already inside an async coroutine, prefer
+        :meth:`async_register_llm_catalog_entry` — the POST here is
+        blocking ``requests.post`` and will deadlock the event loop if
+        the target URL resolves back to the same uvicorn worker.
+
+        Args:
+            served_model_name: Logical model name (vLLM ``--model_name``).
+                Also becomes the catalog row's ``name``.
+            hf_model_id: HuggingFace Hub id (e.g. ``"Qwen/Qwen2.5-Coder-7B-Instruct"``),
+                or ``None`` for MLflow-backed LLMs.
+            user_id: Override for the ``kubeflow-userid`` / catalog
+                ``register_user_id``. Falls back to
+                ``common.get_current_user()`` (reads the Kubeflow
+                namespace's ``owner`` annotation) which is what notebook
+                consumers want.
+            extra_tags: Additional MLflow tags to set on the run.
+
+        Returns:
+            The MLflow ``run_id`` — which is also the catalog row's
+            primary key.
+
+        Raises:
+            CogflowModelError: If opening the MLflow run itself fails.
+                Backend POST failures are *not* raised (warn-only).
+        """
+        run_id, start_time_ms, description, hf_model_id = (
+            self._prepare_llm_catalog_run(
+                served_model_name=served_model_name,
+                hf_model_id=hf_model_id,
+                extra_tags=extra_tags,
+            )
+        )
+
+        url, model_dict, headers, _ = self._build_llm_catalog_payload(
+            run_id=run_id,
+            start_time_ms=start_time_ms,
+            served_model_name=served_model_name,
+            hf_model_id=hf_model_id,
+            description=description,
+            user_id=user_id,
+        )
+
+        # Best-effort POST — same pattern as log_model. If the catalog
+        # service is unreachable we still want the deploy to proceed;
+        # the warning surfaces in logs.
+        try:
             network.make_post_request(url=url, data=model_dict, headers=headers)
+            logger.info(
+                "Registered LLM catalog entry via CogFlow backend: %s (run_id=%s)",
+                url,
+                run_id,
+            )
+        except Exception as post_err:
+            logger.warning(
+                "Failed to post LLM catalog entry to CogFlow backend "
+                "(deploy proceeds regardless): %s",
+                str(post_err),
+            )
+
+        return run_id
+
+    async def async_register_llm_catalog_entry(
+        self,
+        *,
+        served_model_name: str,
+        hf_model_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        extra_tags: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Async variant of :meth:`register_llm_catalog_entry`.
+
+        Identical semantics, but the backend POST to ``{API_PATH}
+        {LOG_MODEL}`` uses :func:`network.make_async_post_request`
+        (httpx-backed) so the event loop stays free during the call.
+        This is what lets ``cog-api -> cogflow -> cog-api`` self-calls
+        terminate — when the POST target is the same uvicorn worker
+        that's running the outer coroutine, a sync ``requests.post``
+        deadlocks the loop, and the callback can't be accepted.
+
+        MLflow's tracking client is still sync (no first-party async
+        MLflow yet), so the run-open/close step blocks the loop
+        briefly. That's fine in practice: MLflow server is a separate
+        service, so the block never deadlocks — it just delays other
+        coroutines on the same worker for the duration of the run
+        setup/teardown.
+
+        Return value and exception semantics match the sync variant.
+        """
+        run_id, start_time_ms, description, hf_model_id = (
+            self._prepare_llm_catalog_run(
+                served_model_name=served_model_name,
+                hf_model_id=hf_model_id,
+                extra_tags=extra_tags,
+            )
+        )
+
+        url, model_dict, headers, _ = self._build_llm_catalog_payload(
+            run_id=run_id,
+            start_time_ms=start_time_ms,
+            served_model_name=served_model_name,
+            hf_model_id=hf_model_id,
+            description=description,
+            user_id=user_id,
+        )
+
+        try:
+            await network.make_async_post_request(
+                url=url, data=model_dict, headers=headers
+            )
             logger.info(
                 "Registered LLM catalog entry via CogFlow backend: %s (run_id=%s)",
                 url,

--- a/cogflow/utils/network.py
+++ b/cogflow/utils/network.py
@@ -90,26 +90,21 @@ async def make_async_post_request(
     headers: Optional[dict] = None,
     timeout: int = DEFAULT_TIMEOUT,
 ) -> dict:
-    """Async POST mirror of :func:`make_post_request` (httpx-backed).
+    """Async POST mirror of :func:`make_post_request`.
 
     Exists so callers already inside an ``async def`` can POST without
     blocking the event loop — critical when the target URL resolves back
-    to the same uvicorn worker (``cog-api -> cogflow -> cog-api``). The
-    sync version deadlocks in that loop; this one does not.
+    to the same process serving the caller. The sync version deadlocks
+    in that loop; this one does not.
 
-    Retries 3x with exponential backoff on :class:`httpx.HTTPError` (the
-    ``tenacity`` ``@retry`` decorator works on async functions since
-    tenacity 6.2). Other exception types (e.g. ``json.JSONDecodeError``
-    from a malformed response body) are *not* retried — they're logic
+    Retries up to 3 times with exponential backoff on transport-level
+    HTTP errors. Other exception types (for example, a decoding error
+    on a malformed response body) are *not* retried — they're logic
     errors, not transients.
 
     Note: no ``files=`` support here — async multipart uploads aren't
-    needed today, and adding them means fiddling with ``httpx`` multipart
-    shape, which we can revisit when a caller wants it.
-
-    Body selection mirrors the sync version: ``elif data:`` (so an empty
-    dict ``{}`` is treated the same as no body, matching the sync
-    contract).
+    needed today. Body selection matches the sync version: an empty
+    dict ``{}`` is treated the same as no body.
     """
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:

--- a/cogflow/utils/network.py
+++ b/cogflow/utils/network.py
@@ -6,6 +6,7 @@ validating URIs, handling UUID conversions, and serializing datetime objects.
 """
 
 from typing import List, Optional, Union
+import httpx
 import requests
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -65,6 +66,59 @@ def make_post_request(
 
     except requests.RequestException as exp:
         logger.exception("Error making POST request to %s: %s", url, exp)
+        raise
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+async def make_async_post_request(
+    url: str,
+    data: Optional[dict] = None,
+    params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """Async POST mirror of :func:`make_post_request` (httpx-backed).
+
+    Exists so callers already inside an ``async def`` can POST without
+    blocking the event loop — critical when the target URL resolves back
+    to the same uvicorn worker (``cog-api -> cogflow -> cog-api``). The
+    sync version deadlocks in that loop; this one does not.
+
+    Retries 3x with exponential backoff on :class:`httpx.HTTPError` (the
+    ``tenacity`` ``@retry`` decorator works on async functions since
+    tenacity 6.2).
+
+    Note: no ``files=`` support here — async multipart uploads aren't
+    needed today, and adding them means fiddling with ``httpx`` multipart
+    shape, which we can revisit when a caller wants it.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if data is not None:
+                response = await client.post(
+                    url, json=data, params=params, headers=headers
+                )
+            else:
+                response = await client.post(
+                    url, params=params, headers=headers
+                )
+
+        if response.is_success:
+            logger.info(
+                "POST %s succeeded with status %s", url, response.status_code
+            )
+            return response.json()
+
+        logger.warning(
+            "POST %s failed: %s - %s",
+            url,
+            response.status_code,
+            response.text[:200],
+        )
+        response.raise_for_status()
+
+    except httpx.HTTPError as exp:
+        logger.exception("Error making async POST request to %s: %s", url, exp)
         raise
 
 

--- a/cogflow/utils/network.py
+++ b/cogflow/utils/network.py
@@ -8,7 +8,12 @@ validating URIs, handling UUID conversions, and serializing datetime objects.
 from typing import List, Optional, Union
 import httpx
 import requests
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from .logging import get_logger
 
@@ -69,7 +74,15 @@ def make_post_request(
         raise
 
 
-@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    # Restrict to httpx errors so a JSON decode bug (or similar logic
+    # error in the response body) fails fast instead of being retried
+    # 3x. The sync make_post_request is bare-@retry by historical
+    # accident; we don't change it here to keep the diff scoped.
+    retry=retry_if_exception_type(httpx.HTTPError),
+)
 async def make_async_post_request(
     url: str,
     data: Optional[dict] = None,
@@ -86,15 +99,21 @@ async def make_async_post_request(
 
     Retries 3x with exponential backoff on :class:`httpx.HTTPError` (the
     ``tenacity`` ``@retry`` decorator works on async functions since
-    tenacity 6.2).
+    tenacity 6.2). Other exception types (e.g. ``json.JSONDecodeError``
+    from a malformed response body) are *not* retried — they're logic
+    errors, not transients.
 
     Note: no ``files=`` support here — async multipart uploads aren't
     needed today, and adding them means fiddling with ``httpx`` multipart
     shape, which we can revisit when a caller wants it.
+
+    Body selection mirrors the sync version: ``elif data:`` (so an empty
+    dict ``{}`` is treated the same as no body, matching the sync
+    contract).
     """
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            if data is not None:
+            if data:
                 response = await client.post(
                     url, json=data, params=params, headers=headers
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dependencies = [
     "tenacity",
     "kubernetes",
     "kubernetes_asyncio",
-    "minio>=7.2.0"
+    "minio>=7.2.0",
+    "httpx >=0.25,<1"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pylint==3.2.6
 pycodestyle==2.12.1
 kafka-python==2.0.2
 psutil==5.9.5
+httpx>=0.25,<1

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -82,6 +82,148 @@ def test_make_post_request_failure(mocker):
 
 
 # ============================================================
+# Async POST (httpx-backed mirror of make_post_request)
+# ============================================================
+
+
+class FakeAsyncResponse:
+    """Minimal stand-in for httpx.Response — only the surface
+    make_async_post_request touches.
+    """
+
+    def __init__(
+        self,
+        is_success=True,
+        status_code=200,
+        json_data=None,
+        text="",
+    ):
+        self.is_success = is_success
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        # Mirror what httpx.Response.raise_for_status raises on 4xx/5xx
+        # — make_async_post_request only catches httpx.HTTPError.
+        import httpx as _httpx
+
+        request = _httpx.Request("POST", "http://x")
+        response = _httpx.Response(
+            status_code=self.status_code,
+            request=request,
+        )
+        raise _httpx.HTTPStatusError(
+            f"{self.status_code} error", request=request, response=response
+        )
+
+
+class _FakeAsyncClient:
+    """Lightweight stand-in for httpx.AsyncClient used as an async
+    context manager; tests parametrize what .post() returns or raises.
+    """
+
+    def __init__(self, *, post_return=None, post_raises=None, captured=None):
+        self._post_return = post_return
+        self._post_raises = post_raises
+        self._captured = captured if captured is not None else []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **kwargs):
+        self._captured.append({"url": url, **kwargs})
+        if self._post_raises is not None:
+            raise self._post_raises
+        return self._post_return
+
+
+@pytest.mark.asyncio
+async def test_make_async_post_request_success_with_json(mocker):
+    captured = []
+    response = FakeAsyncResponse(is_success=True, json_data={"a": 1})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            post_return=response, captured=captured
+        ),
+    )
+
+    result = await network.make_async_post_request(
+        url="http://x",
+        data={"x": 1},
+    )
+    assert result == {"a": 1}
+    # Match sync semantics: dict body sent as JSON.
+    assert captured[0]["json"] == {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_make_async_post_request_no_body(mocker):
+    """Empty / None data should send no JSON body — mirrors sync."""
+    captured = []
+    response = FakeAsyncResponse(is_success=True, json_data={})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            post_return=response, captured=captured
+        ),
+    )
+
+    await network.make_async_post_request(url="http://x")
+    assert "json" not in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_make_async_post_request_retries_then_raises(mocker):
+    """4xx response triggers raise_for_status -> httpx.HTTPError ->
+    tenacity retries up to 3x then re-raises as RetryError."""
+    captured = []
+    response = FakeAsyncResponse(is_success=False, status_code=400, text="bad")
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            post_return=response, captured=captured
+        ),
+    )
+
+    with pytest.raises(RetryError):
+        await network.make_async_post_request(url="http://x")
+    assert len(captured) == 3  # stop_after_attempt(3)
+
+
+@pytest.mark.asyncio
+async def test_make_async_post_request_does_not_retry_logic_errors(mocker):
+    """Non-httpx errors (e.g. JSON decode) should NOT be retried —
+    they're logic errors, not transients. Verifies the
+    retry_if_exception_type(httpx.HTTPError) restriction."""
+    captured = []
+
+    class _BoomResponse(FakeAsyncResponse):
+        def json(self):
+            raise ValueError("not json")
+
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            post_return=_BoomResponse(is_success=True),
+            captured=captured,
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        await network.make_async_post_request(url="http://x", data={"a": 1})
+    # Single attempt — no retry on non-httpx errors.
+    assert len(captured) == 1
+
+
+# ============================================================
 # GET
 # ============================================================
 


### PR DESCRIPTION
## Summary
Real async fix for the `cog-api → cogflow → cog-api` deadlock hit in prod by `POST /apidev/models-serving`. When cog-api's async handler awaits `async_serve_llm`, the inner `register_llm_catalog_entry` called a blocking `requests.post` back to `{API_PATH}/models/log` — and since that URL resolves to the same uvicorn worker, the event loop accepting the callback was the one blocked on it. Result: 15s × 3 retries, catalog POST lost, ISVC orphaned.

Supersedes #90 (which used `asyncio.to_thread`). This PR takes the httpx route because the deadlock is specifically the self-call, not MLflow: MLflow server is a separate service, so the brief event-loop block during `mlflow.start_run` et al. doesn't self-deadlock. Only the `/models/log` POST needs real async I/O.

## Changes
- **`pyproject.toml`**: add `httpx >=0.25,<1` as a first-class dependency.
- **`cogflow/utils/network.py`**: new `make_async_post_request` — httpx-backed mirror of the existing sync `make_post_request`, same `@retry(stop_after_attempt(3))` policy (tenacity's decorator supports async since 6.2).
- **`cogflow/core/models.py`**: extract two helpers so sync and async paths don't duplicate logic:
  - `_prepare_llm_catalog_run` — validates `hf_model_id`, opens/closes the MLflow run, sets tags.
  - `_build_llm_catalog_payload` — shapes the `/models/log` POST body.
  - Existing `register_llm_catalog_entry` rebuilt on these helpers; behaviour unchanged.
  - New `async_register_llm_catalog_entry` — same semantics, uses `make_async_post_request` for the backend call.
- **`cogflow/core/async_serving.py`**: `async_serve_llm` awaits `async_register_llm_catalog_entry` instead of the sync method.

## What this PR does NOT do
- Does not touch sync `serve_llm` / `register_llm_catalog_entry` behaviour. Notebook users of the sync API are unaffected.
- Does not convert MLflow's tracking client to async — no first-party async MLflow exists. When one does, `_prepare_llm_catalog_run` is the single place to swap it in.
- Does not change timeout / retry counts on either path.

## Test plan
- [ ] Merge.
- [ ] Release a cogflow version from `refactor` (e.g. `2.0.1b11`) including this commit.
- [ ] Bump Cog-Engine's cogflow pin to that version; rebuild the cog-api image.
- [ ] Re-run the prod repro:
  ```
  curl -X POST 'https://dashboard.cog.hiro-develop.nl/apidev/models-serving' \
    -H 'Content-Type: application/json' \
    -d '{"isvc_name":"qwen25-coder","hf_model_id":"Qwen/Qwen2.5-Coder-7B-Instruct"}'
  ```
  Expect: response within a few seconds (no 45s deadlock), `model_info` row inserted, ISVC created.
- [ ] (Optional) add a unit test that starts a FastAPI app with both `/models-serving` and `/models/log` on the same event loop, calls `async_serve_llm`, asserts the callback is received concurrently with the outer call (run duration ≪ timeout × retries).