### PR TITLE
network: async mirrors for GET/DELETE/PATCH/raw/health

### DIFF
--- a/cogflow/core/datasets.py
+++ b/cogflow/core/datasets.py
@@ -346,6 +346,145 @@ class DatasetManager:
         logger.info("Dataset file deleted successfully (dataset_id=%s)", dataset_id)
         return True
 
+    async def async_get_dataset(self, dataset_id: Union[str, UUID]):
+        """Async mirror of :meth:`get_dataset`.
+
+        Same UUID validation, request shape, and response handling as
+        the sync variant. Uses :func:`network.make_async_get_request`
+        so a caller already inside an ``async def`` doesn't block the
+        event loop on the round-trip.
+        """
+        try:
+            dataset_id = common.normalize_uuid(dataset_id)
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Invalid dataset_id '{dataset_id}'",
+                raise_as=CogflowValidationError,
+                re_raise=True,
+            )
+
+        headers = {"kubeflow-userid": common.get_current_user()}
+
+        resp = None
+        try:
+            logger.info("Fetching dataset metadata for ID=%s", dataset_id)
+
+            resp = await network.make_async_get_request(
+                url=self.base_url,
+                path_params=dataset_id,
+                headers=headers,
+            )
+
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Failed to fetch dataset '{dataset_id}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+        if not isinstance(resp, dict):
+            raise CogflowArtifactError(
+                f"Unexpected API response format for dataset '{dataset_id}': {type(resp)}"
+            )
+
+        if "data" not in resp:
+            raise CogflowArtifactError(
+                f"Dataset API returned no 'data' field for dataset '{dataset_id}'"
+            )
+
+        data = resp.get("data")
+
+        if not data:
+            CogflowErrorHandler.log_and_raise(
+                f"Dataset '{dataset_id}' not found or returned empty data",
+                raise_as=CogflowDatasetError,
+            )
+
+        logger.info("Successfully retrieved dataset '%s'", dataset_id)
+        return data
+
+    async def async_get_prometheus_dataset(self, dataset_id: Union[str, UUID]):
+        """Async mirror of :meth:`get_prometheus_dataset`."""
+        try:
+            dataset_id = common.normalize_uuid(dataset_id)
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Invalid dataset_id '{dataset_id}'",
+                raise_as=CogflowArtifactError,
+                re_raise=True,
+            )
+
+        url = f"{self.base_url}/{dataset_id}/prometheus"
+        headers = {"kubeflow-userid": common.get_current_user()}
+
+        resp = None
+        try:
+            logger.info("Fetching Prometheus dataset for ID=%s", dataset_id)
+
+            resp = await network.make_async_get_request(
+                url=url,
+                headers=headers,
+            )
+
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Failed to fetch Prometheus dataset '{dataset_id}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+        if not isinstance(resp, dict):
+            raise CogflowArtifactError(
+                f"Unexpected API response format for Prometheus dataset '{dataset_id}'"
+            )
+
+        if "data" not in resp:
+            raise CogflowArtifactError(
+                f"Prometheus dataset API returned no 'data' field for dataset '{dataset_id}'"
+            )
+
+        data = resp.get("data")
+
+        if not data:
+            CogflowErrorHandler.log_and_raise(
+                f"Prometheus dataset '{dataset_id}' returned empty 'data'",
+                raise_as=CogflowDatasetError,
+            )
+        logger.info("Successfully retrieved Prometheus dataset '%s'", dataset_id)
+        return data
+
+    async def async_delete_dataset(self, dataset_id: Union[str, UUID]) -> bool:
+        """Async mirror of :meth:`delete_dataset`."""
+        try:
+            dataset_id = common.normalize_uuid(dataset_id)
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Invalid dataset_id '{dataset_id}'",
+                raise_as=CogflowValidationError,
+                re_raise=True,
+            )
+
+        url = f"{self.base_url}/{dataset_id}/file"
+        headers = {"kubeflow-userid": common.get_current_user()}
+
+        try:
+            await network.make_async_delete_request(url=url, headers=headers)
+        except Exception as e:
+            CogflowErrorHandler.handle_exception(
+                e,
+                context=f"Failed to delete dataset file '{dataset_id}'",
+                raise_as=CogflowConnectionError,
+                re_raise=True,
+            )
+
+        logger.info("Dataset file deleted successfully (dataset_id=%s)", dataset_id)
+        return True
+
     def download_dataset(
         self,
         dataset_id: Union[str, UUID],

--- a/cogflow/core/pipelines/components.py
+++ b/cogflow/core/pipelines/components.py
@@ -19,6 +19,7 @@ Depends ONLY on:
 
 from __future__ import annotations
 
+import asyncio
 import io
 from typing import Mapping, List, Optional
 from uuid import UUID
@@ -33,6 +34,10 @@ from ...utils.network import (
     make_post_request,
     make_patch_request,
     make_get_request_raw,
+    make_async_get_request,
+    make_async_post_request,
+    make_async_patch_request,
+    make_async_get_request_raw,
 )
 from ...utils.exceptions import (
     CogflowErrorHandler,
@@ -237,6 +242,111 @@ def register_component(
     try:
         url = f"{endpoint}?creator={creator}" if creator else endpoint
         resp = make_post_request(url, data=payload, headers=headers, timeout=time_out)
+        return resp.get("data")
+    except Exception as exc:
+        raise CogflowComponentRegistryError(
+            f"Failed creating component '{component_name}'"
+        ) from exc
+
+
+# ============================================================================
+
+
+async def async_register_component(
+    *,
+    name: str = None,
+    yaml_path: str = None,
+    yaml_data: str = None,
+    bucket_name: str = None,
+    category: str = None,
+    creator: str = None,
+    overwrite: bool = False,
+):
+    """Async mirror of :func:`register_component`.
+
+    Same return value, validation, and registry semantics. The
+    registry GET / POST / PATCH calls go through the async network
+    helpers so the event loop stays free during the round-trip. The
+    synchronous prelude — YAML parse + MinIO upload — runs inside
+    ``asyncio.to_thread`` because the MinIO client is sync; that part
+    still consumes a worker thread but doesn't block the event loop.
+    """
+    creator = creator or common.get_current_user()
+    bucket_name = bucket_name or config.COMPONENTS_BUCKET_NAME
+    time_out = config.TIME_OUT
+
+    parsed = parse_component_yaml(yaml_path=yaml_path, yaml_data=yaml_data)
+    component_name = name or parsed["name"]
+    if not component_name:
+        raise CogflowComponentValidationError("Component name missing in YAML.")
+
+    try:
+        if yaml_data:
+            data_bytes = yaml_data.encode("utf-8")
+        else:
+            with open(yaml_path, "rb") as f:
+                data_bytes = f.read()
+    except Exception as exc:
+        raise CogflowComponentValidationError("Failed reading YAML.") from exc
+
+    object_name = f"{component_name.replace(' ', '_')}.yaml"
+
+    # MinIO client is sync — offload the upload to a worker thread.
+    s3_url = await asyncio.to_thread(
+        _upload_yaml_to_minio,
+        bucket_name=bucket_name,
+        object_name=object_name,
+        data_bytes=data_bytes,
+        overwrite=True,
+    )
+
+    base_api = config.API_PATH.rstrip("/")
+    comp = config.COMPONENTS.lstrip("/")
+    endpoint = f"{base_api}/{comp}"
+
+    payload = {
+        "name": component_name,
+        "input_path": parsed["inputs"],
+        "output_path": parsed["outputs"],
+        "component_file": s3_url,
+        "category": category,
+    }
+    headers = {"Content-Type": "application/json"}
+
+    check_url = f"{endpoint}?name={component_name}"
+    try:
+        resp = await make_async_get_request_raw(check_url, timeout=time_out)
+        if resp is None:
+            existing = []
+        else:
+            existing = resp.get("data", [])
+    except Exception:
+        raise CogflowComponentRegistryError(
+            f"Failed checking registry for '{component_name}'"
+        )
+
+    if existing:
+        if not overwrite:
+            raise CogflowComponentValidationError(
+                f"Component '{component_name}' already exists; overwrite=False."
+            )
+
+        try:
+            url = f"{endpoint}?creator={creator}" if creator else endpoint
+            resp = await make_async_patch_request(
+                url, data=payload, headers=headers, timeout=time_out
+            )
+            return resp.get("data")
+        except Exception as exc:
+            raise CogflowComponentRegistryError(
+                f"Failed updating component '{component_name}'"
+            ) from exc
+
+    try:
+        url = f"{endpoint}?creator={creator}" if creator else endpoint
+        resp = await make_async_post_request(
+            url, data=payload, headers=headers, timeout=time_out
+        )
         return resp.get("data")
     except Exception as exc:
         raise CogflowComponentRegistryError(

--- a/cogflow/core/pipelines/components.py
+++ b/cogflow/core/pipelines/components.py
@@ -34,7 +34,6 @@ from ...utils.network import (
     make_post_request,
     make_patch_request,
     make_get_request_raw,
-    make_async_get_request,
     make_async_post_request,
     make_async_patch_request,
     make_async_get_request_raw,
@@ -267,9 +266,10 @@ async def async_register_component(
     Same return value, validation, and registry semantics. The
     registry GET / POST / PATCH calls go through the async network
     helpers so the event loop stays free during the round-trip. The
-    synchronous prelude — YAML parse + MinIO upload — runs inside
-    ``asyncio.to_thread`` because the MinIO client is sync; that part
-    still consumes a worker thread but doesn't block the event loop.
+    MinIO upload step runs sync inside ``asyncio.to_thread`` because
+    the MinIO client has no async API; the rest of the sync prelude
+    (YAML parse + reading bytes from disk when ``yaml_path`` is given)
+    stays on the event loop because it's CPU-cheap and short.
     """
     creator = creator or common.get_current_user()
     bucket_name = bucket_name or config.COMPONENTS_BUCKET_NAME
@@ -316,14 +316,21 @@ async def async_register_component(
     check_url = f"{endpoint}?name={component_name}"
     try:
         resp = await make_async_get_request_raw(check_url, timeout=time_out)
-        if resp is None:
-            existing = []
-        else:
-            existing = resp.get("data", [])
     except Exception:
         raise CogflowComponentRegistryError(
             f"Failed checking registry for '{component_name}'"
         )
+
+    # make_async_get_request_raw returns None on transport failure;
+    # don't silently treat that as "no existing component", or an
+    # intermittent registry outage could re-create a record that
+    # already exists when overwrite=True.
+    if resp is None:
+        raise CogflowComponentRegistryError(
+            f"Failed checking registry for '{component_name}'"
+        )
+
+    existing = resp.get("data", [])
 
     if existing:
         if not overwrite:

--- a/cogflow/utils/network.py
+++ b/cogflow/utils/network.py
@@ -3,6 +3,18 @@ CogFlow Network Utilities
 
 Provides standardized helpers for making HTTP/HTTPS API requests,
 validating URIs, handling UUID conversions, and serializing datetime objects.
+
+Two parallel surfaces live here:
+
+- The original sync helpers (``make_post_request``, ``make_get_request``,
+  ``make_delete_request``, ``make_patch_request``, ``make_get_request_stream``,
+  ``make_get_request_raw``, ``make_health_check_request``) use ``requests``.
+- The ``make_async_*`` variants use ``httpx.AsyncClient`` so callers
+  already inside an ``async def`` can issue the same requests without
+  blocking the event loop. Tenacity's ``@retry`` decorator works for
+  both sync and async functions — the async variants are retried
+  asynchronously, with the same backoff parameters as their sync
+  counterparts.
 """
 
 from typing import List, Optional, Union
@@ -113,14 +125,10 @@ async def make_async_post_request(
                     url, json=data, params=params, headers=headers
                 )
             else:
-                response = await client.post(
-                    url, params=params, headers=headers
-                )
+                response = await client.post(url, params=params, headers=headers)
 
         if response.is_success:
-            logger.info(
-                "POST %s succeeded with status %s", url, response.status_code
-            )
+            logger.info("POST %s succeeded with status %s", url, response.status_code)
             return response.json()
 
         logger.warning(
@@ -134,6 +142,226 @@ async def make_async_post_request(
     except httpx.HTTPError as exp:
         logger.exception("Error making async POST request to %s: %s", url, exp)
         raise
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(httpx.HTTPError),
+)
+async def make_async_get_request(
+    url: str,
+    path_params: Optional[str] = None,
+    query_params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    paginate: bool = False,
+) -> Union[dict, List[dict]]:
+    """Async GET mirror of :func:`make_get_request`.
+
+    Same pagination semantics as the sync version. Retries on
+    httpx-level transport errors only (decode bugs in the response
+    body fall through to the caller).
+    """
+    full_url = (
+        f"{url.rstrip('/')}/{str(path_params).lstrip('/')}" if path_params else url
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if not paginate:
+                response = await client.get(
+                    full_url, params=query_params, headers=headers
+                )
+                if response.is_success:
+                    logger.info(
+                        "GET %s succeeded with status %s",
+                        full_url,
+                        response.status_code,
+                    )
+                    return response.json()
+
+                logger.warning(
+                    "GET %s failed: %s - %s",
+                    full_url,
+                    response.status_code,
+                    response.text[:200],
+                )
+                # Match sync version: pagination falls through on a
+                # non-OK first page so the caller can still observe
+                # whatever partial pages do come back.
+
+            # Pagination mode
+            all_data: List[dict] = []
+            page = 1
+            limit = (query_params or {}).get("limit", 10)
+
+            while True:
+                page_params = dict(query_params or {})
+                page_params.update({"page": page, "limit": limit})
+
+                response = await client.get(
+                    full_url, params=page_params, headers=headers
+                )
+                if not response.is_success:
+                    logger.warning("GET pagination failed on page %s", page)
+                    break
+
+                payload = response.json()
+                data = payload.get("data", [])
+                all_data.extend(data)
+
+                pagination = payload.get("pagination", {})
+                total = pagination.get("total_items", len(data))
+
+                if len(all_data) >= total:
+                    break
+                page += 1
+
+        logger.info("GET %s completed with %s total items.", full_url, len(all_data))
+        return all_data
+
+    except httpx.HTTPError as exp:
+        logger.exception("Error making async GET request to %s: %s", url, exp)
+        raise
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(httpx.HTTPError),
+)
+async def make_async_delete_request(
+    url: str,
+    path_params: Optional[str] = None,
+    query_params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> bool:
+    """Async DELETE mirror of :func:`make_delete_request`.
+
+    Success is determined solely by HTTP status; 204 No Content is
+    treated as success.
+    """
+    full_url = f"{url.rstrip('/')}/{path_params}" if path_params else url
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.delete(
+                full_url, params=query_params, headers=headers
+            )
+
+        if response.status_code in (200, 202, 204):
+            logger.info(
+                "DELETE %s succeeded with status %s",
+                full_url,
+                response.status_code,
+            )
+            return True
+
+        logger.warning(
+            "DELETE %s failed: %s - %s",
+            full_url,
+            response.status_code,
+            response.text[:200],
+        )
+        response.raise_for_status()
+        return False
+
+    except httpx.HTTPError as exp:
+        logger.exception("Error making async DELETE request to %s: %s", url, exp)
+        raise
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(httpx.HTTPError),
+)
+async def make_async_patch_request(
+    url: str,
+    data: Optional[dict] = None,
+    params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """Async PATCH mirror of :func:`make_patch_request`."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if data:
+                response = await client.patch(
+                    url, json=data, params=params, headers=headers
+                )
+            else:
+                response = await client.patch(url, params=params, headers=headers)
+
+        if response.is_success:
+            logger.info("PATCH %s succeeded with status %s", url, response.status_code)
+            return response.json()
+
+        logger.warning(
+            "PATCH %s failed: %s - %s",
+            url,
+            response.status_code,
+            response.text[:200],
+        )
+        response.raise_for_status()
+
+    except httpx.HTTPError as exp:
+        logger.exception("Error making async PATCH request to %s: %s", url, exp)
+        raise
+
+
+async def make_async_get_request_raw(
+    url: str,
+    params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> Optional[dict]:
+    """Async raw-GET mirror of :func:`make_get_request_raw`.
+
+    Returns the parsed JSON body or ``None`` on transport failure —
+    same behaviour as the sync version (which returns the parsed JSON
+    on success and ``None`` on transport failure, despite the
+    ``Response`` annotation in the original docstring).
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, params=params, headers=headers)
+        return response.json()
+    except httpx.HTTPError as exp:
+        logger.exception("Async raw GET failed for %s: %s", url, exp)
+        return None
+
+
+async def make_async_health_check_request(
+    url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    headers: Optional[dict] = None,
+) -> bool:
+    """Async health-check mirror of :func:`make_health_check_request`.
+
+    No JSON expected. Treats any 2xx response as success. Doesn't
+    retry — health checks are meant to fail fast.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=headers)
+
+        if 200 <= response.status_code < 300:
+            logger.info("Health check to %s succeeded (%s).", url, response.status_code)
+            return True
+
+        logger.warning(
+            "Health check to %s failed (%s): %s",
+            url,
+            response.status_code,
+            response.text[:200],
+        )
+        return False
+
+    except httpx.HTTPError as exp:
+        logger.exception("Async health check request to %s failed: %s", url, exp)
+        return False
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))

--- a/cogflow/utils/network.py
+++ b/cogflow/utils/network.py
@@ -119,7 +119,7 @@ async def make_async_post_request(
     dict ``{}`` is treated the same as no body.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             if data:
                 response = await client.post(
                     url, json=data, params=params, headers=headers
@@ -127,7 +127,7 @@ async def make_async_post_request(
             else:
                 response = await client.post(url, params=params, headers=headers)
 
-        if response.is_success:
+        if not response.is_error:
             logger.info("POST %s succeeded with status %s", url, response.status_code)
             return response.json()
 
@@ -168,12 +168,12 @@ async def make_async_get_request(
     )
 
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             if not paginate:
                 response = await client.get(
                     full_url, params=query_params, headers=headers
                 )
-                if response.is_success:
+                if not response.is_error:
                     logger.info(
                         "GET %s succeeded with status %s",
                         full_url,
@@ -203,7 +203,7 @@ async def make_async_get_request(
                 response = await client.get(
                     full_url, params=page_params, headers=headers
                 )
-                if not response.is_success:
+                if response.is_error:
                     logger.warning("GET pagination failed on page %s", page)
                     break
 
@@ -245,7 +245,7 @@ async def make_async_delete_request(
     """
     full_url = f"{url.rstrip('/')}/{path_params}" if path_params else url
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             response = await client.delete(
                 full_url, params=query_params, headers=headers
             )
@@ -286,7 +286,7 @@ async def make_async_patch_request(
 ) -> dict:
     """Async PATCH mirror of :func:`make_patch_request`."""
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             if data:
                 response = await client.patch(
                     url, json=data, params=params, headers=headers
@@ -294,7 +294,7 @@ async def make_async_patch_request(
             else:
                 response = await client.patch(url, params=params, headers=headers)
 
-        if response.is_success:
+        if not response.is_error:
             logger.info("PATCH %s succeeded with status %s", url, response.status_code)
             return response.json()
 
@@ -325,7 +325,7 @@ async def make_async_get_request_raw(
     ``Response`` annotation in the original docstring).
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             response = await client.get(url, params=params, headers=headers)
         return response.json()
     except httpx.HTTPError as exp:
@@ -344,7 +344,7 @@ async def make_async_health_check_request(
     retry — health checks are meant to fail fast.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             response = await client.get(url, headers=headers)
 
         if 200 <= response.status_code < 300:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -226,3 +226,101 @@ def test_download_yaml_from_minio_failure(mocker):
 
     with pytest.raises(CogflowComponentStorageError):
         download_yaml_from_minio("bucket", "file.yaml", "/tmp/file.yaml")
+
+
+# ============================================================
+# async_register_component
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_async_register_component_create(mocker):
+    mocker.patch(
+        "cogflow.core.pipelines.components.parse_component_yaml",
+        return_value={"name": "comp", "inputs": [], "outputs": []},
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components._upload_yaml_to_minio",
+        return_value="s3://bucket/comp.yaml",
+    )
+
+    async def fake_get_raw(*_a, **_kw):
+        return {"data": []}
+
+    async def fake_post(*_a, **_kw):
+        return {"data": {"id": "123"}}
+
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_get_request_raw",
+        side_effect=fake_get_raw,
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_post_request",
+        side_effect=fake_post,
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data=b"yaml"))
+
+    from cogflow.core.pipelines.components import async_register_component
+
+    result = await async_register_component(yaml_data="name: comp")
+    assert result["id"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_async_register_component_existing_no_overwrite(mocker):
+    mocker.patch(
+        "cogflow.core.pipelines.components.parse_component_yaml",
+        return_value={"name": "comp", "inputs": [], "outputs": []},
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components._upload_yaml_to_minio",
+        return_value="s3://bucket/comp.yaml",
+    )
+
+    async def fake_get_raw(*_a, **_kw):
+        return {"data": [{"id": "existing"}]}
+
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_get_request_raw",
+        side_effect=fake_get_raw,
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data=b"yaml"))
+
+    from cogflow.core.pipelines.components import async_register_component
+
+    with pytest.raises(CogflowComponentValidationError):
+        await async_register_component(yaml_data="name: comp", overwrite=False)
+
+
+@pytest.mark.asyncio
+async def test_async_register_component_existing_with_overwrite(mocker):
+    """Overwrite=True path should PATCH and return the registry's data."""
+    mocker.patch(
+        "cogflow.core.pipelines.components.parse_component_yaml",
+        return_value={"name": "comp", "inputs": [], "outputs": []},
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components._upload_yaml_to_minio",
+        return_value="s3://bucket/comp.yaml",
+    )
+
+    async def fake_get_raw(*_a, **_kw):
+        return {"data": [{"id": "existing"}]}
+
+    async def fake_patch(*_a, **_kw):
+        return {"data": {"id": "existing", "updated": True}}
+
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_get_request_raw",
+        side_effect=fake_get_raw,
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_patch_request",
+        side_effect=fake_patch,
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data=b"yaml"))
+
+    from cogflow.core.pipelines.components import async_register_component
+
+    result = await async_register_component(yaml_data="name: comp", overwrite=True)
+    assert result["updated"] is True

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -324,3 +324,31 @@ async def test_async_register_component_existing_with_overwrite(mocker):
 
     result = await async_register_component(yaml_data="name: comp", overwrite=True)
     assert result["updated"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_register_component_registry_unreachable(mocker):
+    """When the registry check returns None (transport failure) we must
+    NOT silently treat it as 'no existing component'; raise instead."""
+    mocker.patch(
+        "cogflow.core.pipelines.components.parse_component_yaml",
+        return_value={"name": "comp", "inputs": [], "outputs": []},
+    )
+    mocker.patch(
+        "cogflow.core.pipelines.components._upload_yaml_to_minio",
+        return_value="s3://bucket/comp.yaml",
+    )
+
+    async def fake_get_raw(*_a, **_kw):
+        return None
+
+    mocker.patch(
+        "cogflow.core.pipelines.components.make_async_get_request_raw",
+        side_effect=fake_get_raw,
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data=b"yaml"))
+
+    from cogflow.core.pipelines.components import async_register_component
+
+    with pytest.raises(CogflowComponentRegistryError):
+        await async_register_component(yaml_data="name: comp")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -208,3 +208,79 @@ def test_download_dataset_network_error(mocker, manager):
 
     with pytest.raises(CogflowConnectionError):
         manager.download_dataset("uuid")
+
+
+# ============================================================
+# Async dataset operations
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_async_get_dataset_success(mocker, manager):
+    mocker.patch("cogflow.utils.common.normalize_uuid", return_value="uuid")
+    mocker.patch("cogflow.utils.common.get_current_user", return_value="user")
+
+    async def fake(*_a, **_kw):
+        return {"data": {"id": "uuid"}}
+
+    mocker.patch("cogflow.utils.network.make_async_get_request", side_effect=fake)
+    result = await manager.async_get_dataset("uuid")
+    assert result["id"] == "uuid"
+
+
+@pytest.mark.asyncio
+async def test_async_get_dataset_network_error(mocker, manager):
+    mocker.patch("cogflow.utils.common.normalize_uuid", return_value="uuid")
+
+    async def fake(*_a, **_kw):
+        raise Exception("network")
+
+    mocker.patch("cogflow.utils.network.make_async_get_request", side_effect=fake)
+    with pytest.raises(CogflowConnectionError):
+        await manager.async_get_dataset("uuid")
+
+
+@pytest.mark.asyncio
+async def test_async_get_prometheus_dataset_success(mocker, manager):
+    mocker.patch("cogflow.utils.common.normalize_uuid", return_value="uuid")
+    mocker.patch("cogflow.utils.common.get_current_user", return_value="user")
+
+    async def fake(*_a, **_kw):
+        return {"data": {"metric": 42}}
+
+    mocker.patch("cogflow.utils.network.make_async_get_request", side_effect=fake)
+    result = await manager.async_get_prometheus_dataset("uuid")
+    assert result["metric"] == 42
+
+
+@pytest.mark.asyncio
+async def test_async_get_prometheus_dataset_empty_data(mocker, manager):
+    mocker.patch("cogflow.utils.common.normalize_uuid", return_value="uuid")
+
+    async def fake(*_a, **_kw):
+        return {"data": None}
+
+    mocker.patch("cogflow.utils.network.make_async_get_request", side_effect=fake)
+    with pytest.raises(CogflowDatasetError):
+        await manager.async_get_prometheus_dataset("uuid")
+
+
+@pytest.mark.asyncio
+async def test_async_delete_dataset_success(mocker, manager):
+    mocker.patch("cogflow.utils.common.normalize_uuid", return_value="uuid")
+
+    async def fake(*_a, **_kw):
+        return True
+
+    mocker.patch("cogflow.utils.network.make_async_delete_request", side_effect=fake)
+    assert await manager.async_delete_dataset("uuid") is True
+
+
+@pytest.mark.asyncio
+async def test_async_delete_dataset_invalid_uuid(mocker, manager):
+    mocker.patch(
+        "cogflow.utils.common.normalize_uuid",
+        side_effect=ValueError("bad uuid"),
+    )
+    with pytest.raises(CogflowValidationError):
+        await manager.async_delete_dataset("bad")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -123,12 +123,34 @@ class FakeAsyncResponse:
 
 class _FakeAsyncClient:
     """Lightweight stand-in for httpx.AsyncClient used as an async
-    context manager; tests parametrize what .post() returns or raises.
+    context manager. Each verb (.post/.get/.delete/.patch) takes either
+    a return value or an exception to raise; ``.responses`` lets a test
+    return different responses per successive call.
     """
 
-    def __init__(self, *, post_return=None, post_raises=None, captured=None):
+    def __init__(
+        self,
+        *,
+        post_return=None,
+        post_raises=None,
+        get_return=None,
+        get_responses=None,
+        get_raises=None,
+        delete_return=None,
+        delete_raises=None,
+        patch_return=None,
+        patch_raises=None,
+        captured=None,
+    ):
         self._post_return = post_return
         self._post_raises = post_raises
+        self._get_return = get_return
+        self._get_responses = list(get_responses) if get_responses else None
+        self._get_raises = get_raises
+        self._delete_return = delete_return
+        self._delete_raises = delete_raises
+        self._patch_return = patch_return
+        self._patch_raises = patch_raises
         self._captured = captured if captured is not None else []
 
     async def __aenter__(self):
@@ -138,10 +160,30 @@ class _FakeAsyncClient:
         return False
 
     async def post(self, url, **kwargs):
-        self._captured.append({"url": url, **kwargs})
+        self._captured.append({"verb": "post", "url": url, **kwargs})
         if self._post_raises is not None:
             raise self._post_raises
         return self._post_return
+
+    async def get(self, url, **kwargs):
+        self._captured.append({"verb": "get", "url": url, **kwargs})
+        if self._get_raises is not None:
+            raise self._get_raises
+        if self._get_responses:
+            return self._get_responses.pop(0)
+        return self._get_return
+
+    async def delete(self, url, **kwargs):
+        self._captured.append({"verb": "delete", "url": url, **kwargs})
+        if self._delete_raises is not None:
+            raise self._delete_raises
+        return self._delete_return
+
+    async def patch(self, url, **kwargs):
+        self._captured.append({"verb": "patch", "url": url, **kwargs})
+        if self._patch_raises is not None:
+            raise self._patch_raises
+        return self._patch_return
 
 
 @pytest.mark.asyncio
@@ -429,3 +471,177 @@ def test_make_health_check_request_exception(mocker):
     )
 
     assert network.make_health_check_request("http://x") is False
+
+
+# ============================================================
+# Async GET / DELETE / PATCH / raw / health (httpx-backed mirrors)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_make_async_get_request_success(mocker):
+    captured = []
+    response = FakeAsyncResponse(is_success=True, json_data={"v": 1})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            get_return=response, captured=captured
+        ),
+    )
+    assert await network.make_async_get_request("http://x") == {"v": 1}
+    assert captured[0]["verb"] == "get"
+
+
+@pytest.mark.asyncio
+async def test_make_async_get_request_with_path_params(mocker):
+    captured = []
+    response = FakeAsyncResponse(is_success=True, json_data={})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            get_return=response, captured=captured
+        ),
+    )
+    await network.make_async_get_request("http://x", path_params="123")
+    assert captured[0]["url"] == "http://x/123"
+
+
+@pytest.mark.asyncio
+async def test_make_async_get_request_pagination(mocker):
+    """Two pages, second is the final — total_items=2, two items each, stops."""
+    captured = []
+    page1 = FakeAsyncResponse(
+        is_success=True,
+        json_data={
+            "data": [{"id": 1}, {"id": 2}],
+            "pagination": {"total_items": 4},
+        },
+    )
+    page2 = FakeAsyncResponse(
+        is_success=True,
+        json_data={
+            "data": [{"id": 3}, {"id": 4}],
+            "pagination": {"total_items": 4},
+        },
+    )
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            get_responses=[page1, page2], captured=captured
+        ),
+    )
+    result = await network.make_async_get_request(
+        "http://x", query_params={"limit": 2}, paginate=True
+    )
+    assert result == [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+    # Second request should carry page=2.
+    assert captured[1]["params"]["page"] == 2
+
+
+@pytest.mark.parametrize("status", [200, 202, 204])
+@pytest.mark.asyncio
+async def test_make_async_delete_request_success(mocker, status):
+    captured = []
+    response = FakeAsyncResponse(is_success=True, status_code=status)
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            delete_return=response, captured=captured
+        ),
+    )
+    assert await network.make_async_delete_request("http://x") is True
+
+
+@pytest.mark.asyncio
+async def test_make_async_delete_request_failure(mocker):
+    response = FakeAsyncResponse(is_success=False, status_code=500, text="bad")
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(delete_return=response),
+    )
+    with pytest.raises(RetryError):
+        await network.make_async_delete_request("http://x")
+
+
+@pytest.mark.asyncio
+async def test_make_async_patch_request_success(mocker):
+    captured = []
+    response = FakeAsyncResponse(is_success=True, json_data={"updated": True})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            patch_return=response, captured=captured
+        ),
+    )
+    result = await network.make_async_patch_request("http://x", data={"a": 1})
+    assert result == {"updated": True}
+    assert captured[0]["json"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_make_async_patch_request_failure(mocker):
+    response = FakeAsyncResponse(is_success=False, status_code=400, text="bad")
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(patch_return=response),
+    )
+    with pytest.raises(RetryError):
+        await network.make_async_patch_request("http://x", data={})
+
+
+@pytest.mark.asyncio
+async def test_make_async_get_request_raw_success(mocker):
+    response = FakeAsyncResponse(is_success=True, json_data={"raw": True})
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(get_return=response),
+    )
+    assert await network.make_async_get_request_raw("http://x") == {"raw": True}
+
+
+@pytest.mark.asyncio
+async def test_make_async_get_request_raw_failure(mocker):
+    """Same shape as the sync raw helper: transport error → None."""
+    import httpx as _httpx
+
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            get_raises=_httpx.ConnectError("boom")
+        ),
+    )
+    assert await network.make_async_get_request_raw("http://x") is None
+
+
+@pytest.mark.asyncio
+async def test_make_async_health_check_request_success(mocker):
+    response = FakeAsyncResponse(is_success=True, status_code=200)
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(get_return=response),
+    )
+    assert await network.make_async_health_check_request("http://x") is True
+
+
+@pytest.mark.asyncio
+async def test_make_async_health_check_request_non_2xx(mocker):
+    response = FakeAsyncResponse(is_success=False, status_code=500, text="bad")
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(get_return=response),
+    )
+    assert await network.make_async_health_check_request("http://x") is False
+
+
+@pytest.mark.asyncio
+async def test_make_async_health_check_request_exception(mocker):
+    """Health check is meant to fail fast — no retry, just False."""
+    import httpx as _httpx
+
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=lambda **_: _FakeAsyncClient(
+            get_raises=_httpx.ConnectError("boom")
+        ),
+    )
+    assert await network.make_async_health_check_request("http://x") is False

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -97,8 +97,14 @@ class FakeAsyncResponse:
         status_code=200,
         json_data=None,
         text="",
