### PR TITLE
Default LLM ISVCs to RawDeployment + Recreate strategy

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -622,11 +622,14 @@ class AsyncServingManager:
             max_replicas=max_replicas,
             hf_secret_name=hf_secret_name,
         )
+        predictor_spec, effective_annotations = (
+            sync_manager_cls._apply_raw_deployment_defaults(predictor_spec, annotations)
+        )
 
         metadata = async_client.V1ObjectMeta(
             name=isvc_name,
             namespace=namespace,
-            annotations=annotations or {},
+            annotations=effective_annotations,
         )
         body = {
             "apiVersion": f"{self.GROUP}/{self.VERSION}",

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -862,6 +862,41 @@ class ServingManager:
 
         return predictor
 
+    _DEPLOYMENT_MODE_ANNOTATION = "serving.kserve.io/deploymentMode"
+
+    @staticmethod
+    def _apply_raw_deployment_defaults(
+        predictor: Dict[str, Any],
+        annotations: Optional[Dict[str, str]],
+    ) -> tuple[Dict[str, Any], Dict[str, str]]:
+        """Default LLM ISVCs to RawDeployment + Recreate strategy.
+
+        LLM pods are large, GPU-pinned, and almost always run as a single
+        replica. Knative/Serverless mode requires the new revision to be
+        Ready before the old one is torn down — but on a one-GPU node the
+        new pod can never schedule, so the rollout deadlocks. Defaulting
+        to RawDeployment with ``strategy.type: Recreate`` makes the old
+        pod terminate first, freeing the GPU for the new one. Callers can
+        opt out by passing ``serving.kserve.io/deploymentMode`` themselves
+        in ``annotations`` — caller wins.
+
+        Returns the (possibly augmented) predictor and the merged
+        annotations dict that should land on ``metadata.annotations``.
+        """
+        effective_annotations: Dict[str, Any] = {
+            ServingManager._DEPLOYMENT_MODE_ANNOTATION: "RawDeployment",
+            **(annotations or {}),
+        }
+        # ``deploymentStrategy`` is rejected by the KServe webhook for
+        # Serverless ISVCs, so only inject it when the resolved mode is
+        # RawDeployment.
+        if (
+            effective_annotations.get(ServingManager._DEPLOYMENT_MODE_ANNOTATION)
+            == "RawDeployment"
+        ):
+            predictor = {**predictor, "deploymentStrategy": {"type": "Recreate"}}
+        return predictor, effective_annotations
+
     def deploy_llm(
         self,
         *,
@@ -942,12 +977,15 @@ class ServingManager:
             max_replicas=max_replicas,
             hf_secret_name=hf_secret_name,
         )
+        predictor_spec, effective_annotations = (
+            ServingManager._apply_raw_deployment_defaults(predictor_spec, annotations)
+        )
 
         try:
             metadata = client.V1ObjectMeta(
                 name=isvc_name,
                 namespace=namespace,
-                annotations=annotations or {},
+                annotations=effective_annotations,
             )
             body = {
                 "apiVersion": f"{self.GROUP}/{self.VERSION}",


### PR DESCRIPTION
## Summary

LLM pods are large, GPU-pinned, and almost always run as a single replica. KServe's default Knative/Serverless mode requires the new revision to reach Ready before the old one is torn down — but on a one-GPU node the new pod can never schedule (the GPU is held by the old pod), so the rollout deadlocks. Defaulting to RawDeployment with `strategy.type: Recreate` makes the old pod terminate first, freeing the GPU for the new one.

### What changed

- **`ServingManager._apply_raw_deployment_defaults`** (sync) — new static helper. Returns the (possibly augmented) predictor and the merged annotations dict. Caller-supplied `serving.kserve.io/deploymentMode` wins, so opting back into Serverless is a single annotation away.
- `deploymentStrategy` is rejected by the KServe webhook for Serverless ISVCs, so it's only injected when the resolved deployment mode is RawDeployment.
- Wired into both `ServingManager.deploy_llm` (sync) and `AsyncServingManager._deploy_llm` (async) so the two surfaces stay consistent.

### Behavior change

- New default for LLM ISVCs (only the LLM path; classical model serving unchanged): `metadata.annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"` plus `spec.predictor.deploymentStrategy = {type: Recreate}`.
- Existing callers passing the deployment-mode annotation explicitly are unaffected — the merge resolves with the caller wins.

## Test plan

- [ ] CI green
- [ ] Local smoke against a real KServe cluster:
  - Deploy a fresh LLM ISVC via `serve_llm(...)` → annotations include `serving.kserve.io/deploymentMode: RawDeployment`; `spec.predictor.deploymentStrategy.type == "Recreate"`
  - Re-deploy the same ISVC with a different `max_model_len` → old pod terminates first, new pod schedules on the freed GPU
  - Deploy with caller-supplied `annotations={"serving.kserve.io/deploymentMode": "Serverless"}` → resolves Serverless, `deploymentStrategy` is NOT injected (would be webhook-rejected)
  - Async path (`async_serve_llm`) shows the same annotations / predictor shape as sync
- [ ] Copilot review loop until threads clear