+        is_error=None,
     ):
         self.is_success = is_success
+        # Mirror httpx.Response: is_error is True for 4xx/5xx, False
+        # for 1xx/2xx/3xx. Default to the inverse of is_success so
+        # existing test fixtures keep working; explicit override lets
+        # tests cover 3xx-style cases where neither flag is set.
+        self.is_error = (not is_success) if is_error is None else is_error
         self.status_code = status_code
         self._json_data = json_data or {}
         self.text = text
@@ -645,3 +651,43 @@ async def test_make_async_health_check_request_exception(mocker):
         ),
     )
     assert await network.make_async_health_check_request("http://x") is False
+
+
+@pytest.mark.asyncio
+async def test_async_clients_follow_redirects(mocker):
+    """All async helpers must instantiate httpx.AsyncClient with
+    follow_redirects=True so 3xx responses are followed transparently,
+    matching the sync `requests` default. Without this the async path
+    diverges silently on any HTTP→HTTPS hop or trailing-slash redirect.
+    """
+    captured_kwargs = []
+
+    response = FakeAsyncResponse(is_success=True, json_data={"ok": True})
+
+    def _client_factory(**kwargs):
+        captured_kwargs.append(kwargs)
+        return _FakeAsyncClient(
+            post_return=response,
+            get_return=response,
+            delete_return=FakeAsyncResponse(is_success=True, status_code=204),
+            patch_return=response,
+        )
+
+    mocker.patch(
+        "cogflow.utils.network.httpx.AsyncClient",
+        side_effect=_client_factory,
+    )
+
+    await network.make_async_post_request(url="http://x", data={"a": 1})
+    await network.make_async_get_request(url="http://x")
+    await network.make_async_delete_request(url="http://x", path_params="1")
+    await network.make_async_patch_request(url="http://x", data={"a": 1})
+    await network.make_async_get_request_raw(url="http://x")
+    await network.make_async_health_check_request(url="http://x")
+
+    assert len(captured_kwargs) == 6
+    for kw in captured_kwargs:
+        assert kw.get("follow_redirects") is True, (
+            "AsyncClient must be instantiated with follow_redirects=True "
+            "to match sync requests default; got: " + repr(kw)
+        )


### PR DESCRIPTION
## Summary

Completes the async surface of `cogflow/utils/network.py` AND lands the first round of public `async_*` twins on top of it. PR #91 added `make_async_post_request` to fix the cog-api → cogflow → cog-api self-deadlock; this PR adds matching async mirrors for the remaining verbs so any callsite already inside an `async def` can issue any HTTP request without blocking the event loop, then exposes async public methods on the cogflow core surface where the work is purely network-bound.

This is **Stage N+1** of the Cog-Engine async migration plan. Once it lands and a cogflow release goes out, Cog-Engine can start dropping the `asyncio.to_thread` shims that quarantine cogflow calls in stages 5/6/7 (`kfp_pipelines`, `models`, `dataset`) and replace them with direct `await cogflow.async_*()` calls.

### Network helpers (the chokepoint)

All new helpers use `httpx.AsyncClient` instantiated with `follow_redirects=True` (matches the sync `requests` default) and use `not response.is_error` (<400) for success — call-for-call equivalent to `requests.Response.ok`.

- **`make_async_get_request`** — same path-param + pagination semantics as `make_get_request`. Tenacity retries on `httpx.HTTPError` (transport + status errors), matching sync.
- **`make_async_delete_request`** — 200/202/204 → True; matches sync `make_delete_request`'s retry-on-HTTPError policy (`raise_for_status` on non-success raises `HTTPStatusError`, which is a subclass of `HTTPError`, so 4xx/5xx are retried — same as sync).
- **`make_async_patch_request`** — JSON body when `data` is set, raises `RetryError` after 3 retries on a non-success.
- **`make_async_get_request_raw`** — returns parsed JSON or `None` on transport failure (mirrors the sync helper's actual behaviour; the `Response` annotation in the original docstring was incorrect).
- **`make_async_health_check_request`** — no retry; any 2xx → True, anything else (including transport error) → False.

### Public async twins (new)

Where a cogflow public method routes only through `network.py`, this PR adds an `async_*` mirror that re-uses the new helpers above. Pure-compute helpers and methods bound to sync-only SDKs (mlflow client, KFP client, kubernetes, boto3) intentionally stay sync — Cog-Engine continues to wrap those with `asyncio.to_thread` until the relevant SDKs are swapped (see "Why not more?" below).

- **`DatasetManager.async_get_dataset`** — async mirror of `get_dataset` (registry GET).
- **`DatasetManager.async_get_prometheus_dataset`** — async mirror of `get_prometheus_dataset`.
- **`DatasetManager.async_delete_dataset`** — async mirror of `delete_dataset`.
- **`async_register_component`** — async mirror of `register_component`. The MinIO upload step runs sync inside `asyncio.to_thread` because the MinIO SDK has no async client; the rest (registry GET → POST or PATCH) is true async. If the registry GET returns `None` (transport failure), the function raises `CogflowComponentRegistryError` rather than silently treating it as "no existing component" — this is the only behaviour intentionally tighter than the sync version, which crashes in the same case.

Skipped on purpose:
- `async_register_dataset` — needs multipart `files=` which the new async POST helper doesn't accept yet (separate follow-up).
- `async_download_dataset` — streaming response, needs the `AsyncExitStack` pattern (separate follow-up).

### Why not more?

A call-graph audit of cogflow methods Cog-Engine consumes shows most go through mlflow / kfp / kubernetes / boto3 clients, not through `network.py`:

- `start_run`, `set_tag`, `register_model` → mlflow tracking client (sync).
- KFP listing / run lookup → KFP client (sync).
- Pod / namespace / secret ops → `kubernetes` client (sync).
- S3 reads/writes → `boto3` (sync).

Adding an `async_*` twin that just wraps `asyncio.to_thread(...)` inside cogflow gives the caller no real benefit over wrapping at the call site, and clutters the public API. So those stay sync until the relevant SDKs swap (mlflow has no async client; `kubernetes_asyncio` is a viable swap and is the next thing to estimate; `aioboto3` is already in Cog-Engine's plan for Stage 4).

### Notes for review

- **`make_async_get_request_stream` deliberately omitted.** Streaming with `httpx.AsyncClient` requires the client to outlive the iteration, which doesn't fit the "single helper, return a Response" shape. Callers needing async streaming can use the `AsyncExitStack` + handed-off-flag pattern from `S3Utils.fetch_s3_object_stream` in Cog-Engine.
- **Tests**: extended `_FakeAsyncClient` to cover GET/DELETE/PATCH per-verb captured args + per-call response sequences for pagination. 18 network tests, 6 dataset tests, 4 component tests. New `test_async_clients_follow_redirects` pins the `follow_redirects=True` invariant for every async helper. New `test_async_register_component_registry_unreachable` covers the `None`-from-registry path.
- **Pre-existing failure**: `tests/test_async_serving.py::test_async_serve_llm_registers_and_deploys` fails on this branch because it tries real DNS for `cog-api.kubeflow`. The same test fails on `refactor` without my changes — it's environment-dependent (a CI-cluster test). All other tests pass: 274 passed, 1 skipped.

## Test plan

- [x] `black --check` on changed files — clean
- [x] `pycodestyle --max-line-length=120` on changed files — clean
- [x] `pytest tests/` — 274 passed (the one pre-existing env-dependent failure is unchanged)
- [ ] CI green
- [ ] Copilot review loop until threads clear
- [ ] After merge: bump cogflow minor, publish, then queue a Cog-Engine PR that swaps the `asyncio.to_thread(cogflow.X, ...)` shims in `app/services/{kfp_pipeline_service,model_register_service,dataset_service}.py` for `await cogflow.async_X(...)` for the methods covered here
