### PR TITLE
agent: add Cognitive Framework Agent SDK (Phase 1)

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -21,6 +21,7 @@ _LAZY_SUBMODULES = [
     "network",  # resolves to cogflow.utils.network
     "config",  # resolves to cogflow.config
     "pipelines",  # resolves to cogflow.pipelines
+    "agent",  # resolves to cogflow.agent (Cognitive Framework Agent SDK)
 ]
 
 # Create lazy module and copy current attributes

--- a/cogflow/agent/__init__.py
+++ b/cogflow/agent/__init__.py
@@ -1,0 +1,52 @@
+"""Cognitive Framework Agent SDK.
+
+A LangGraph-shaped Python API whose graphs round-trip to Flowise V2 AgentFlow
+JSON. See ``cogflow/cogflow/agent/__init__.py`` callers for the full mapping
+table in the architecture plan.
+
+Drop-in import migration (see plan §3a):
+
+    from cogflow.agent import StateGraph, START, END, MessagesState
+    from cogflow.agent import create_react_agent, interrupt, Command
+    from cogflow.agent.tools import tool, ToolNode
+"""
+
+from __future__ import annotations
+
+# Defer the heavy import behind a helpful message so users who pip-installed
+# bare ``cogflow`` see actionable text instead of a raw ModuleNotFoundError.
+try:
+    from langgraph.graph import END, START
+except ModuleNotFoundError as _exc:  # pragma: no cover - install-time guard
+    raise ModuleNotFoundError(
+        "cogflow.agent requires LangGraph. Install with `pip install cogflow[agent]`."
+    ) from _exc
+
+try:
+    from langgraph.types import Command, interrupt  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - older langgraph
+    interrupt = None  # type: ignore[assignment]
+    Command = None  # type: ignore[assignment]
+
+from . import compile, nodes, parse, tracing
+from .graph import StateGraph
+from .prebuilt import create_react_agent
+from .state import MessagesState, add_messages
+from .tools import ToolNode, tool
+
+__all__ = [
+    "Command",
+    "END",
+    "MessagesState",
+    "START",
+    "StateGraph",
+    "ToolNode",
+    "add_messages",
+    "compile",
+    "create_react_agent",
+    "interrupt",
+    "nodes",
+    "parse",
+    "tool",
+    "tracing",
+]

--- a/cogflow/agent/__init__.py
+++ b/cogflow/agent/__init__.py
@@ -13,13 +13,17 @@ Drop-in import migration (see plan §3a):
 
 from __future__ import annotations
 
-# Defer the heavy import behind a helpful message so users who pip-installed
-# bare ``cogflow`` see actionable text instead of a raw ModuleNotFoundError.
+# Defer the heavy imports behind a single helpful message so users who pip-
+# installed bare ``cogflow`` see actionable text instead of a raw
+# ``ModuleNotFoundError`` from langgraph OR langchain_core (both are required
+# at import time because submodules below depend on each).
 try:
+    import langchain_core  # noqa: F401 — verified-then-used by submodules
     from langgraph.graph import END, START
 except ModuleNotFoundError as _exc:  # pragma: no cover - install-time guard
     raise ModuleNotFoundError(
-        "cogflow.agent requires LangGraph. Install with `pip install cogflow[agent]`."
+        f"cogflow.agent requires `{_exc.name}`. "
+        "Install with `pip install cogflow[agent]`."
     ) from _exc
 
 try:

--- a/cogflow/agent/__init__.py
+++ b/cogflow/agent/__init__.py
@@ -1,8 +1,8 @@
 """Cognitive Framework Agent SDK.
 
 A LangGraph-shaped Python API whose graphs round-trip to Flowise V2 AgentFlow
-JSON. See ``cogflow/cogflow/agent/__init__.py`` callers for the full mapping
-table in the architecture plan.
+JSON. See ``cogflow/agent/__init__.py`` callers for the full mapping table in
+the architecture plan.
 
 Drop-in import migration (see plan §3a):
 

--- a/cogflow/agent/compile/__init__.py
+++ b/cogflow/agent/compile/__init__.py
@@ -1,6 +1,6 @@
 """IR compilers (IR -> LangGraph, IR -> Flowise JSON)."""
 
-from . import to_flowise, to_langgraph as _to_langgraph_module
+from . import to_flowise
 from .to_langgraph import to_langgraph
 
-__all__ = ["to_flowise", "to_langgraph", "_to_langgraph_module"]
+__all__ = ["to_flowise", "to_langgraph"]

--- a/cogflow/agent/compile/__init__.py
+++ b/cogflow/agent/compile/__init__.py
@@ -1,0 +1,6 @@
+"""IR compilers (IR -> LangGraph, IR -> Flowise JSON)."""
+
+from . import to_flowise, to_langgraph as _to_langgraph_module
+from .to_langgraph import to_langgraph
+
+__all__ = ["to_flowise", "to_langgraph", "_to_langgraph_module"]

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -95,11 +95,19 @@ def _edge_to_dict(edge: IREdge, graph: IRGraph) -> dict[str, Any]:
             result["sourceHandle"] = edge.source_handle
         if edge.target_handle is not None:
             result["targetHandle"] = edge.target_handle
-        # Overlay is_human_input onto data.isHumanInput so IR-side mutations
+        # Overlay is_human_input + edgeLabel onto data so IR-side mutations
         # survive re-emission of provenance-carrying edges.
         data = result.setdefault("data", {})
         data["isHumanInput"] = edge.is_human_input
+        if edge.label is not None:
+            data["edgeLabel"] = edge.label
         return result
+
+    edge_data: dict[str, Any] = {"isHumanInput": edge.is_human_input}
+    if edge.label is not None:
+        # Conditional / ConditionAgent branches carry their selector value here;
+        # Flowise renders it on the canvas and re-imports it via ``data.edgeLabel``.
+        edge_data["edgeLabel"] = edge.label
 
     return {
         "id": edge.id,
@@ -110,7 +118,7 @@ def _edge_to_dict(edge: IREdge, graph: IRGraph) -> dict[str, Any]:
         "target": edge.target,
         "targetHandle": edge.target_handle or _default_target_handle(edge.target),
         "type": "agentFlow",
-        "data": {"isHumanInput": edge.is_human_input},
+        "data": edge_data,
     }
 
 

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -47,7 +47,9 @@ def _node_to_dict(node: IRNode) -> dict[str, Any]:
         data = result.setdefault("data", {})
         data["id"] = node.id
         data["label"] = node.label
-        data["inputs"] = node.config if node.config else data.get("inputs", "")
+        # Always overlay node.config onto data.inputs (including ``{}``) so
+        # IR-side mutations — including intentional clears — survive export.
+        data["inputs"] = dict(node.config)
         return result
 
     flowise_name = IR_TYPE_TO_FLOWISE_NAME[node.type]

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -1,0 +1,125 @@
+"""IR -> Flowise V2 AgentFlow JSON.
+
+When an IR node carries ``flowise_provenance['node']`` (set by the importer),
+we re-emit that dict verbatim, overlaying any current ``config`` so user
+mutations in IR survive the round-trip. For Python-built nodes without
+provenance we synthesize a minimal-but-valid Flowise node block from the IR.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from ..constants import (
+    IR_TYPE_TO_FLOWISE_CATEGORY,
+    IR_TYPE_TO_FLOWISE_NAME,
+)
+from ..ir.model import IREdge, IRGraph, IRNode
+
+
+def _node_to_dict(node: IRNode) -> dict[str, Any]:
+    raw = (node.flowise_provenance or {}).get("node") if node.flowise_provenance else None
+    if isinstance(raw, dict):
+        result = copy.deepcopy(raw)
+        result["id"] = node.id
+        result["position"] = {"x": node.position.x, "y": node.position.y}
+        result.setdefault("positionAbsolute", {"x": node.position.x, "y": node.position.y})
+        data = result.setdefault("data", {})
+        data["id"] = node.id
+        data["label"] = node.label
+        data["inputs"] = node.config if node.config else data.get("inputs", "")
+        return result
+
+    flowise_name = IR_TYPE_TO_FLOWISE_NAME[node.type]
+    category = IR_TYPE_TO_FLOWISE_CATEGORY[node.type]
+    return {
+        "id": node.id,
+        "type": "stickyNote" if node.type == "sticky_note" else "agentFlow",
+        "position": {"x": node.position.x, "y": node.position.y},
+        "positionAbsolute": {"x": node.position.x, "y": node.position.y},
+        "data": {
+            "id": node.id,
+            "label": node.label,
+            "version": 1,
+            "name": flowise_name,
+            "type": category,
+            "baseClasses": [category],
+            "category": "Agent Flows",
+            "description": "",
+            "inputParams": [],
+            "inputAnchors": [
+                {"id": p.id, "name": p.name, "label": p.label, "type": p.type_} for p in node.inputs
+            ],
+            "inputs": node.config or {},
+            "outputAnchors": [
+                {"id": p.id, "name": p.name, "label": p.label} for p in node.outputs
+            ],
+            "outputs": {},
+            "selected": False,
+        },
+        "selected": False,
+        "dragging": False,
+    }
+
+
+def _edge_to_dict(edge: IREdge) -> dict[str, Any]:
+    raw = (edge.flowise_provenance or {}).get("edge") if edge.flowise_provenance else None
+    if isinstance(raw, dict):
+        result = copy.deepcopy(raw)
+        result["id"] = edge.id
+        result["source"] = edge.source
+        result["target"] = edge.target
+        if edge.source_handle is not None:
+            result["sourceHandle"] = edge.source_handle
+        if edge.target_handle is not None:
+            result["targetHandle"] = edge.target_handle
+        return result
+
+    return {
+        "id": edge.id,
+        "source": edge.source,
+        "sourceHandle": edge.source_handle or f"{edge.source}-output",
+        "target": edge.target,
+        "targetHandle": edge.target_handle or edge.target,
+        "type": "agentFlow",
+        "data": {"isHumanInput": edge.is_human_input},
+    }
+
+
+def to_dict(graph: IRGraph, *, analytics: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Serialize an IRGraph to a Flowise V2 AgentFlow JSON dict."""
+    provenance = graph.flowise_provenance or {}
+    out: dict[str, Any] = {}
+    if graph.description is not None:
+        out["description"] = graph.description
+    usecases = provenance.get("usecases") if isinstance(provenance, dict) else None
+    if usecases is not None:
+        out["usecases"] = usecases
+
+    out["nodes"] = [_node_to_dict(n) for n in graph.nodes]
+    out["edges"] = [_edge_to_dict(e) for e in graph.edges]
+
+    if graph.viewport is not None:
+        out["viewport"] = graph.viewport
+
+    extra = provenance.get("extra") if isinstance(provenance, dict) else None
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            out.setdefault(k, v)
+
+    if analytics is not None:
+        out["analytic"] = analytics
+
+    return out
+
+
+def to_file(graph: IRGraph, path: str | Path, *, indent: int = 4, **kwargs: Any) -> Path:
+    p = Path(path)
+    p.write_text(json.dumps(to_dict(graph, **kwargs), indent=indent))
+    return p
+
+
+__all__ = ["to_dict", "to_file"]

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -17,6 +17,7 @@ from ..constants import (
     IR_TYPE_TO_FLOWISE_CATEGORY,
     IR_TYPE_TO_FLOWISE_NAME,
 )
+from ..ir import END_SENTINEL
 from ..ir.model import IREdge, IRGraph, IRNode
 
 
@@ -140,7 +141,12 @@ def to_dict(graph: IRGraph, *, analytics: dict[str, Any] | None = None) -> dict[
         out["usecases"] = usecases
 
     out["nodes"] = [_node_to_dict(n) for n in graph.nodes]
-    out["edges"] = [_edge_to_dict(e, graph) for e in graph.edges]
+    # Skip edges that target the LangGraph END sentinel — they're a runtime
+    # concept (recorded by ``StateGraph.add_conditional_edges`` when a branch
+    # routes to ``END``) and have no Flowise canvas representation. Emitting
+    # them verbatim would produce ``"target": "__end__"``, an invalid id that
+    # Flowise rejects on import.
+    out["edges"] = [_edge_to_dict(e, graph) for e in graph.edges if e.target != END_SENTINEL]
 
     # Direction B: when the Start node has no Flowise provenance (i.e. the
     # graph was authored in Python), populate its ``data.inputs.startState``

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -89,13 +89,27 @@ def _edge_to_dict(edge: IREdge, graph: IRGraph) -> dict[str, Any]:
     raw = (edge.flowise_provenance or {}).get("edge") if edge.flowise_provenance else None
     if isinstance(raw, dict):
         result = copy.deepcopy(raw)
+        original_source = raw.get("source")
+        original_target = raw.get("target")
         result["id"] = edge.id
         result["source"] = edge.source
         result["target"] = edge.target
+
+        # When source / target were retargeted in IR, the provenance handles
+        # would otherwise point at the old node's anchors. Rebuild them from
+        # the current source / target so the emitted JSON stays internally
+        # consistent (Flowise rejects edges whose handle id doesn't exist on
+        # the referenced node).
         if edge.source_handle is not None:
             result["sourceHandle"] = edge.source_handle
+        elif edge.source != original_source:
+            result["sourceHandle"] = _default_output_handle(graph, edge.source)
+
         if edge.target_handle is not None:
             result["targetHandle"] = edge.target_handle
+        elif edge.target != original_target:
+            result["targetHandle"] = _default_target_handle(edge.target)
+
         # Overlay is_human_input + edgeLabel onto data so IR-side mutations
         # survive re-emission of provenance-carrying edges.
         data = result.setdefault("data", {})

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -25,8 +25,11 @@ def _node_to_dict(node: IRNode) -> dict[str, Any]:
     if isinstance(raw, dict):
         result = copy.deepcopy(raw)
         result["id"] = node.id
-        result["position"] = {"x": node.position.x, "y": node.position.y}
-        result.setdefault("positionAbsolute", {"x": node.position.x, "y": node.position.y})
+        pos = {"x": node.position.x, "y": node.position.y}
+        result["position"] = pos
+        # Flowise reads both ``position`` and ``positionAbsolute`` — keep them
+        # in sync so a mutated IR position doesn't leave the canvas inconsistent.
+        result["positionAbsolute"] = dict(pos)
         data = result.setdefault("data", {})
         data["id"] = node.id
         data["label"] = node.label

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -20,6 +20,20 @@ from ..constants import (
 from ..ir.model import IREdge, IRGraph, IRNode
 
 
+def _default_output_handle(graph: IRGraph, node_id: str) -> str:
+    """The canonical sourceHandle id Flowise expects on the source node."""
+    node = graph.node_by_id(node_id)
+    if node is not None and node.outputs:
+        return node.outputs[0].id
+    flowise_name = IR_TYPE_TO_FLOWISE_NAME.get(node.type, "output") if node else "output"
+    return f"{node_id}-output-{flowise_name}"
+
+
+def _default_target_handle(node_id: str) -> str:
+    """Flowise targetHandle defaults to the bare node id."""
+    return node_id
+
+
 def _node_to_dict(node: IRNode) -> dict[str, Any]:
     raw = (node.flowise_provenance or {}).get("node") if node.flowise_provenance else None
     if isinstance(raw, dict):
@@ -68,7 +82,7 @@ def _node_to_dict(node: IRNode) -> dict[str, Any]:
     }
 
 
-def _edge_to_dict(edge: IREdge) -> dict[str, Any]:
+def _edge_to_dict(edge: IREdge, graph: IRGraph) -> dict[str, Any]:
     raw = (edge.flowise_provenance or {}).get("edge") if edge.flowise_provenance else None
     if isinstance(raw, dict):
         result = copy.deepcopy(raw)
@@ -88,9 +102,11 @@ def _edge_to_dict(edge: IREdge) -> dict[str, Any]:
     return {
         "id": edge.id,
         "source": edge.source,
-        "sourceHandle": edge.source_handle or f"{edge.source}-output",
+        # Default handles derived from actual node anchors so synthesized edges
+        # round-trip cleanly through Flowise (the canvas matches by handle id).
+        "sourceHandle": edge.source_handle or _default_output_handle(graph, edge.source),
         "target": edge.target,
-        "targetHandle": edge.target_handle or edge.target,
+        "targetHandle": edge.target_handle or _default_target_handle(edge.target),
         "type": "agentFlow",
         "data": {"isHumanInput": edge.is_human_input},
     }
@@ -107,7 +123,7 @@ def to_dict(graph: IRGraph, *, analytics: dict[str, Any] | None = None) -> dict[
         out["usecases"] = usecases
 
     out["nodes"] = [_node_to_dict(n) for n in graph.nodes]
-    out["edges"] = [_edge_to_dict(e) for e in graph.edges]
+    out["edges"] = [_edge_to_dict(e, graph) for e in graph.edges]
 
     if graph.viewport is not None:
         out["viewport"] = graph.viewport

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -79,6 +79,10 @@ def _edge_to_dict(edge: IREdge) -> dict[str, Any]:
             result["sourceHandle"] = edge.source_handle
         if edge.target_handle is not None:
             result["targetHandle"] = edge.target_handle
+        # Overlay is_human_input onto data.isHumanInput so IR-side mutations
+        # survive re-emission of provenance-carrying edges.
+        data = result.setdefault("data", {})
+        data["isHumanInput"] = edge.is_human_input
         return result
 
     return {

--- a/cogflow/agent/compile/to_flowise.py
+++ b/cogflow/agent/compile/to_flowise.py
@@ -112,6 +112,13 @@ def _edge_to_dict(edge: IREdge, graph: IRGraph) -> dict[str, Any]:
     }
 
 
+def _start_state_payload(graph: IRGraph) -> list[dict[str, Any]]:
+    """``data.inputs.startState`` shape Flowise expects, derived from IR state."""
+    return [
+        {"key": f.key, "value": "" if f.default is None else f.default} for f in graph.state
+    ]
+
+
 def to_dict(graph: IRGraph, *, analytics: dict[str, Any] | None = None) -> dict[str, Any]:
     """Serialize an IRGraph to a Flowise V2 AgentFlow JSON dict."""
     provenance = graph.flowise_provenance or {}
@@ -124,6 +131,25 @@ def to_dict(graph: IRGraph, *, analytics: dict[str, Any] | None = None) -> dict[
 
     out["nodes"] = [_node_to_dict(n) for n in graph.nodes]
     out["edges"] = [_edge_to_dict(e, graph) for e in graph.edges]
+
+    # Direction B: when the Start node has no Flowise provenance (i.e. the
+    # graph was authored in Python), populate its ``data.inputs.startState``
+    # from ``graph.state`` so the exported canvas reflects the declared
+    # schema. Provenance-backed Start nodes are left untouched to preserve
+    # lossless round-trip on JSON-imported graphs.
+    if graph.state:
+        for ir_node, emitted in zip(graph.nodes, out["nodes"]):
+            if ir_node.type != "start":
+                continue
+            if ir_node.flowise_provenance and "node" in ir_node.flowise_provenance:
+                continue
+            data = emitted.setdefault("data", {})
+            inputs = data.get("inputs")
+            if not isinstance(inputs, dict):
+                inputs = {}
+                data["inputs"] = inputs
+            inputs["startState"] = _start_state_payload(graph)
+            break
 
     if graph.viewport is not None:
         out["viewport"] = graph.viewport

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -1,0 +1,127 @@
+"""IR -> langgraph.graph.CompiledStateGraph.
+
+Sticky-note nodes are skipped at compile time. Condition / Condition-Agent
+nodes are folded into a ``add_conditional_edges`` registration; their runtime
+callable still runs (so users can read ``_condition_branch`` from state),
+but routing comes from the IR edge fan-out.
+
+For nodes loaded from JSON we don't have a factory instance carrying live
+references to a model or tool callable. Such nodes get a passthrough body —
+useful for structure / round-trip tests. Pass ``factories={node_id: factory}``
+to ``to_langgraph`` to inject live runtime objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from langgraph.graph import END, START, StateGraph
+
+from ..ir.model import IRGraph, IRNode
+from ..ir.validate import validate
+from ..nodes import FACTORY_BY_IR_TYPE, NodeFactory
+from ..state import introspect_state, synthesize_typeddict
+from .topo import edges_from
+
+
+_SKIP_TYPES = {"sticky_note"}
+_CONDITION_TYPES = {"condition", "condition_agent"}
+
+
+def _passthrough(_state: Any) -> dict[str, Any]:
+    return {}
+
+
+def _callable_for(node: IRNode, factories: Mapping[str, NodeFactory] | None) -> Callable[..., Any]:
+    if factories and node.id in factories:
+        return factories[node.id].to_callable(node)
+    factory_cls = FACTORY_BY_IR_TYPE.get(node.type)
+    if factory_cls is None:
+        return _passthrough
+    # Instantiate without the kwargs-validating __init__ so JSON-loaded nodes
+    # can supply their (Flowise-shaped) config dict directly.
+    bare = factory_cls.__new__(factory_cls)
+    bare.config = dict(node.config)  # type: ignore[attr-defined]
+    bare._model = None  # type: ignore[attr-defined]
+    bare._tools = []  # type: ignore[attr-defined]
+    bare._fn = None  # type: ignore[attr-defined]
+    bare._rules = node.config.get("conditionItems") or []  # type: ignore[attr-defined]
+    bare._scenarios = node.config.get("conditionAgentScenarios") or []  # type: ignore[attr-defined]
+    return bare.to_callable(node)
+
+
+def _state_schema(graph: IRGraph) -> type:
+    if graph.state:
+        return synthesize_typeddict(graph.state)
+    # Fall back to a TypedDict carrying ``messages`` only.
+    from .. import state as _state_mod  # type: ignore  # noqa: F401
+    return synthesize_typeddict(introspect_state(_state_mod.MessagesState))
+
+
+def to_langgraph(
+    graph: IRGraph,
+    *,
+    factories: Mapping[str, NodeFactory] | None = None,
+    state_schema: type | None = None,
+    checkpointer: Any = None,
+    interrupt_before: list[str] | None = None,
+    interrupt_after: list[str] | None = None,
+):
+    """Compile an IRGraph into a ``CompiledStateGraph``."""
+    validate(graph)
+
+    schema = state_schema or _state_schema(graph)
+    builder = StateGraph(schema)
+
+    runtime_nodes = [n for n in graph.nodes if n.type not in _SKIP_TYPES and n.type != "start"]
+    runtime_ids = {n.id for n in runtime_nodes}
+
+    for node in runtime_nodes:
+        builder.add_node(node.id, _callable_for(node, factories))
+
+    # Entry edge: from START to whatever the start node fans out to (skip the
+    # IR Start node itself; it has no runtime body).
+    start_id = graph.entry
+    if start_id is not None:
+        for e in edges_from(graph, start_id):
+            if e.target in runtime_ids:
+                builder.add_edge(START, e.target)
+
+    # Runtime edges. Condition nodes use add_conditional_edges; everything else
+    # is a plain add_edge.
+    for node in runtime_nodes:
+        outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids or e.target == start_id]
+        if not outs:
+            builder.add_edge(node.id, END)
+            continue
+
+        if node.type in _CONDITION_TYPES and len(outs) > 1:
+            branch_to_target: dict[str, str] = {}
+            for e in outs:
+                key = e.label or e.target_handle or e.target
+                branch_to_target[key] = e.target
+
+            def router(state: dict[str, Any], _mapping: dict[str, str] = branch_to_target) -> str:
+                branch = state.get("_condition_branch")
+                if isinstance(branch, str) and branch in _mapping:
+                    return _mapping[branch]
+                return next(iter(_mapping.values()))
+
+            builder.add_conditional_edges(node.id, router)
+        else:
+            for e in outs:
+                builder.add_edge(node.id, e.target)
+
+    # Any runtime node with no outgoing edge to a runtime node goes to END.
+    for node in runtime_nodes:
+        if not edges_from(graph, node.id):
+            builder.add_edge(node.id, END)
+
+    return builder.compile(
+        checkpointer=checkpointer,
+        interrupt_before=interrupt_before or [],
+        interrupt_after=interrupt_after or [],
+    )
+
+
+__all__ = ["to_langgraph"]

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -90,7 +90,11 @@ def to_langgraph(
     # Runtime edges. Condition nodes use add_conditional_edges; everything else
     # is a plain add_edge.
     for node in runtime_nodes:
-        outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids or e.target == start_id]
+        # Only route to nodes actually registered with the builder. Edges that
+        # target the Start (or skipped) node are dropped — looping back to
+        # entry would require routing to LangGraph's ``START`` sentinel, which
+        # is not what an edge to a removed Start node means.
+        outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids]
         if not outs:
             builder.add_edge(node.id, END)
             continue

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -76,13 +76,22 @@ def to_langgraph(
     for node in runtime_nodes:
         builder.add_node(node.id, _callable_for(node, factories))
 
-    # Entry edge: from START to whatever the start node fans out to (skip the
-    # IR Start node itself; it has no runtime body).
+    # Entry edge from LangGraph's START sentinel. Two cases:
+    #   - ``graph.entry`` points at a Start IR node (the common case from a
+    #     Flowise import): the Start node has no runtime body, so we fan out
+    #     to whatever it links to.
+    #   - ``graph.entry`` points at a regular runtime node (the "entry
+    #     override" case ``ir.validate`` allows when no Start node is
+    #     present): wire START directly to it so its body runs.
     start_id = graph.entry
     if start_id is not None:
-        for e in edges_from(graph, start_id):
-            if e.target in runtime_ids:
-                builder.add_edge(START, e.target)
+        entry_node = graph.node_by_id(start_id)
+        if entry_node is not None and entry_node.type == "start":
+            for e in edges_from(graph, start_id):
+                if e.target in runtime_ids:
+                    builder.add_edge(START, e.target)
+        elif start_id in runtime_ids:
+            builder.add_edge(START, start_id)
 
     # Runtime edges. Condition nodes use add_conditional_edges; everything else
     # is a plain add_edge.

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -38,16 +38,13 @@ def _callable_for(node: IRNode, factories: Mapping[str, NodeFactory] | None) -> 
     factory_cls = FACTORY_BY_IR_TYPE.get(node.type)
     if factory_cls is None:
         return _passthrough
-    # Instantiate without the kwargs-validating __init__ so JSON-loaded nodes
-    # can supply their (Flowise-shaped) config dict directly.
-    bare = factory_cls.__new__(factory_cls)
-    bare.config = dict(node.config)  # type: ignore[attr-defined]
-    bare._model = None  # type: ignore[attr-defined]
-    bare._tools = []  # type: ignore[attr-defined]
-    bare._fn = None  # type: ignore[attr-defined]
-    bare._rules = node.config.get("conditionItems") or []  # type: ignore[attr-defined]
-    bare._scenarios = node.config.get("conditionAgentScenarios") or []  # type: ignore[attr-defined]
-    return bare.to_callable(node)
+    # Hydrate via the stable factory API rather than reaching into private
+    # attributes. Each factory's ``to_callable`` reads its runtime state
+    # through ``getattr(self, "_attr", default)`` so a hydrated-from-IR
+    # instance behaves as a safe passthrough until a live model/tool is
+    # injected via the ``factories=`` parameter.
+    instance = factory_cls.from_ir(node)
+    return instance.to_callable(node)
 
 
 def _state_schema(graph: IRGraph) -> type:

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -95,6 +95,9 @@ def to_langgraph(
 
     # Runtime edges. Condition nodes use add_conditional_edges; everything else
     # is a plain add_edge.
+    finish_ids = {fid for fid in graph.finish if fid in runtime_ids}
+    end_edged: set[str] = set()  # nodes already wired to END (avoid duplicates)
+
     for node in runtime_nodes:
         # Only route to nodes actually registered with the builder. Edges that
         # target the Start (or skipped) node are dropped — looping back to
@@ -103,6 +106,7 @@ def to_langgraph(
         outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids]
         if not outs:
             builder.add_edge(node.id, END)
+            end_edged.add(node.id)
             continue
 
         if node.type in _CONDITION_TYPES and len(outs) > 1:
@@ -121,6 +125,12 @@ def to_langgraph(
         else:
             for e in outs:
                 builder.add_edge(node.id, e.target)
+
+    # Explicit finish points (``IRGraph.finish``) — wire them to END unless we
+    # already did so via the leaf-node path above. A node can be both a finish
+    # point AND have outgoing edges; in that case it needs an explicit END edge.
+    for fid in finish_ids - end_edged:
+        builder.add_edge(fid, END)
 
     return builder.compile(
         checkpointer=checkpointer,

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -112,11 +112,6 @@ def to_langgraph(
             for e in outs:
                 builder.add_edge(node.id, e.target)
 
-    # Any runtime node with no outgoing edge to a runtime node goes to END.
-    for node in runtime_nodes:
-        if not edges_from(graph, node.id):
-            builder.add_edge(node.id, END)
-
     return builder.compile(
         checkpointer=checkpointer,
         interrupt_before=interrupt_before or [],

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Mapping
 from langgraph.graph import END, START, StateGraph
 
 from ..ir.model import IRGraph, IRNode
-from ..ir.validate import validate
+from ..ir.validate import END_SENTINEL, validate
 from ..nodes import FACTORY_BY_IR_TYPE, NodeFactory
 from ..state import introspect_state, synthesize_typeddict
 from .topo import edges_from
@@ -114,23 +114,30 @@ def to_langgraph(
     end_edged: set[str] = set()  # nodes already wired to END (avoid duplicates)
 
     for node in runtime_nodes:
-        # Only route to nodes actually registered with the builder. Edges that
-        # target the Start (or skipped) node are dropped — looping back to
-        # entry would require routing to LangGraph's ``START`` sentinel, which
-        # is not what an edge to a removed Start node means.
-        outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids]
+        # Only route to nodes actually registered with the builder, plus the
+        # END sentinel for branches that terminate. Edges that target the
+        # Start (or skipped) node are dropped — looping back to entry would
+        # require routing to LangGraph's ``START`` sentinel, which is not what
+        # an edge to a removed Start node means.
+        outs = [
+            e
+            for e in edges_from(graph, node.id)
+            if e.target in runtime_ids or e.target == END_SENTINEL
+        ]
         if not outs:
             builder.add_edge(node.id, END)
             end_edged.add(node.id)
             continue
 
         if node.type in _CONDITION_TYPES and len(outs) > 1:
-            branch_to_target: dict[str, str] = {}
+            branch_to_target: dict[str, Any] = {}
             for e in outs:
                 key = e.label or e.target_handle or e.target
-                branch_to_target[key] = e.target
+                # Translate the IR END sentinel back to LangGraph's END object
+                # so only this specific branch terminates (not the whole node).
+                branch_to_target[key] = END if e.target == END_SENTINEL else e.target
 
-            def router(state: dict[str, Any], _mapping: dict[str, str] = branch_to_target) -> str:
+            def router(state: dict[str, Any], _mapping: dict[str, Any] = branch_to_target) -> Any:
                 branch = state.get("_condition_branch")
                 if isinstance(branch, str) and branch in _mapping:
                     return _mapping[branch]
@@ -139,7 +146,10 @@ def to_langgraph(
             builder.add_conditional_edges(node.id, router)
         else:
             for e in outs:
-                builder.add_edge(node.id, e.target)
+                target = END if e.target == END_SENTINEL else e.target
+                builder.add_edge(node.id, target)
+                if target == END:
+                    end_edged.add(node.id)
 
     # Explicit finish points (``IRGraph.finish``) — wire them to END unless we
     # already did so via the leaf-node path above. A node can be both a finish

--- a/cogflow/agent/compile/to_langgraph.py
+++ b/cogflow/agent/compile/to_langgraph.py
@@ -84,14 +84,29 @@ def to_langgraph(
     #     override" case ``ir.validate`` allows when no Start node is
     #     present): wire START directly to it so its body runs.
     start_id = graph.entry
+    start_wired = False
     if start_id is not None:
         entry_node = graph.node_by_id(start_id)
         if entry_node is not None and entry_node.type == "start":
             for e in edges_from(graph, start_id):
                 if e.target in runtime_ids:
                     builder.add_edge(START, e.target)
+                    start_wired = True
         elif start_id in runtime_ids:
             builder.add_edge(START, start_id)
+            start_wired = True
+
+    # Degenerate case: a Start node with no runtime targets (e.g., a Flowise
+    # import containing only a Start node, or Start fanning into nodes we
+    # skip at compile). LangGraph would refuse to compile without any START
+    # edge, so wire a safe START → END so the graph still produces a valid
+    # CompiledStateGraph that immediately terminates.
+    if not start_wired and not runtime_nodes:
+        builder.add_edge(START, END)
+    elif not start_wired and runtime_nodes:
+        # Fallback for malformed graphs whose entry doesn't reach any runtime
+        # node: enter the first declared runtime node so something runs.
+        builder.add_edge(START, runtime_nodes[0].id)
 
     # Runtime edges. Condition nodes use add_conditional_edges; everything else
     # is a plain add_edge.

--- a/cogflow/agent/compile/topo.py
+++ b/cogflow/agent/compile/topo.py
@@ -1,0 +1,49 @@
+"""Topology helpers for compilation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from ..ir.model import IREdge, IRGraph
+
+
+def edges_from(graph: IRGraph, source: str) -> list[IREdge]:
+    return [e for e in graph.edges if e.source == source]
+
+
+def edges_to(graph: IRGraph, target: str) -> list[IREdge]:
+    return [e for e in graph.edges if e.target == target]
+
+
+def adjacency(graph: IRGraph) -> dict[str, list[str]]:
+    adj: dict[str, list[str]] = defaultdict(list)
+    for e in graph.edges:
+        adj[e.source].append(e.target)
+    return adj
+
+
+def reachable(graph: IRGraph, start: str) -> set[str]:
+    seen: set[str] = set()
+    stack = [start]
+    adj = adjacency(graph)
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(adj.get(node, []))
+    return seen
+
+
+def terminal_node_ids(graph: IRGraph, runtime_node_ids: Iterable[str]) -> set[str]:
+    """Nodes with no outgoing runtime edges — they should route to END."""
+    runtime_set = set(runtime_node_ids)
+    has_out: set[str] = set()
+    for e in graph.edges:
+        if e.source in runtime_set and e.target in runtime_set:
+            has_out.add(e.source)
+    return runtime_set - has_out
+
+
+__all__ = ["adjacency", "edges_from", "edges_to", "reachable", "terminal_node_ids"]

--- a/cogflow/agent/constants.py
+++ b/cogflow/agent/constants.py
@@ -1,0 +1,55 @@
+"""Constants for cogflow.agent.
+
+START/END are imported from langgraph so object identity holds for users who
+mix and match ``cogflow.agent.END`` with ``langgraph.graph.END``.
+"""
+
+from langgraph.graph import END, START
+
+# Mapping from our IR node type to the Flowise V2 ``data.name`` discriminator.
+IR_TYPE_TO_FLOWISE_NAME: dict[str, str] = {
+    "start": "startAgentflow",
+    "llm": "llmAgentflow",
+    "agent": "agentAgentflow",
+    "tool": "toolAgentflow",
+    "condition": "conditionAgentflow",
+    "condition_agent": "conditionAgentAgentflow",
+    "direct_reply": "directReplyAgentflow",
+    "loop": "loopAgentflow",
+    "iteration": "iterationAgentflow",
+    "http": "httpAgentflow",
+    "retriever": "retrieverAgentflow",
+    "custom_function": "customFunctionAgentflow",
+    "human_input": "humanInputAgentflow",
+    "execute_flow": "executeFlowAgentflow",
+    "sticky_note": "stickyNoteAgentflow",
+}
+
+FLOWISE_NAME_TO_IR_TYPE: dict[str, str] = {v: k for k, v in IR_TYPE_TO_FLOWISE_NAME.items()}
+
+# Flowise capitalises ``data.type`` (the category type, distinct from ``data.name``).
+IR_TYPE_TO_FLOWISE_CATEGORY: dict[str, str] = {
+    "start": "Start",
+    "llm": "LLM",
+    "agent": "Agent",
+    "tool": "Tool",
+    "condition": "Condition",
+    "condition_agent": "ConditionAgent",
+    "direct_reply": "DirectReply",
+    "loop": "Loop",
+    "iteration": "Iteration",
+    "http": "HTTP",
+    "retriever": "Retriever",
+    "custom_function": "CustomFunction",
+    "human_input": "HumanInput",
+    "execute_flow": "ExecuteFlow",
+    "sticky_note": "StickyNote",
+}
+
+__all__ = [
+    "END",
+    "FLOWISE_NAME_TO_IR_TYPE",
+    "IR_TYPE_TO_FLOWISE_CATEGORY",
+    "IR_TYPE_TO_FLOWISE_NAME",
+    "START",
+]

--- a/cogflow/agent/constants.py
+++ b/cogflow/agent/constants.py
@@ -23,6 +23,11 @@ IR_TYPE_TO_FLOWISE_NAME: dict[str, str] = {
     "human_input": "humanInputAgentflow",
     "execute_flow": "executeFlowAgentflow",
     "sticky_note": "stickyNoteAgentflow",
+    # Sentinel for Flowise node discriminators we don't recognize. Real
+    # imports always carry full provenance, so emit() re-uses the raw node
+    # dict and this fallback name only surfaces for Python-built unknown
+    # nodes (a deliberately broken case).
+    "unknown": "unknownAgentflow",
 }
 
 FLOWISE_NAME_TO_IR_TYPE: dict[str, str] = {v: k for k, v in IR_TYPE_TO_FLOWISE_NAME.items()}
@@ -44,6 +49,7 @@ IR_TYPE_TO_FLOWISE_CATEGORY: dict[str, str] = {
     "human_input": "HumanInput",
     "execute_flow": "ExecuteFlow",
     "sticky_note": "StickyNote",
+    "unknown": "Unknown",
 }
 
 __all__ = [

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -23,6 +23,7 @@ from langgraph.graph import END, START
 from langgraph.graph import StateGraph as _LangGraphStateGraph
 
 from .ir import (
+    END_SENTINEL,
     IRGraph,
     IRNode,
     IRPort,
@@ -144,12 +145,18 @@ class StateGraph(_LangGraphStateGraph):
         if isinstance(mapping, list):
             mapping = {k: k for k in mapping}
         for branch, target in mapping.items():
-            if target == END:
-                self.ir.finish.append(source)
-                continue
-            edge = _ir_add_edge(self.ir, source=source, target=target, label=str(branch))
-            edge.target_handle = target
-        return super().add_conditional_edges(source, path, path_map, then)  # type: ignore[no-any-return]
+            # Branch-level termination: a single branch routing to END must NOT
+            # force every other branch to terminate too (the prior behavior
+            # incorrectly added ``source`` to ``ir.finish``). Record the
+            # END sentinel as the edge target so ``to_langgraph`` translates
+            # only this branch to LangGraph's END.
+            real_target = END_SENTINEL if target == END else target
+            edge = _ir_add_edge(self.ir, source=source, target=real_target, label=str(branch))
+            edge.target_handle = None if real_target == END_SENTINEL else target
+        # ``then`` was added in newer langgraph; pass through only when set.
+        if then is None:
+            return super().add_conditional_edges(source, path, path_map)  # type: ignore[no-any-return]
+        return super().add_conditional_edges(source, path, path_map, then=then)  # type: ignore[no-any-return]
 
     def set_entry_point(self, key: str) -> "StateGraph":  # type: ignore[override]
         start_node = _synthesize_start_node(self.ir)

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -104,6 +104,16 @@ class StateGraph(_LangGraphStateGraph):
             type="custom_function",
             label=kwargs.pop("label", name),
             config={"customFunctionPython": getattr(node, "__name__", f"node_{idx}")},
+            # Default Flowise output anchor so emitted edges reference an id
+            # that actually exists on this node (matches ``NodeFactory.default_outputs``).
+            outputs=[
+                IRPort(
+                    id=f"{name}-output-customFunctionAgentflow",
+                    name="customFunctionAgentflow",
+                    label="CustomFunction",
+                    type="custom_function",
+                )
+            ],
         )
         _ir_add_node(self.ir, ir_node)
         super().add_node(name, node, **kwargs)

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -23,7 +23,6 @@ from langgraph.graph import END, START
 from langgraph.graph import StateGraph as _LangGraphStateGraph
 
 from .ir import (
-    IREdge,
     IRGraph,
     IRNode,
     IRPort,

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -38,13 +38,22 @@ def _synthesize_start_node(graph: IRGraph) -> IRNode:
     for n in graph.nodes:
         if n.type == "start":
             return n
+    # Pick a collision-free id. ``__start__`` is the obvious choice but a user
+    # may already have added a node with that name; probe upward until free.
+    existing_ids = {n.id for n in graph.nodes}
+    candidate = "__start__"
+    suffix = 0
+    while candidate in existing_ids:
+        suffix += 1
+        candidate = f"__start_{suffix}__"
+
     node = IRNode(
-        id="__start__",
+        id=candidate,
         type="start",
         label="Start",
         outputs=[
             IRPort(
-                id="__start__-output-startAgentflow",
+                id=f"{candidate}-output-startAgentflow",
                 name="startAgentflow",
                 label="Start",
                 type="start",

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -68,9 +68,17 @@ class StateGraph(_LangGraphStateGraph):
     # ------------------------------------------------------------------
     # add_node
     # ------------------------------------------------------------------
-    def add_node(self, name: str, node: Any = None, **kwargs: Any) -> "StateGraph":  # type: ignore[override]
+    def add_node(self, name: Any, node: Any = None, **kwargs: Any) -> "StateGraph":  # type: ignore[override]
+        # LangGraph supports ``add_node(fn)`` (name inferred from the callable).
+        # Normalize that form here so IR capture works for both signatures.
+        if node is None and callable(name) and not isinstance(name, NodeFactory):
+            fn = name
+            name = getattr(fn, "__name__", f"node_{next(self._node_counter)}")
+            node = fn
+
         if node is None:
-            # langgraph's add_node(fn) form — name omitted
+            # Some advanced langgraph forms (e.g. metadata-only updates) fall
+            # through here. Pass to the parent unchanged; no IR row recorded.
             return super().add_node(name, **kwargs)  # type: ignore[no-any-return]
 
         if isinstance(node, NodeFactory):

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -113,7 +113,16 @@ class StateGraph(_LangGraphStateGraph):
     # edges
     # ------------------------------------------------------------------
     def add_edge(self, start_key: str, end_key: str) -> "StateGraph":  # type: ignore[override]
-        if start_key == START:
+        # Order matters: check END first so ``add_edge(START, END)`` doesn't
+        # try to record an IR edge whose ``target`` is the LangGraph END
+        # sentinel rather than a real node id.
+        if end_key == END:
+            if start_key == START:
+                start_node = _synthesize_start_node(self.ir)
+                self.ir.finish.append(start_node.id)
+            else:
+                self.ir.finish.append(start_key)
+        elif start_key == START:
             start_node = _synthesize_start_node(self.ir)
             _ir_add_edge(
                 self.ir,
@@ -121,8 +130,6 @@ class StateGraph(_LangGraphStateGraph):
                 target=end_key,
                 source_handle=f"{start_node.id}-output-startAgentflow",
             )
-        elif end_key == END:
-            self.ir.finish.append(start_key)
         else:
             _ir_add_edge(self.ir, source=start_key, target=end_key)
         return super().add_edge(start_key, end_key)  # type: ignore[no-any-return]

--- a/cogflow/agent/graph.py
+++ b/cogflow/agent/graph.py
@@ -1,0 +1,143 @@
+"""StateGraph facade — LangGraph-shaped API that also captures IR.
+
+Users get a drop-in subclass of ``langgraph.graph.StateGraph``: every method
+that mutates the graph (``add_node``, ``add_edge``, ``add_conditional_edges``,
+``set_entry_point``, ``set_finish_point``) also updates an in-memory
+``IRGraph`` accessible via the ``.ir`` attribute. The compiled output is a
+real ``langgraph.graph.CompiledStateGraph``.
+
+Phase 1 behavior:
+ - Passing a ``NodeFactory`` instance to ``add_node`` captures its IR type and
+   config faithfully (so the graph round-trips to Flowise JSON).
+ - Passing a raw callable is supported and registered with LangGraph
+   unchanged; the IR row is recorded as a ``custom_function`` node, which
+   round-trips structurally but won't be runtime-equivalent in Flowise.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Callable, Mapping
+
+from langgraph.graph import END, START
+from langgraph.graph import StateGraph as _LangGraphStateGraph
+
+from .ir import (
+    IREdge,
+    IRGraph,
+    IRNode,
+    IRPort,
+    add_edge as _ir_add_edge,
+    add_node as _ir_add_node,
+)
+from .nodes.base import NodeFactory
+from .state import introspect_state
+
+
+def _synthesize_start_node(graph: IRGraph) -> IRNode:
+    for n in graph.nodes:
+        if n.type == "start":
+            return n
+    node = IRNode(
+        id="__start__",
+        type="start",
+        label="Start",
+        outputs=[
+            IRPort(
+                id="__start__-output-startAgentflow",
+                name="startAgentflow",
+                label="Start",
+                type="start",
+            )
+        ],
+    )
+    graph.nodes.insert(0, node)
+    graph.entry = node.id
+    return node
+
+
+class StateGraph(_LangGraphStateGraph):
+    """LangGraph-shaped StateGraph that also captures an IRGraph."""
+
+    def __init__(self, state_schema: type | None = None, *args: Any, **kwargs: Any) -> None:
+        super().__init__(state_schema, *args, **kwargs)
+        self.ir = IRGraph(state=introspect_state(state_schema))
+        self._factories: dict[str, NodeFactory] = {}
+        self._node_counter = itertools.count()
+
+    # ------------------------------------------------------------------
+    # add_node
+    # ------------------------------------------------------------------
+    def add_node(self, name: str, node: Any = None, **kwargs: Any) -> "StateGraph":  # type: ignore[override]
+        if node is None:
+            # langgraph's add_node(fn) form — name omitted
+            return super().add_node(name, **kwargs)  # type: ignore[no-any-return]
+
+        if isinstance(node, NodeFactory):
+            ir_node = node.emit_ir(name, label=kwargs.pop("label", name))
+            self._factories[name] = node
+            _ir_add_node(self.ir, ir_node)
+            super().add_node(name, node.to_callable(ir_node), **kwargs)
+            return self
+
+        # Raw callable — record as custom_function for IR provenance only.
+        idx = next(self._node_counter)
+        ir_node = IRNode(
+            id=name,
+            type="custom_function",
+            label=kwargs.pop("label", name),
+            config={"customFunctionPython": getattr(node, "__name__", f"node_{idx}")},
+        )
+        _ir_add_node(self.ir, ir_node)
+        super().add_node(name, node, **kwargs)
+        return self
+
+    # ------------------------------------------------------------------
+    # edges
+    # ------------------------------------------------------------------
+    def add_edge(self, start_key: str, end_key: str) -> "StateGraph":  # type: ignore[override]
+        if start_key == START:
+            start_node = _synthesize_start_node(self.ir)
+            _ir_add_edge(
+                self.ir,
+                source=start_node.id,
+                target=end_key,
+                source_handle=f"{start_node.id}-output-startAgentflow",
+            )
+        elif end_key == END:
+            self.ir.finish.append(start_key)
+        else:
+            _ir_add_edge(self.ir, source=start_key, target=end_key)
+        return super().add_edge(start_key, end_key)  # type: ignore[no-any-return]
+
+    def add_conditional_edges(  # type: ignore[override]
+        self,
+        source: str,
+        path: Callable[..., Any],
+        path_map: Mapping[str, str] | list[str] | None = None,
+        then: str | None = None,
+    ) -> "StateGraph":
+        mapping = path_map or {}
+        if isinstance(mapping, list):
+            mapping = {k: k for k in mapping}
+        for branch, target in mapping.items():
+            if target == END:
+                self.ir.finish.append(source)
+                continue
+            edge = _ir_add_edge(self.ir, source=source, target=target, label=str(branch))
+            edge.target_handle = target
+        return super().add_conditional_edges(source, path, path_map, then)  # type: ignore[no-any-return]
+
+    def set_entry_point(self, key: str) -> "StateGraph":  # type: ignore[override]
+        start_node = _synthesize_start_node(self.ir)
+        _ir_add_edge(
+            self.ir,
+            source=start_node.id,
+            target=key,
+            source_handle=f"{start_node.id}-output-startAgentflow",
+        )
+        return super().set_entry_point(key)  # type: ignore[no-any-return]
+
+    def set_finish_point(self, key: str) -> "StateGraph":  # type: ignore[override]
+        self.ir.finish.append(key)
+        return super().set_finish_point(key)  # type: ignore[no-any-return]

--- a/cogflow/agent/ir/__init__.py
+++ b/cogflow/agent/ir/__init__.py
@@ -11,9 +11,10 @@ from .model import (
     IRStateField,
     IRStateType,
 )
-from .validate import IRValidationError, validate
+from .validate import END_SENTINEL, IRValidationError, validate
 
 __all__ = [
+    "END_SENTINEL",
     "IREdge",
     "IRGraph",
     "IRNode",

--- a/cogflow/agent/ir/__init__.py
+++ b/cogflow/agent/ir/__init__.py
@@ -1,0 +1,30 @@
+"""IR (intermediate representation) for cogflow.agent graphs."""
+
+from .builders import add_edge, add_node, fresh_edge_id
+from .model import (
+    IREdge,
+    IRGraph,
+    IRNode,
+    IRNodeType,
+    IRPort,
+    IRPosition,
+    IRStateField,
+    IRStateType,
+)
+from .validate import IRValidationError, validate
+
+__all__ = [
+    "IREdge",
+    "IRGraph",
+    "IRNode",
+    "IRNodeType",
+    "IRPort",
+    "IRPosition",
+    "IRStateField",
+    "IRStateType",
+    "IRValidationError",
+    "add_edge",
+    "add_node",
+    "fresh_edge_id",
+    "validate",
+]

--- a/cogflow/agent/ir/builders.py
+++ b/cogflow/agent/ir/builders.py
@@ -1,0 +1,46 @@
+"""Helpers for assembling an IRGraph from the StateGraph facade."""
+
+from __future__ import annotations
+
+import itertools
+
+from .model import IREdge, IRGraph, IRNode
+
+
+_counter = itertools.count()
+
+
+def fresh_edge_id(source: str, target: str, source_handle: str | None) -> str:
+    suffix = next(_counter)
+    sh = source_handle or f"{source}-output"
+    return f"{source}-{sh}-{target}-{suffix}"
+
+
+def add_node(graph: IRGraph, node: IRNode) -> IRNode:
+    graph.nodes.append(node)
+    if node.type == "start" and graph.entry is None:
+        graph.entry = node.id
+    return node
+
+
+def add_edge(
+    graph: IRGraph,
+    source: str,
+    target: str,
+    *,
+    source_handle: str | None = None,
+    target_handle: str | None = None,
+    label: str | None = None,
+    is_human_input: bool = False,
+) -> IREdge:
+    edge = IREdge(
+        id=fresh_edge_id(source, target, source_handle),
+        source=source,
+        target=target,
+        source_handle=source_handle,
+        target_handle=target_handle,
+        label=label,
+        is_human_input=is_human_input,
+    )
+    graph.edges.append(edge)
+    return edge

--- a/cogflow/agent/ir/builders.py
+++ b/cogflow/agent/ir/builders.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import itertools
-
 from .model import IREdge, IRGraph, IRNode
 
 
-_counter = itertools.count()
+def fresh_edge_id(graph: IRGraph, source: str, target: str, source_handle: str | None) -> str:
+    """Generate an edge id that's deterministic *within* one graph.
 
-
-def fresh_edge_id(source: str, target: str, source_handle: str | None) -> str:
-    suffix = next(_counter)
+    The suffix advances a per-graph counter on ``IRGraph`` so two processes
+    building the same graph in the same order produce identical ids — which
+    matters for diffing exported Flowise JSON.
+    """
+    suffix = graph.next_edge_seq()
     sh = source_handle or f"{source}-output"
     return f"{source}-{sh}-{target}-{suffix}"
 
@@ -34,7 +35,7 @@ def add_edge(
     is_human_input: bool = False,
 ) -> IREdge:
     edge = IREdge(
-        id=fresh_edge_id(source, target, source_handle),
+        id=fresh_edge_id(graph, source, target, source_handle),
         source=source,
         target=target,
         source_handle=source_handle,

--- a/cogflow/agent/ir/model.py
+++ b/cogflow/agent/ir/model.py
@@ -1,0 +1,124 @@
+"""Intermediate Representation for cogflow.agent graphs.
+
+The IR is the single source of truth shared by:
+    - parse.flowise        (Flowise V2 AgentFlow JSON -> IR)
+    - compile.to_flowise   (IR -> Flowise V2 AgentFlow JSON)
+    - compile.to_langgraph (IR -> langgraph CompiledStateGraph)
+    - graph.StateGraph     (Python builder API mutates an IR alongside langgraph)
+
+`flowise_provenance` on every node/edge/graph captures everything we don't
+explicitly model so round-trip is lossless even for nodes whose runtime
+semantics we only partially translate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+IRNodeType = Literal[
+    "start",
+    "llm",
+    "agent",
+    "tool",
+    "condition",
+    "condition_agent",
+    "direct_reply",
+    "loop",
+    "iteration",
+    "http",
+    "retriever",
+    "custom_function",
+    "human_input",
+    "execute_flow",
+    "sticky_note",
+]
+
+IRStateType = Literal["str", "int", "float", "bool", "list", "dict", "messages"]
+
+
+class IRPort(BaseModel):
+    """An input or output anchor on an IR node."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    label: str | None = None
+    type_: str = Field("default", alias="type")
+
+
+class IRPosition(BaseModel):
+    x: float = 0.0
+    y: float = 0.0
+
+
+class IRStateField(BaseModel):
+    """One field of the shared graph state."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    type_: IRStateType = Field("str", alias="type")
+    default: Any = None
+    reducer: str | None = None  # "add_messages" | "operator.add" | None
+
+
+class IRNode(BaseModel):
+    """An IR node."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    type: IRNodeType
+    label: str
+    config: dict[str, Any] = Field(default_factory=dict)
+    inputs: list[IRPort] = Field(default_factory=list)
+    outputs: list[IRPort] = Field(default_factory=list)
+    position: IRPosition = Field(default_factory=IRPosition)
+    flowise_provenance: dict[str, Any] | None = None
+
+
+class IREdge(BaseModel):
+    """An IR edge."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    source: str
+    target: str
+    source_handle: str | None = None
+    target_handle: str | None = None
+    label: str | None = None
+    is_human_input: bool = False
+    flowise_provenance: dict[str, Any] | None = None
+
+
+class IRGraph(BaseModel):
+    """A complete graph in IR form."""
+
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: Literal["1.0"] = "1.0"
+    name: str = "agentflow"
+    description: str | None = None
+    state: list[IRStateField] = Field(default_factory=list)
+    nodes: list[IRNode] = Field(default_factory=list)
+    edges: list[IREdge] = Field(default_factory=list)
+    entry: str | None = None
+    finish: list[str] = Field(default_factory=list)
+    viewport: dict[str, float] | None = None
+    flowise_provenance: dict[str, Any] | None = None
+
+    def node_by_id(self, node_id: str) -> IRNode | None:
+        for n in self.nodes:
+            if n.id == node_id:
+                return n
+        return None
+
+    def outgoing(self, node_id: str) -> list[IREdge]:
+        return [e for e in self.edges if e.source == node_id]
+
+    def incoming(self, node_id: str) -> list[IREdge]:
+        return [e for e in self.edges if e.target == node_id]

--- a/cogflow/agent/ir/model.py
+++ b/cogflow/agent/ir/model.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 IRNodeType = Literal[
     "start",
@@ -114,6 +114,14 @@ class IRGraph(BaseModel):
     finish: list[str] = Field(default_factory=list)
     viewport: dict[str, float] | None = None
     flowise_provenance: dict[str, Any] | None = None
+
+    # Per-graph edge counter for deterministic id generation. Excluded from
+    # serialization so JSON dumps remain stable across processes.
+    _edge_counter: int = PrivateAttr(default=0)
+
+    def next_edge_seq(self) -> int:
+        self._edge_counter += 1
+        return self._edge_counter
 
     def node_by_id(self, node_id: str) -> IRNode | None:
         for n in self.nodes:

--- a/cogflow/agent/ir/model.py
+++ b/cogflow/agent/ir/model.py
@@ -33,6 +33,10 @@ IRNodeType = Literal[
     "human_input",
     "execute_flow",
     "sticky_note",
+    # Catch-all for Flowise node names we don't recognize. Lossless via
+    # provenance on export; compiles to a passthrough runtime node so the
+    # surrounding edges keep routing.
+    "unknown",
 ]
 
 IRStateType = Literal["str", "int", "float", "bool", "list", "dict", "messages"]

--- a/cogflow/agent/ir/validate.py
+++ b/cogflow/agent/ir/validate.py
@@ -1,0 +1,41 @@
+"""Topology validation for IR graphs."""
+
+from __future__ import annotations
+
+from .model import IRGraph
+
+
+class IRValidationError(ValueError):
+    """Raised when an IRGraph fails topology validation."""
+
+
+def validate(graph: IRGraph) -> None:
+    """Raise IRValidationError if the graph is structurally invalid."""
+
+    node_ids = {n.id for n in graph.nodes}
+
+    if len(node_ids) != len(graph.nodes):
+        raise IRValidationError("duplicate node ids in graph")
+
+    starts = [n for n in graph.nodes if n.type == "start"]
+    if len(starts) > 1:
+        raise IRValidationError(f"expected at most one Start node, found {len(starts)}")
+    if graph.nodes and not starts and graph.entry is None:
+        raise IRValidationError("graph has nodes but no Start node and no entry override")
+
+    if graph.entry is not None and graph.entry not in node_ids:
+        raise IRValidationError(f"entry node id {graph.entry!r} not in graph")
+
+    for fid in graph.finish:
+        if fid not in node_ids:
+            raise IRValidationError(f"finish node id {fid!r} not in graph")
+
+    edge_ids: set[str] = set()
+    for e in graph.edges:
+        if e.id in edge_ids:
+            raise IRValidationError(f"duplicate edge id {e.id!r}")
+        edge_ids.add(e.id)
+        if e.source not in node_ids:
+            raise IRValidationError(f"edge {e.id!r} source {e.source!r} missing")
+        if e.target not in node_ids:
+            raise IRValidationError(f"edge {e.id!r} target {e.target!r} missing")

--- a/cogflow/agent/ir/validate.py
+++ b/cogflow/agent/ir/validate.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from .model import IRGraph
 
+# Sentinel target for edges that terminate the graph. Matches LangGraph's
+# ``END`` (``"__end__"``) so the compile path can translate without a lookup.
+END_SENTINEL = "__end__"
+
 
 class IRValidationError(ValueError):
     """Raised when an IRGraph fails topology validation."""
@@ -37,5 +41,7 @@ def validate(graph: IRGraph) -> None:
         edge_ids.add(e.id)
         if e.source not in node_ids:
             raise IRValidationError(f"edge {e.id!r} source {e.source!r} missing")
-        if e.target not in node_ids:
+        # The END sentinel is a legitimate edge target for conditional branches
+        # that terminate; it doesn't correspond to a node.
+        if e.target != END_SENTINEL and e.target not in node_ids:
             raise IRValidationError(f"edge {e.id!r} target {e.target!r} missing")

--- a/cogflow/agent/nodes/__init__.py
+++ b/cogflow/agent/nodes/__init__.py
@@ -1,0 +1,46 @@
+"""Node factories — one per Flowise V2 AgentFlow node type.
+
+MVP-7 nodes ship in Phase 1; the remaining 8 bridge nodes are added in Phase 2.
+"""
+
+from .agent import AgentFactory, agent
+from .base import NodeFactory
+from .condition import ConditionFactory, condition
+from .condition_agent import ConditionAgentFactory, condition_agent
+from .direct_reply import DirectReplyFactory, direct_reply
+from .llm import LLMFactory, llm
+from .start import StartFactory, start
+from .sticky_note import StickyNoteFactory, sticky_note
+from .tool import ToolFactory, tool_node
+
+FACTORY_BY_IR_TYPE: dict[str, type[NodeFactory]] = {
+    "start": StartFactory,
+    "llm": LLMFactory,
+    "agent": AgentFactory,
+    "tool": ToolFactory,
+    "condition": ConditionFactory,
+    "condition_agent": ConditionAgentFactory,
+    "direct_reply": DirectReplyFactory,
+    "sticky_note": StickyNoteFactory,
+}
+
+__all__ = [
+    "AgentFactory",
+    "ConditionAgentFactory",
+    "ConditionFactory",
+    "DirectReplyFactory",
+    "FACTORY_BY_IR_TYPE",
+    "LLMFactory",
+    "NodeFactory",
+    "StartFactory",
+    "StickyNoteFactory",
+    "ToolFactory",
+    "agent",
+    "condition",
+    "condition_agent",
+    "direct_reply",
+    "llm",
+    "start",
+    "sticky_note",
+    "tool_node",
+]

--- a/cogflow/agent/nodes/agent.py
+++ b/cogflow/agent/nodes/agent.py
@@ -8,6 +8,7 @@ from langchain_core.messages import AIMessage, BaseMessage
 
 from ..ir.model import IRNode
 from .base import NodeFactory
+from .llm import _coerce_messages
 
 
 class AgentFactory(NodeFactory):
@@ -41,13 +42,17 @@ class AgentFactory(NodeFactory):
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
         model = self._model if not isinstance(self._model, str) else None
         tools = list(self._tools)
+        # Mirror LLMFactory: surface the configured prompt (Flowise
+        # ``agentMessages``) as a prefix on every invocation so system/dev
+        # prompts apply to both Python-first and JSON-loaded graphs.
+        prompts = _coerce_messages(self.config.get("agentMessages"))
 
         def agent_node(state: dict[str, Any]) -> dict[str, Any]:
             if model is None:
                 return {}
-            messages = list(state.get("messages") or [])
+            history = list(state.get("messages") or [])
             bound = model.bind_tools(tools) if tools and hasattr(model, "bind_tools") else model
-            response = bound.invoke(messages)
+            response = bound.invoke(prompts + history)
             if not isinstance(response, BaseMessage):
                 response = AIMessage(content=str(response))
             return {"messages": [response]}

--- a/cogflow/agent/nodes/agent.py
+++ b/cogflow/agent/nodes/agent.py
@@ -1,0 +1,59 @@
+"""Agent node — ReAct-style agent loop wrapped as a single node."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from langchain_core.messages import AIMessage, BaseMessage
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+
+class AgentFactory(NodeFactory):
+    ir_type = "agent"
+
+    def __init__(
+        self,
+        *,
+        model: Any = None,
+        tools: list[Any] | None = None,
+        messages: list[dict[str, str]] | None = None,
+        enable_memory: bool = True,
+        memory_type: str = "allMessages",
+        return_response_as: str = "userMessage",
+        update_state: list[dict[str, str]] | None = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            agentModel=model if isinstance(model, str) else "chatOpenAI",
+            agentMessages=messages or "",
+            agentTools="",
+            agentEnableMemory=enable_memory,
+            agentMemoryType=memory_type,
+            agentReturnResponseAs=return_response_as,
+            agentUpdateState=update_state or "",
+            **extra,
+        )
+        self._model = model
+        self._tools = tools or []
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        model = self._model if not isinstance(self._model, str) else None
+        tools = list(self._tools)
+
+        def agent_node(state: dict[str, Any]) -> dict[str, Any]:
+            if model is None:
+                return {}
+            messages = list(state.get("messages") or [])
+            bound = model.bind_tools(tools) if tools and hasattr(model, "bind_tools") else model
+            response = bound.invoke(messages)
+            if not isinstance(response, BaseMessage):
+                response = AIMessage(content=str(response))
+            return {"messages": [response]}
+
+        return agent_node
+
+
+def agent(**kwargs: Any) -> AgentFactory:
+    return AgentFactory(**kwargs)

--- a/cogflow/agent/nodes/agent.py
+++ b/cogflow/agent/nodes/agent.py
@@ -26,14 +26,16 @@ class AgentFactory(NodeFactory):
         update_state: list[dict[str, str]] | None = None,
         **extra: Any,
     ) -> None:
+        # Preserve explicit empty lists. Flowise treats "" (unset) and [] (declared
+        # empty) as different shapes; coercing one to the other breaks round-trip.
         super().__init__(
             agentModel=model if isinstance(model, str) else "chatOpenAI",
-            agentMessages=messages or "",
+            agentMessages=messages if messages is not None else "",
             agentTools="",
             agentEnableMemory=enable_memory,
             agentMemoryType=memory_type,
             agentReturnResponseAs=return_response_as,
-            agentUpdateState=update_state or "",
+            agentUpdateState=update_state if update_state is not None else "",
             **extra,
         )
         self._model = model

--- a/cogflow/agent/nodes/agent.py
+++ b/cogflow/agent/nodes/agent.py
@@ -40,8 +40,9 @@ class AgentFactory(NodeFactory):
         self._tools = tools or []
 
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
-        model = self._model if not isinstance(self._model, str) else None
-        tools = list(self._tools)
+        raw_model = getattr(self, "_model", None)
+        model = raw_model if not isinstance(raw_model, str) else None
+        tools = list(getattr(self, "_tools", []) or [])
         # Mirror LLMFactory: surface the configured prompt (Flowise
         # ``agentMessages``) as a prefix on every invocation so system/dev
         # prompts apply to both Python-first and JSON-loaded graphs.

--- a/cogflow/agent/nodes/base.py
+++ b/cogflow/agent/nodes/base.py
@@ -7,9 +7,13 @@ to Flowise JSON is delegated to ``compile.to_flowise``, which reads
 ``IRNode.flowise_provenance`` when present (lossless) and falls back to
 ``flowise_template`` (Python-first nodes).
 
-For Phase 1 the runtime callables for nodes that wrap chat models return their
-state unchanged when ``model`` is None. Real LLM wiring is exercised in tests
-via ``langchain_core.language_models.fake.FakeListChatModel``.
+For Phase 1 the runtime callables for nodes that wrap chat models return an
+empty state update when ``model`` is None. Live-LLM behaviour is verified by
+``test_compile_langgraph.test_simple_graph_invokes`` (plain Python callable
+node) and by ``test_marketplace_simple_rag`` (JSON-loaded Agent node with
+the model left unwired). Wiring against a real ``FakeListChatModel`` /
+``FakeMessagesListChatModel`` for the model-bearing factories is deferred
+to Phase 2.
 """
 
 from __future__ import annotations

--- a/cogflow/agent/nodes/base.py
+++ b/cogflow/agent/nodes/base.py
@@ -58,6 +58,24 @@ class NodeFactory(ABC):
         """The ``data.inputs`` block emitted when there's no provenance to copy."""
         return dict(node.config)
 
+    # ------------------------------------------------------------------
+    # JSON-loaded hydration
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_ir(cls, node: IRNode) -> "NodeFactory":
+        """Construct a factory instance from an IR row.
+
+        Used by ``compile.to_langgraph`` when no live factory was registered
+        for the node (i.e. the graph came from a Flowise JSON import). The
+        default implementation skips ``__init__`` so subclasses with strict
+        keyword args don't break, and seeds only the common attributes that
+        every factory's ``to_callable`` consults. Subclasses with additional
+        runtime state should override this method.
+        """
+        instance = cls.__new__(cls)
+        instance.config = dict(node.config)
+        return instance
+
 
 def passthrough(state: Any) -> dict[str, Any]:
     """Returns an empty update; useful for nodes whose runtime is stubbed."""

--- a/cogflow/agent/nodes/base.py
+++ b/cogflow/agent/nodes/base.py
@@ -1,0 +1,64 @@
+"""Base classes for node factories.
+
+A NodeFactory carries the user-provided config for one node. The runtime
+contract is intentionally minimal: ``emit_ir`` produces the IR row, and
+``to_callable`` produces the Python function LangGraph will invoke. Round-trip
+to Flowise JSON is delegated to ``compile.to_flowise``, which reads
+``IRNode.flowise_provenance`` when present (lossless) and falls back to
+``flowise_template`` (Python-first nodes).
+
+For Phase 1 the runtime callables for nodes that wrap chat models return their
+state unchanged when ``model`` is None. Real LLM wiring is exercised in tests
+via ``langchain_core.language_models.fake.FakeListChatModel``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Mapping
+
+from ..ir.model import IRNode, IRNodeType, IRPort
+from ..constants import IR_TYPE_TO_FLOWISE_CATEGORY, IR_TYPE_TO_FLOWISE_NAME
+
+
+class NodeFactory(ABC):
+    """One factory instance per ``g.add_node(name, factory)`` call."""
+
+    ir_type: IRNodeType
+
+    def __init__(self, **config: Any) -> None:
+        self.config: dict[str, Any] = dict(config)
+
+    def default_outputs(self, node_id: str) -> list[IRPort]:
+        flowise_name = IR_TYPE_TO_FLOWISE_NAME[self.ir_type]
+        return [
+            IRPort(
+                id=f"{node_id}-output-{flowise_name}",
+                name=flowise_name,
+                label=IR_TYPE_TO_FLOWISE_CATEGORY[self.ir_type],
+                type=self.ir_type,
+            )
+        ]
+
+    def emit_ir(self, node_id: str, label: str | None = None) -> IRNode:
+        return IRNode(
+            id=node_id,
+            type=self.ir_type,
+            label=label or node_id,
+            config=dict(self.config),
+            inputs=[],
+            outputs=self.default_outputs(node_id),
+        )
+
+    @abstractmethod
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        """Return a Python function suitable for ``StateGraph.add_node``."""
+
+    def flowise_inputs(self, node: IRNode) -> dict[str, Any]:
+        """The ``data.inputs`` block emitted when there's no provenance to copy."""
+        return dict(node.config)
+
+
+def passthrough(state: Any) -> dict[str, Any]:
+    """Returns an empty update; useful for nodes whose runtime is stubbed."""
+    return {}

--- a/cogflow/agent/nodes/condition.py
+++ b/cogflow/agent/nodes/condition.py
@@ -60,7 +60,9 @@ class ConditionFactory(NodeFactory):
         self._rules = rules or []
 
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
-        rules = list(self._rules)
+        # Fall back to the IR-stored ``conditionItems`` config when hydrated
+        # from JSON (no ``_rules`` attribute set).
+        rules = list(getattr(self, "_rules", None) or self.config.get("conditionItems") or [])
 
         def condition_node(state: dict[str, Any]) -> dict[str, Any]:
             for rule in rules:

--- a/cogflow/agent/nodes/condition.py
+++ b/cogflow/agent/nodes/condition.py
@@ -1,0 +1,53 @@
+"""Condition node — deterministic rule-based router."""
+
+from __future__ import annotations
+
+import operator as _op
+import re
+from typing import Any, Callable, Mapping
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    "Equal": _op.eq,
+    "NotEqual": _op.ne,
+    "Contains": lambda a, b: b in (a or ""),
+    "NotContains": lambda a, b: b not in (a or ""),
+    "StartsWith": lambda a, b: isinstance(a, str) and a.startswith(b),
+    "EndsWith": lambda a, b: isinstance(a, str) and a.endswith(b),
+    "RegexMatch": lambda a, b: bool(re.search(b, a or "")),
+    "Greater": _op.gt,
+    "Less": _op.lt,
+}
+
+
+class ConditionFactory(NodeFactory):
+    ir_type = "condition"
+
+    def __init__(
+        self,
+        *,
+        rules: list[dict[str, Any]] | None = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(conditionItems=rules or [], **extra)
+        self._rules = rules or []
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        rules = list(self._rules)
+
+        def condition_node(state: dict[str, Any]) -> dict[str, Any]:
+            for rule in rules:
+                op = _OPS.get(rule.get("operation", "Equal"), _op.eq)
+                left = state.get(rule.get("variable") or "")
+                right = rule.get("value")
+                if op(left, right):
+                    return {"_condition_branch": rule.get("output", "match")}
+            return {"_condition_branch": "default"}
+
+        return condition_node
+
+
+def condition(**kwargs: Any) -> ConditionFactory:
+    return ConditionFactory(**kwargs)

--- a/cogflow/agent/nodes/condition.py
+++ b/cogflow/agent/nodes/condition.py
@@ -9,16 +9,41 @@ from typing import Any, Callable, Mapping
 from ..ir.model import IRNode
 from .base import NodeFactory
 
+
+def _as_str(value: Any) -> str:
+    """Coerce any value to a string for string-shaped operators."""
+    if value is None:
+        return ""
+    return value if isinstance(value, str) else str(value)
+
+
+def _regex_match(a: Any, b: Any) -> bool:
+    try:
+        return bool(re.search(_as_str(b), _as_str(a)))
+    except re.error:
+        return False
+
+
+def _safe_cmp(op: Callable[[Any, Any], bool]) -> Callable[[Any, Any], bool]:
+    def cmp(a: Any, b: Any) -> bool:
+        try:
+            return op(a, b)
+        except TypeError:
+            return False
+
+    return cmp
+
+
 _OPS: dict[str, Callable[[Any, Any], bool]] = {
     "Equal": _op.eq,
     "NotEqual": _op.ne,
-    "Contains": lambda a, b: b in (a or ""),
-    "NotContains": lambda a, b: b not in (a or ""),
-    "StartsWith": lambda a, b: isinstance(a, str) and a.startswith(b),
-    "EndsWith": lambda a, b: isinstance(a, str) and a.endswith(b),
-    "RegexMatch": lambda a, b: bool(re.search(b, a or "")),
-    "Greater": _op.gt,
-    "Less": _op.lt,
+    "Contains": lambda a, b: _as_str(b) in _as_str(a),
+    "NotContains": lambda a, b: _as_str(b) not in _as_str(a),
+    "StartsWith": lambda a, b: _as_str(a).startswith(_as_str(b)),
+    "EndsWith": lambda a, b: _as_str(a).endswith(_as_str(b)),
+    "RegexMatch": _regex_match,
+    "Greater": _safe_cmp(_op.gt),
+    "Less": _safe_cmp(_op.lt),
 }
 
 

--- a/cogflow/agent/nodes/condition_agent.py
+++ b/cogflow/agent/nodes/condition_agent.py
@@ -49,10 +49,17 @@ class ConditionAgentFactory(NodeFactory):
                 HumanMessage(content="Reply with only the scenario name."),
             ]
             response = model.invoke(prompt)
-            choice = (getattr(response, "content", "") or "").strip()
-            names = [s.get("name", s.get("output")) for s in scenarios]
+            choice = (getattr(response, "content", "") or "").strip().casefold()
+            names = [s.get("name", s.get("output")) for s in scenarios if s.get("name", s.get("output"))]
+            # Prefer an exact match (case-insensitive) on the model's reply so
+            # overlapping scenario names like "approve" / "approved" don't
+            # silently route to the shorter prefix.
             for name in names:
-                if name and name in choice:
+                if name.casefold() == choice:
+                    return {"_condition_branch": name}
+            # Fall back to whole-word containment, then to the first scenario.
+            for name in names:
+                if name.casefold() in choice.split():
                     return {"_condition_branch": name}
             return {"_condition_branch": names[0] if names else "default"}
 

--- a/cogflow/agent/nodes/condition_agent.py
+++ b/cogflow/agent/nodes/condition_agent.py
@@ -1,0 +1,62 @@
+"""Condition Agent node — LLM-driven router."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+
+class ConditionAgentFactory(NodeFactory):
+    ir_type = "condition_agent"
+
+    def __init__(
+        self,
+        *,
+        model: Any = None,
+        instructions: str | None = None,
+        scenarios: list[dict[str, str]] | None = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            conditionAgentModel=model if isinstance(model, str) else "chatOpenAI",
+            conditionAgentInstructions=instructions or "",
+            conditionAgentScenarios=scenarios or [],
+            **extra,
+        )
+        self._model = model
+        self._scenarios = scenarios or []
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        model = self._model if not isinstance(self._model, str) else None
+        scenarios = list(self._scenarios)
+        instructions = self.config.get("conditionAgentInstructions", "") or ""
+
+        def condition_agent_node(state: dict[str, Any]) -> dict[str, Any]:
+            if model is None or not scenarios:
+                return {"_condition_branch": "default"}
+            scenario_text = "\n".join(
+                f"- {s.get('name', s.get('output', 'scenario'))}: {s.get('description', '')}"
+                for s in scenarios
+            )
+            prompt = [
+                SystemMessage(content=f"{instructions}\nChoose exactly one scenario name from:\n{scenario_text}"),
+                *(state.get("messages") or []),
+                HumanMessage(content="Reply with only the scenario name."),
+            ]
+            response = model.invoke(prompt)
+            choice = (getattr(response, "content", "") or "").strip()
+            names = [s.get("name", s.get("output")) for s in scenarios]
+            for name in names:
+                if name and name in choice:
+                    return {"_condition_branch": name}
+            return {"_condition_branch": names[0] if names else "default"}
+
+        return condition_agent_node
+
+
+def condition_agent(**kwargs: Any) -> ConditionAgentFactory:
+    return ConditionAgentFactory(**kwargs)

--- a/cogflow/agent/nodes/condition_agent.py
+++ b/cogflow/agent/nodes/condition_agent.py
@@ -31,8 +31,9 @@ class ConditionAgentFactory(NodeFactory):
         self._scenarios = scenarios or []
 
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
-        model = self._model if not isinstance(self._model, str) else None
-        scenarios = list(self._scenarios)
+        raw_model = getattr(self, "_model", None)
+        model = raw_model if not isinstance(raw_model, str) else None
+        scenarios = list(getattr(self, "_scenarios", None) or self.config.get("conditionAgentScenarios") or [])
         instructions = self.config.get("conditionAgentInstructions", "") or ""
 
         def condition_agent_node(state: dict[str, Any]) -> dict[str, Any]:

--- a/cogflow/agent/nodes/direct_reply.py
+++ b/cogflow/agent/nodes/direct_reply.py
@@ -1,0 +1,34 @@
+"""Direct Reply node — writes a terminal assistant message and routes to END."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from langchain_core.messages import AIMessage
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+
+class DirectReplyFactory(NodeFactory):
+    ir_type = "direct_reply"
+
+    def __init__(self, *, message: str = "", **extra: Any) -> None:
+        super().__init__(directReplyMessage=message, **extra)
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        message = self.config.get("directReplyMessage", "")
+
+        def direct_reply_node(state: dict[str, Any]) -> dict[str, Any]:
+            rendered = message
+            try:
+                rendered = message.format(**state) if message else ""
+            except (KeyError, IndexError):
+                rendered = message
+            return {"messages": [AIMessage(content=rendered)]} if rendered else {}
+
+        return direct_reply_node
+
+
+def direct_reply(**kwargs: Any) -> DirectReplyFactory:
+    return DirectReplyFactory(**kwargs)

--- a/cogflow/agent/nodes/llm.py
+++ b/cogflow/agent/nodes/llm.py
@@ -1,0 +1,73 @@
+"""LLM node — single chat-model call, no tools."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+
+def _coerce_messages(items: Any) -> list[BaseMessage]:
+    out: list[BaseMessage] = []
+    if not items:
+        return out
+    if isinstance(items, str):
+        return [SystemMessage(content=items)]
+    for entry in items:
+        if isinstance(entry, BaseMessage):
+            out.append(entry)
+            continue
+        if isinstance(entry, Mapping):
+            role = entry.get("role", "user")
+            content = entry.get("content", "")
+            if role == "system":
+                out.append(SystemMessage(content=content))
+            elif role == "assistant":
+                out.append(AIMessage(content=content))
+            else:
+                out.append(HumanMessage(content=content))
+    return out
+
+
+class LLMFactory(NodeFactory):
+    ir_type = "llm"
+
+    def __init__(
+        self,
+        *,
+        model: Any = None,
+        messages: list[dict[str, str]] | None = None,
+        update_state: list[dict[str, str]] | None = None,
+        return_response_as: str = "assistantMessage",
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            llmModel=model if isinstance(model, str) else "chatOpenAI",
+            llmMessages=messages or "",
+            llmUpdateState=update_state or "",
+            llmReturnResponseAs=return_response_as,
+            **extra,
+        )
+        self._model = model
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        model = self._model if not isinstance(self._model, str) else None
+        prompts = _coerce_messages(self.config.get("llmMessages"))
+
+        def llm_node(state: dict[str, Any]) -> dict[str, Any]:
+            history = list(state.get("messages") or [])
+            if model is None:
+                return {}
+            response = model.invoke(prompts + history)
+            if not isinstance(response, BaseMessage):
+                response = AIMessage(content=str(response))
+            return {"messages": [response]}
+
+        return llm_node
+
+
+def llm(**kwargs: Any) -> LLMFactory:
+    return LLMFactory(**kwargs)

--- a/cogflow/agent/nodes/llm.py
+++ b/cogflow/agent/nodes/llm.py
@@ -47,10 +47,12 @@ class LLMFactory(NodeFactory):
         return_response_as: str = "assistantMessage",
         **extra: Any,
     ) -> None:
+        # Preserve explicit empty lists. Flowise treats "" (unset) and [] (declared
+        # empty) as different shapes; coercing one to the other breaks round-trip.
         super().__init__(
             llmModel=model if isinstance(model, str) else "chatOpenAI",
-            llmMessages=messages or "",
-            llmUpdateState=update_state or "",
+            llmMessages=messages if messages is not None else "",
+            llmUpdateState=update_state if update_state is not None else "",
             llmReturnResponseAs=return_response_as,
             **extra,
         )

--- a/cogflow/agent/nodes/llm.py
+++ b/cogflow/agent/nodes/llm.py
@@ -57,7 +57,10 @@ class LLMFactory(NodeFactory):
         self._model = model
 
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
-        model = self._model if not isinstance(self._model, str) else None
+        # ``_model`` may be absent on instances hydrated via ``from_ir``;
+        # fall back to None so JSON-loaded nodes become passthroughs.
+        raw_model = getattr(self, "_model", None)
+        model = raw_model if not isinstance(raw_model, str) else None
         prompts = _coerce_messages(self.config.get("llmMessages"))
 
         def llm_node(state: dict[str, Any]) -> dict[str, Any]:

--- a/cogflow/agent/nodes/llm.py
+++ b/cogflow/agent/nodes/llm.py
@@ -23,7 +23,10 @@ def _coerce_messages(items: Any) -> list[BaseMessage]:
         if isinstance(entry, Mapping):
             role = entry.get("role", "user")
             content = entry.get("content", "")
-            if role == "system":
+            # Flowise's message UI exposes a ``developer`` role alongside
+            # system/assistant/user. Map it to SystemMessage so prompt intent
+            # survives import (LangChain has no first-class developer message).
+            if role in ("system", "developer"):
                 out.append(SystemMessage(content=content))
             elif role == "assistant":
                 out.append(AIMessage(content=content))

--- a/cogflow/agent/nodes/start.py
+++ b/cogflow/agent/nodes/start.py
@@ -1,0 +1,36 @@
+"""Start node — entry point of an agentflow."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from ..ir.model import IRNode
+from .base import NodeFactory, passthrough
+
+
+class StartFactory(NodeFactory):
+    ir_type = "start"
+
+    def __init__(
+        self,
+        *,
+        input_type: str = "chatInput",
+        ephemeral_memory: bool = False,
+        persist_state: bool = False,
+        state: list[dict[str, Any]] | None = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            startInputType=input_type,
+            startEphemeralMemory=ephemeral_memory,
+            startPersistState=persist_state,
+            startState=state or "",
+            **extra,
+        )
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        return passthrough
+
+
+def start(**kwargs: Any) -> StartFactory:
+    return StartFactory(**kwargs)

--- a/cogflow/agent/nodes/start.py
+++ b/cogflow/agent/nodes/start.py
@@ -20,11 +20,14 @@ class StartFactory(NodeFactory):
         state: list[dict[str, Any]] | None = None,
         **extra: Any,
     ) -> None:
+        # Flowise represents an unset ``startState`` as an empty string but an
+        # explicitly empty array as ``[]``. Only fall back to "" when the user
+        # didn't pass anything; preserve the empty-list shape when they did.
         super().__init__(
             startInputType=input_type,
             startEphemeralMemory=ephemeral_memory,
             startPersistState=persist_state,
-            startState=state or "",
+            startState=state if state is not None else "",
             **extra,
         )
 

--- a/cogflow/agent/nodes/sticky_note.py
+++ b/cogflow/agent/nodes/sticky_note.py
@@ -1,0 +1,22 @@
+"""Sticky Note node — IR-only documentation; skipped at LangGraph compile."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from ..ir.model import IRNode
+from .base import NodeFactory, passthrough
+
+
+class StickyNoteFactory(NodeFactory):
+    ir_type = "sticky_note"
+
+    def __init__(self, *, text: str = "", **extra: Any) -> None:
+        super().__init__(note=text, **extra)
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        return passthrough
+
+
+def sticky_note(**kwargs: Any) -> StickyNoteFactory:
+    return StickyNoteFactory(**kwargs)

--- a/cogflow/agent/nodes/tool.py
+++ b/cogflow/agent/nodes/tool.py
@@ -1,0 +1,46 @@
+"""Tool node — exposes a callable that an Agent node may invoke."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from ..ir.model import IRNode
+from .base import NodeFactory
+
+
+class ToolFactory(NodeFactory):
+    ir_type = "tool"
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        fn: Callable[..., Any] | None = None,
+        description: str | None = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            toolName=name or (getattr(fn, "__name__", "tool") if fn else "tool"),
+            toolDescription=description or (getattr(fn, "__doc__", "") if fn else ""),
+            **extra,
+        )
+        self._fn = fn
+
+    def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
+        fn = self._fn
+
+        def tool_node(state: dict[str, Any]) -> dict[str, Any]:
+            if fn is None:
+                return {}
+            args = state.get("tool_input") or {}
+            try:
+                result = fn(**args) if isinstance(args, Mapping) else fn(args)
+            except TypeError:
+                result = fn()
+            return {"tool_output": result}
+
+        return tool_node
+
+
+def tool_node(**kwargs: Any) -> ToolFactory:
+    return ToolFactory(**kwargs)

--- a/cogflow/agent/nodes/tool.py
+++ b/cogflow/agent/nodes/tool.py
@@ -27,7 +27,7 @@ class ToolFactory(NodeFactory):
         self._fn = fn
 
     def to_callable(self, node: IRNode, ctx: Mapping[str, Any] | None = None) -> Callable[..., Any]:
-        fn = self._fn
+        fn = getattr(self, "_fn", None)
 
         def tool_node(state: dict[str, Any]) -> dict[str, Any]:
             if fn is None:

--- a/cogflow/agent/nodes/tool.py
+++ b/cogflow/agent/nodes/tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Callable, Mapping
 
 from ..ir.model import IRNode
@@ -32,11 +33,39 @@ class ToolFactory(NodeFactory):
         def tool_node(state: dict[str, Any]) -> dict[str, Any]:
             if fn is None:
                 return {}
-            args = state.get("tool_input") or {}
+            args = state.get("tool_input")
+            # Pick the call shape from the callable's signature instead of
+            # try/except'ing TypeError — that earlier approach swallowed real
+            # TypeErrors thrown inside the tool body and could call ``fn``
+            # twice when the first call partially succeeded.
             try:
-                result = fn(**args) if isinstance(args, Mapping) else fn(args)
-            except TypeError:
+                sig = inspect.signature(fn)
+                params = sig.parameters
+            except (TypeError, ValueError):
+                # Builtins / C-implemented callables: best-effort fallback.
+                result = fn(args) if args is not None else fn()
+                return {"tool_output": result}
+
+            if not params:
                 result = fn()
+            elif isinstance(args, Mapping):
+                # Match keys to named parameters; pass everything if **kwargs
+                # is accepted, else only matching keys.
+                accepts_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+                if accepts_var_kw:
+                    result = fn(**args)
+                else:
+                    result = fn(**{k: v for k, v in args.items() if k in params})
+            elif args is None:
+                # No tool_input supplied; only call zero-arg form if signature allows.
+                positional_required = [
+                    p for p in params.values()
+                    if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                    and p.default is inspect.Parameter.empty
+                ]
+                result = fn() if not positional_required else fn(None)
+            else:
+                result = fn(args)
             return {"tool_output": result}
 
         return tool_node

--- a/cogflow/agent/parse/__init__.py
+++ b/cogflow/agent/parse/__init__.py
@@ -1,0 +1,5 @@
+"""Parsers (Flowise V2 JSON -> IR)."""
+
+from . import flowise
+
+__all__ = ["flowise"]

--- a/cogflow/agent/parse/flowise.py
+++ b/cogflow/agent/parse/flowise.py
@@ -26,9 +26,10 @@ from ..ir.model import (
 
 def _ir_type_for(name: str) -> str:
     if name not in FLOWISE_NAME_TO_IR_TYPE:
-        # Unknown node names default to sticky_note (no-op at compile) so we
-        # don't lose the JSON; provenance still round-trips exactly.
-        return "sticky_note"
+        # Unknown node names map to ``unknown`` so the compiler treats them as
+        # passthrough runtime nodes (keeps surrounding edges flowing) while
+        # ``flowise_provenance`` preserves the original JSON for round-trip.
+        return "unknown"
     return FLOWISE_NAME_TO_IR_TYPE[name]
 
 

--- a/cogflow/agent/parse/flowise.py
+++ b/cogflow/agent/parse/flowise.py
@@ -1,0 +1,144 @@
+"""Flowise V2 AgentFlow JSON -> IR.
+
+Strategy: extract the runtime-relevant fields (id, position, type, label,
+inputs) into first-class IR fields; store the full original node/edge dicts in
+``flowise_provenance`` so emitter can reconstruct byte-for-byte JSON later.
+
+The reverse direction is in ``cogflow.agent.compile.to_flowise``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..constants import FLOWISE_NAME_TO_IR_TYPE
+from ..ir.model import (
+    IREdge,
+    IRGraph,
+    IRNode,
+    IRPort,
+    IRPosition,
+    IRStateField,
+)
+
+
+def _ir_type_for(name: str) -> str:
+    if name not in FLOWISE_NAME_TO_IR_TYPE:
+        # Unknown node names default to sticky_note (no-op at compile) so we
+        # don't lose the JSON; provenance still round-trips exactly.
+        return "sticky_note"
+    return FLOWISE_NAME_TO_IR_TYPE[name]
+
+
+def _coerce_inputs(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _ports(raw: list[Any] | None) -> list[IRPort]:
+    if not raw:
+        return []
+    out: list[IRPort] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        out.append(
+            IRPort(
+                id=entry.get("id", ""),
+                name=entry.get("name", ""),
+                label=entry.get("label"),
+                type=entry.get("type", "default"),
+            )
+        )
+    return out
+
+
+def _state_from_start(inputs: dict[str, Any]) -> list[IRStateField]:
+    raw = inputs.get("startState")
+    out: list[IRStateField] = []
+    if not isinstance(raw, list):
+        return out
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get("key")
+        if not key:
+            continue
+        out.append(IRStateField(key=key, default=entry.get("value")))
+    # always ensure ``messages`` exists with the add_messages reducer so chat
+    # semantics work regardless of whether the user explicitly declared it.
+    if not any(f.key == "messages" for f in out):
+        out.append(IRStateField(key="messages", type="messages", reducer="add_messages"))
+    return out
+
+
+def from_dict(raw: dict[str, Any]) -> IRGraph:
+    """Parse a Flowise V2 AgentFlow JSON dict into an IRGraph."""
+    graph = IRGraph(
+        description=raw.get("description"),
+        viewport=raw.get("viewport"),
+        flowise_provenance={
+            "usecases": raw.get("usecases"),
+            # keep any unknown top-level keys
+            "extra": {k: v for k, v in raw.items() if k not in {"description", "usecases", "nodes", "edges", "viewport"}},
+        },
+    )
+
+    state_set = False
+    for raw_node in raw.get("nodes") or []:
+        data = raw_node.get("data") or {}
+        name = data.get("name") or ""
+        ir_type = _ir_type_for(name)
+        inputs = _coerce_inputs(data.get("inputs"))
+        position = raw_node.get("position") or {}
+
+        if ir_type == "start" and not state_set:
+            graph.state = _state_from_start(inputs)
+            state_set = True
+
+        node = IRNode(
+            id=raw_node.get("id") or data.get("id") or "",
+            type=ir_type,
+            label=data.get("label") or raw_node.get("id") or "",
+            config=dict(inputs),
+            inputs=_ports(data.get("inputAnchors")),
+            outputs=_ports(data.get("outputAnchors")),
+            position=IRPosition(x=position.get("x", 0.0), y=position.get("y", 0.0)),
+            flowise_provenance={"node": raw_node},
+        )
+        graph.nodes.append(node)
+        if ir_type == "start" and graph.entry is None:
+            graph.entry = node.id
+
+    for raw_edge in raw.get("edges") or []:
+        data = raw_edge.get("data") or {}
+        graph.edges.append(
+            IREdge(
+                id=raw_edge.get("id", ""),
+                source=raw_edge.get("source", ""),
+                target=raw_edge.get("target", ""),
+                source_handle=raw_edge.get("sourceHandle"),
+                target_handle=raw_edge.get("targetHandle"),
+                is_human_input=bool(data.get("isHumanInput")),
+                flowise_provenance={"edge": raw_edge},
+            )
+        )
+
+    # If a chat-style graph has no explicit ``messages`` reducer in the Start
+    # node, still ensure runtime state has one (mirrors LangGraph defaults).
+    if not state_set and not any(f.key == "messages" for f in graph.state):
+        graph.state.append(IRStateField(key="messages", type="messages", reducer="add_messages"))
+
+    return graph
+
+
+def from_file(path: str | Path) -> IRGraph:
+    """Read a Flowise V2 JSON file and parse it into an IRGraph."""
+    p = Path(path)
+    return from_dict(json.loads(p.read_text()))
+
+
+__all__ = ["from_dict", "from_file"]

--- a/cogflow/agent/parse/flowise.py
+++ b/cogflow/agent/parse/flowise.py
@@ -59,19 +59,24 @@ def _ports(raw: list[Any] | None) -> list[IRPort]:
 def _state_from_start(inputs: dict[str, Any]) -> list[IRStateField]:
     raw = inputs.get("startState")
     out: list[IRStateField] = []
-    if not isinstance(raw, list):
-        return out
-    for entry in raw:
-        if not isinstance(entry, dict):
-            continue
-        key = entry.get("key")
-        if not key:
-            continue
-        out.append(IRStateField(key=key, default=entry.get("value")))
-    # always ensure ``messages`` exists with the add_messages reducer so chat
-    # semantics work regardless of whether the user explicitly declared it.
-    if not any(f.key == "messages" for f in out):
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            key = entry.get("key")
+            if not key:
+                continue
+            out.append(IRStateField(key=key, default=entry.get("value")))
+
+    # Always normalize the ``messages`` field to type=messages + add_messages.
+    # Whether the user declared it explicitly or not, LangGraph needs the
+    # reducer to preserve chat semantics across nodes.
+    existing = next((f for f in out if f.key == "messages"), None)
+    if existing is None:
         out.append(IRStateField(key="messages", type="messages", reducer="add_messages"))
+    else:
+        existing.type_ = "messages"
+        existing.reducer = "add_messages"
     return out
 
 

--- a/cogflow/agent/parse/flowise.py
+++ b/cogflow/agent/parse/flowise.py
@@ -128,6 +128,11 @@ def from_dict(raw: dict[str, Any]) -> IRGraph:
                 target=raw_edge.get("target", ""),
                 source_handle=raw_edge.get("sourceHandle"),
                 target_handle=raw_edge.get("targetHandle"),
+                # ``edgeLabel`` carries the Condition / ConditionAgent branch
+                # name. ``compile.to_langgraph`` reads ``edge.label`` to build
+                # ``add_conditional_edges`` routing, so dropping this would
+                # silently mis-route imported conditional flows.
+                label=data.get("edgeLabel"),
                 is_human_input=bool(data.get("isHumanInput")),
                 flowise_provenance={"edge": raw_edge},
             )

--- a/cogflow/agent/parse/schema.py
+++ b/cogflow/agent/parse/schema.py
@@ -1,0 +1,75 @@
+"""Pydantic mirror of the Flowise V2 AgentFlow JSON shape.
+
+Mirrors ``packages/agentflow/src/core/types/index.ts`` in the Flowise source.
+We use ``extra='allow'`` so we never reject a JSON field — anything we don't
+model passes through into IR provenance and is re-emitted on export.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FlowisePosition(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    x: float = 0.0
+    y: float = 0.0
+
+
+class FlowiseAnchor(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: str
+    name: str
+    label: str | None = None
+    type: str | None = None
+
+
+class FlowiseNodeData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: str
+    name: str  # discriminator: startAgentflow, llmAgentflow, ...
+    label: str = ""
+    type: str | None = None
+    inputs: dict[str, Any] | str = Field(default_factory=dict)
+    inputAnchors: list[FlowiseAnchor] = Field(default_factory=list)
+    outputAnchors: list[FlowiseAnchor] = Field(default_factory=list)
+
+
+class FlowiseNode(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: str
+    type: str | None = "agentFlow"
+    position: FlowisePosition = Field(default_factory=FlowisePosition)
+    data: FlowiseNodeData
+    width: float | None = None
+    height: float | None = None
+
+
+class FlowiseEdgeData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    sourceColor: str | None = None
+    targetColor: str | None = None
+    edgeLabel: str | None = None
+    isHumanInput: bool | None = None
+
+
+class FlowiseEdge(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: str
+    source: str
+    target: str
+    sourceHandle: str | None = None
+    targetHandle: str | None = None
+    type: str | None = "agentFlow"
+    data: FlowiseEdgeData | None = None
+
+
+class FlowiseFlow(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    description: str | None = None
+    usecases: list[str] | None = None
+    nodes: list[FlowiseNode] = Field(default_factory=list)
+    edges: list[FlowiseEdge] = Field(default_factory=list)
+    viewport: dict[str, float] | None = None

--- a/cogflow/agent/prebuilt.py
+++ b/cogflow/agent/prebuilt.py
@@ -1,0 +1,10 @@
+"""Re-exports of LangGraph prebuilt helpers.
+
+A future Phase-3 wrapper will replace ``create_react_agent`` with a version that
+also emits proper IR. For Phase 1 we expose it as-is so the migration table
+holds: ``from cogflow.agent.prebuilt import create_react_agent``.
+"""
+
+from langgraph.prebuilt import create_react_agent
+
+__all__ = ["create_react_agent"]

--- a/cogflow/agent/runtime/__init__.py
+++ b/cogflow/agent/runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime helpers (checkpointers, invoke shortcuts)."""
+
+from .checkpoint import MemorySaver, SqliteSaver
+from .invoke import ainvoke, astream, invoke, stream
+
+__all__ = ["MemorySaver", "SqliteSaver", "ainvoke", "astream", "invoke", "stream"]

--- a/cogflow/agent/runtime/checkpoint.py
+++ b/cogflow/agent/runtime/checkpoint.py
@@ -1,0 +1,10 @@
+"""Re-exports of LangGraph checkpointers."""
+
+from langgraph.checkpoint.memory import MemorySaver
+
+try:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+except ImportError:  # pragma: no cover - optional sqlite extra
+    SqliteSaver = None  # type: ignore[assignment]
+
+__all__ = ["MemorySaver", "SqliteSaver"]

--- a/cogflow/agent/runtime/invoke.py
+++ b/cogflow/agent/runtime/invoke.py
@@ -1,0 +1,33 @@
+"""Thin pass-through wrappers for the LangGraph runnable interface.
+
+A compiled cogflow.agent graph is just a ``langgraph.graph.CompiledStateGraph``;
+nothing here needs to do real work. The wrappers exist so users can import the
+helpers from ``cogflow.agent.runtime.invoke`` in scripts that don't already hold
+a reference to the compiled graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def invoke(app: Any, inputs: dict[str, Any], *, config: dict[str, Any] | None = None) -> dict[str, Any]:
+    return app.invoke(inputs, config=config)
+
+
+def stream(app: Any, inputs: dict[str, Any], *, config: dict[str, Any] | None = None):
+    yield from app.stream(inputs, config=config)
+
+
+async def ainvoke(
+    app: Any, inputs: dict[str, Any], *, config: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return await app.ainvoke(inputs, config=config)
+
+
+async def astream(app: Any, inputs: dict[str, Any], *, config: dict[str, Any] | None = None):
+    async for step in app.astream(inputs, config=config):
+        yield step
+
+
+__all__ = ["ainvoke", "astream", "invoke", "stream"]

--- a/cogflow/agent/state.py
+++ b/cogflow/agent/state.py
@@ -92,9 +92,14 @@ def introspect_state(state_schema: type | None) -> list[IRStateField]:
         else:
             type_ir = _python_type_to_ir(hint)
 
-        if key == "messages" and reducer_name is None:
-            reducer_name = "add_messages"
+        # Always normalize the ``messages`` channel: type=messages and the
+        # ``add_messages`` reducer. Mirrors ``parse.flowise._state_from_start``
+        # so introspect(TypedDict) ↔ Flowise startState round-trips through
+        # IR with a single canonical shape.
+        if key == "messages":
             type_ir = "messages"
+            if reducer_name is None:
+                reducer_name = "add_messages"
         out.append(IRStateField(key=key, type=type_ir, reducer=reducer_name))
     return out
 

--- a/cogflow/agent/state.py
+++ b/cogflow/agent/state.py
@@ -1,0 +1,129 @@
+"""State / channel / reducer plumbing.
+
+LangGraph's runtime state is a TypedDict. Fields may carry a reducer via
+``Annotated[T, reducer]`` (e.g. ``add_messages`` for chat history). Flowise V2
+declares state instead as a list of ``{key, value}`` pairs on the Start node's
+``startState`` input. This module bridges both forms through ``IRStateField``.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Annotated, Any, Iterable, get_args, get_origin, get_type_hints
+
+from langgraph.graph import MessagesState as _LangGraphMessagesState
+from langgraph.graph import add_messages as _add_messages
+
+from .ir.model import IRStateField, IRStateType
+
+# Re-exports so users can ``from cogflow.agent import MessagesState, add_messages``.
+MessagesState = _LangGraphMessagesState
+add_messages = _add_messages
+
+
+_REDUCER_REGISTRY: dict[str, Any] = {
+    "add_messages": add_messages,
+    "operator.add": operator.add,
+}
+
+
+def register_reducer(name: str, fn: Any) -> None:
+    _REDUCER_REGISTRY[name] = fn
+
+
+def reducer_by_name(name: str | None) -> Any:
+    if name is None:
+        return None
+    if name not in _REDUCER_REGISTRY:
+        raise KeyError(f"unknown reducer {name!r}; register with register_reducer()")
+    return _REDUCER_REGISTRY[name]
+
+
+def _reducer_name(fn: Any) -> str | None:
+    """Best-effort identification of a known reducer callable."""
+    for name, registered in _REDUCER_REGISTRY.items():
+        if fn is registered:
+            return name
+    mod = getattr(fn, "__module__", "")
+    qual = getattr(fn, "__qualname__", "")
+    if mod == "operator" and qual == "add":
+        return "operator.add"
+    return None
+
+
+_TYPE_TO_IR: dict[type, IRStateType] = {
+    str: "str",
+    int: "int",
+    float: "float",
+    bool: "bool",
+    list: "list",
+    dict: "dict",
+}
+
+
+def _python_type_to_ir(tp: Any) -> IRStateType:
+    origin = get_origin(tp) or tp
+    if origin in _TYPE_TO_IR:
+        return _TYPE_TO_IR[origin]
+    return "str"
+
+
+def introspect_state(state_schema: type | None) -> list[IRStateField]:
+    """Convert a TypedDict (optionally with Annotated reducers) into IRStateFields."""
+    if state_schema is None:
+        return []
+    try:
+        hints = get_type_hints(state_schema, include_extras=True)
+    except Exception:
+        return []
+
+    out: list[IRStateField] = []
+    for key, hint in hints.items():
+        reducer_name: str | None = None
+        type_ir: IRStateType = "str"
+        if get_origin(hint) is Annotated:
+            base, *meta = get_args(hint)
+            type_ir = _python_type_to_ir(base)
+            for m in meta:
+                name = _reducer_name(m)
+                if name is not None:
+                    reducer_name = name
+                    break
+        else:
+            type_ir = _python_type_to_ir(hint)
+
+        if key == "messages" and reducer_name is None:
+            reducer_name = "add_messages"
+            type_ir = "messages"
+        out.append(IRStateField(key=key, type=type_ir, reducer=reducer_name))
+    return out
+
+
+_IR_TYPE_TO_PY: dict[IRStateType, type] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "messages": list,
+}
+
+
+def synthesize_typeddict(fields: Iterable[IRStateField], name: str = "FlowState") -> type:
+    """Build a TypedDict class from IRStateField list at runtime.
+
+    Annotated reducers are reattached so LangGraph's channel system works
+    unchanged (``add_messages``, ``operator.add``, …).
+    """
+    from typing import TypedDict  # local import to keep top-level clean
+
+    annotations: dict[str, Any] = {}
+    for f in fields:
+        base = _IR_TYPE_TO_PY.get(f.type_, str)
+        if f.reducer is not None:
+            annotations[f.key] = Annotated[base, reducer_by_name(f.reducer)]
+        else:
+            annotations[f.key] = base
+
+    return TypedDict(name, annotations, total=False)  # type: ignore[operator]

--- a/cogflow/agent/tests/conftest.py
+++ b/cogflow/agent/tests/conftest.py
@@ -1,4 +1,12 @@
-"""Shared fixtures for cogflow.agent tests."""
+"""Shared fixtures for cogflow.agent tests.
+
+Marketplace JSON fixtures are vendored under ``fixtures/`` so the test suite
+runs anywhere — no dependence on an external Flowise checkout.
+
+The whole suite skips early if ``langgraph`` isn't installed, so a plain
+``pytest`` run on a base ``cogflow`` install (without the ``agent`` extra)
+collects without failing.
+"""
 
 from __future__ import annotations
 
@@ -6,27 +14,28 @@ from pathlib import Path
 
 import pytest
 
+# Ensure agent SDK deps are available before collecting any tests in this dir.
+pytest.importorskip("langgraph", reason="cogflow.agent tests require `pip install cogflow[agent]`")
 
-MARKETPLACE_DIR = Path(
-    "/home/ali/project/coge/flow/src_flowise/Flowise/packages/server/marketplaces/agentflowsv2"
-)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(scope="session")
 def marketplace_dir() -> Path:
-    return MARKETPLACE_DIR
+    return FIXTURE_DIR
 
 
 @pytest.fixture(scope="session")
 def simple_rag_path(marketplace_dir: Path) -> Path:
-    return marketplace_dir / "Simple RAG.json"
+    return marketplace_dir / "simple_rag.json"
 
 
 @pytest.fixture(scope="session")
 def structured_output_path(marketplace_dir: Path) -> Path:
-    return marketplace_dir / "Structured Output.json"
+    return marketplace_dir / "structured_output.json"
 
 
 @pytest.fixture(scope="session")
 def translator_path(marketplace_dir: Path) -> Path:
-    return marketplace_dir / "Translator.json"
+    return marketplace_dir / "translator.json"

--- a/cogflow/agent/tests/conftest.py
+++ b/cogflow/agent/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures for cogflow.agent tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+MARKETPLACE_DIR = Path(
+    "/home/ali/project/coge/flow/src_flowise/Flowise/packages/server/marketplaces/agentflowsv2"
+)
+
+
+@pytest.fixture(scope="session")
+def marketplace_dir() -> Path:
+    return MARKETPLACE_DIR
+
+
+@pytest.fixture(scope="session")
+def simple_rag_path(marketplace_dir: Path) -> Path:
+    return marketplace_dir / "Simple RAG.json"
+
+
+@pytest.fixture(scope="session")
+def structured_output_path(marketplace_dir: Path) -> Path:
+    return marketplace_dir / "Structured Output.json"
+
+
+@pytest.fixture(scope="session")
+def translator_path(marketplace_dir: Path) -> Path:
+    return marketplace_dir / "Translator.json"

--- a/cogflow/agent/tests/conftest.py
+++ b/cogflow/agent/tests/conftest.py
@@ -14,8 +14,11 @@ from pathlib import Path
 
 import pytest
 
-# Ensure agent SDK deps are available before collecting any tests in this dir.
+# Ensure the full agent SDK dep set is available before collecting any tests
+# in this dir. Both deps come from the ``agent`` extra; skip if either is
+# missing so the suite can never half-collect on a partial install.
 pytest.importorskip("langgraph", reason="cogflow.agent tests require `pip install cogflow[agent]`")
+pytest.importorskip("langchain_core", reason="cogflow.agent tests require `pip install cogflow[agent]`")
 
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"

--- a/cogflow/agent/tests/fixtures/simple_rag.json
+++ b/cogflow/agent/tests/fixtures/simple_rag.json
@@ -1,0 +1,628 @@
+{
+    "description": "A basic RAG agent that can retrieve documents from document store and answer questions",
+    "usecases": ["Documents QnA"],
+    "nodes": [
+        {
+            "id": "startAgentflow_0",
+            "type": "agentFlow",
+            "position": {
+                "x": 64,
+                "y": 98.5
+            },
+            "data": {
+                "id": "startAgentflow_0",
+                "label": "Start",
+                "version": 1.1,
+                "name": "startAgentflow",
+                "type": "Start",
+                "color": "#7EE787",
+                "hideInput": true,
+                "baseClasses": ["Start"],
+                "category": "Agent Flows",
+                "description": "Starting point of the agentflow",
+                "inputParams": [
+                    {
+                        "label": "Input Type",
+                        "name": "startInputType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "Chat Input",
+                                "name": "chatInput",
+                                "description": "Start the conversation with chat input"
+                            },
+                            {
+                                "label": "Form Input",
+                                "name": "formInput",
+                                "description": "Start the workflow with form inputs"
+                            }
+                        ],
+                        "default": "chatInput",
+                        "id": "startAgentflow_0-input-startInputType-options",
+                        "display": true
+                    },
+                    {
+                        "label": "Form Title",
+                        "name": "formTitle",
+                        "type": "string",
+                        "placeholder": "Please Fill Out The Form",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formTitle-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Description",
+                        "name": "formDescription",
+                        "type": "string",
+                        "placeholder": "Complete all fields below to continue",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formDescription-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Input Types",
+                        "name": "formInputTypes",
+                        "description": "Specify the type of form input",
+                        "type": "array",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "array": [
+                            {
+                                "label": "Type",
+                                "name": "type",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "String",
+                                        "name": "string"
+                                    },
+                                    {
+                                        "label": "Number",
+                                        "name": "number"
+                                    },
+                                    {
+                                        "label": "Boolean",
+                                        "name": "boolean"
+                                    },
+                                    {
+                                        "label": "Options",
+                                        "name": "options"
+                                    }
+                                ],
+                                "default": "string"
+                            },
+                            {
+                                "label": "Label",
+                                "name": "label",
+                                "type": "string",
+                                "placeholder": "Label for the input"
+                            },
+                            {
+                                "label": "Variable Name",
+                                "name": "name",
+                                "type": "string",
+                                "placeholder": "Variable name for the input (must be camel case)",
+                                "description": "Variable name must be camel case. For example: firstName, lastName, etc."
+                            },
+                            {
+                                "label": "Add Options",
+                                "name": "addOptions",
+                                "type": "array",
+                                "show": {
+                                    "formInputTypes[$index].type": "options"
+                                },
+                                "array": [
+                                    {
+                                        "label": "Option",
+                                        "name": "option",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-formInputTypes-array",
+                        "display": false
+                    },
+                    {
+                        "label": "Ephemeral Memory",
+                        "name": "startEphemeralMemory",
+                        "type": "boolean",
+                        "description": "Start fresh for every execution without past chat history",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startEphemeralMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Flow State",
+                        "name": "startState",
+                        "description": "Runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "string",
+                                "placeholder": "Foo"
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "placeholder": "Bar",
+                                "optional": true
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-startState-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Persist State",
+                        "name": "startPersistState",
+                        "type": "boolean",
+                        "description": "Persist the state in the same session",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startPersistState-boolean",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "startInputType": "chatInput",
+                    "formTitle": "",
+                    "formDescription": "",
+                    "formInputTypes": "",
+                    "startEphemeralMemory": "",
+                    "startState": "",
+                    "startPersistState": ""
+                },
+                "outputAnchors": [
+                    {
+                        "id": "startAgentflow_0-output-startAgentflow",
+                        "label": "Start",
+                        "name": "startAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "width": 103,
+            "height": 66,
+            "positionAbsolute": {
+                "x": 64,
+                "y": 98.5
+            },
+            "selected": false,
+            "dragging": false
+        },
+        {
+            "id": "agentAgentflow_0",
+            "position": {
+                "x": 216.75,
+                "y": 96.5
+            },
+            "data": {
+                "id": "agentAgentflow_0",
+                "label": "QnA",
+                "version": 1,
+                "name": "agentAgentflow",
+                "type": "Agent",
+                "color": "#4DD0E1",
+                "baseClasses": ["Agent"],
+                "category": "Agent Flows",
+                "description": "Dynamically choose and utilize tools during runtime, enabling multi-step reasoning",
+                "inputParams": [
+                    {
+                        "label": "Model",
+                        "name": "agentModel",
+                        "type": "asyncOptions",
+                        "loadMethod": "listModels",
+                        "loadConfig": true,
+                        "id": "agentAgentflow_0-input-agentModel-asyncOptions",
+                        "display": true
+                    },
+                    {
+                        "label": "Messages",
+                        "name": "agentMessages",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Role",
+                                "name": "role",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "System",
+                                        "name": "system"
+                                    },
+                                    {
+                                        "label": "Assistant",
+                                        "name": "assistant"
+                                    },
+                                    {
+                                        "label": "Developer",
+                                        "name": "developer"
+                                    },
+                                    {
+                                        "label": "User",
+                                        "name": "user"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Content",
+                                "name": "content",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "generateInstruction": true,
+                                "rows": 4
+                            }
+                        ],
+                        "id": "agentAgentflow_0-input-agentMessages-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Tools",
+                        "name": "agentTools",
+                        "type": "array",
+                        "optional": true,
+                        "array": [
+                            {
+                                "label": "Tool",
+                                "name": "agentSelectedTool",
+                                "type": "asyncOptions",
+                                "loadMethod": "listTools",
+                                "loadConfig": true
+                            },
+                            {
+                                "label": "Require Human Input",
+                                "name": "agentSelectedToolRequiresHumanInput",
+                                "type": "boolean",
+                                "optional": true
+                            }
+                        ],
+                        "id": "agentAgentflow_0-input-agentTools-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Knowledge (Document Stores)",
+                        "name": "agentKnowledgeDocumentStores",
+                        "type": "array",
+                        "description": "Give your agent context about different document sources. Document stores must be upserted in advance.",
+                        "array": [
+                            {
+                                "label": "Document Store",
+                                "name": "documentStore",
+                                "type": "asyncOptions",
+                                "loadMethod": "listStores"
+                            },
+                            {
+                                "label": "Describe Knowledge",
+                                "name": "docStoreDescription",
+                                "type": "string",
+                                "generateDocStoreDescription": true,
+                                "placeholder": "Describe what the knowledge base is about, this is useful for the AI to know when and how to search for correct information",
+                                "rows": 4
+                            },
+                            {
+                                "label": "Return Source Documents",
+                                "name": "returnSourceDocuments",
+                                "type": "boolean",
+                                "optional": true
+                            }
+                        ],
+                        "optional": true,
+                        "id": "agentAgentflow_0-input-agentKnowledgeDocumentStores-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Knowledge (Vector Embeddings)",
+                        "name": "agentKnowledgeVSEmbeddings",
+                        "type": "array",
+                        "description": "Give your agent context about different document sources from existing vector stores and embeddings",
+                        "array": [
+                            {
+                                "label": "Vector Store",
+                                "name": "vectorStore",
+                                "type": "asyncOptions",
+                                "loadMethod": "listVectorStores",
+                                "loadConfig": true
+                            },
+                            {
+                                "label": "Embedding Model",
+                                "name": "embeddingModel",
+                                "type": "asyncOptions",
+                                "loadMethod": "listEmbeddings",
+                                "loadConfig": true
+                            },
+                            {
+                                "label": "Knowledge Name",
+                                "name": "knowledgeName",
+                                "type": "string",
+                                "placeholder": "A short name for the knowledge base, this is useful for the AI to know when and how to search for correct information"
+                            },
+                            {
+                                "label": "Describe Knowledge",
+                                "name": "knowledgeDescription",
+                                "type": "string",
+                                "placeholder": "Describe what the knowledge base is about, this is useful for the AI to know when and how to search for correct information",
+                                "rows": 4
+                            },
+                            {
+                                "label": "Return Source Documents",
+                                "name": "returnSourceDocuments",
+                                "type": "boolean",
+                                "optional": true
+                            }
+                        ],
+                        "optional": true,
+                        "id": "agentAgentflow_0-input-agentKnowledgeVSEmbeddings-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Enable Memory",
+                        "name": "agentEnableMemory",
+                        "type": "boolean",
+                        "description": "Enable memory for the conversation thread",
+                        "default": true,
+                        "optional": true,
+                        "id": "agentAgentflow_0-input-agentEnableMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Memory Type",
+                        "name": "agentMemoryType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "All Messages",
+                                "name": "allMessages",
+                                "description": "Retrieve all messages from the conversation"
+                            },
+                            {
+                                "label": "Window Size",
+                                "name": "windowSize",
+                                "description": "Uses a fixed window size to surface the last N messages"
+                            },
+                            {
+                                "label": "Conversation Summary",
+                                "name": "conversationSummary",
+                                "description": "Summarizes the whole conversation"
+                            },
+                            {
+                                "label": "Conversation Summary Buffer",
+                                "name": "conversationSummaryBuffer",
+                                "description": "Summarize conversations once token limit is reached. Default to 2000"
+                            }
+                        ],
+                        "optional": true,
+                        "default": "allMessages",
+                        "show": {
+                            "agentEnableMemory": true
+                        },
+                        "id": "agentAgentflow_0-input-agentMemoryType-options",
+                        "display": true
+                    },
+                    {
+                        "label": "Window Size",
+                        "name": "agentMemoryWindowSize",
+                        "type": "number",
+                        "default": "20",
+                        "description": "Uses a fixed window size to surface the last N messages",
+                        "show": {
+                            "agentMemoryType": "windowSize"
+                        },
+                        "id": "agentAgentflow_0-input-agentMemoryWindowSize-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Max Token Limit",
+                        "name": "agentMemoryMaxTokenLimit",
+                        "type": "number",
+                        "default": "2000",
+                        "description": "Summarize conversations once token limit is reached. Default to 2000",
+                        "show": {
+                            "agentMemoryType": "conversationSummaryBuffer"
+                        },
+                        "id": "agentAgentflow_0-input-agentMemoryMaxTokenLimit-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Input Message",
+                        "name": "agentUserMessage",
+                        "type": "string",
+                        "description": "Add an input message as user message at the end of the conversation",
+                        "rows": 4,
+                        "optional": true,
+                        "acceptVariable": true,
+                        "show": {
+                            "agentEnableMemory": true
+                        },
+                        "id": "agentAgentflow_0-input-agentUserMessage-string",
+                        "display": true
+                    },
+                    {
+                        "label": "Return Response As",
+                        "name": "agentReturnResponseAs",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "User Message",
+                                "name": "userMessage"
+                            },
+                            {
+                                "label": "Assistant Message",
+                                "name": "assistantMessage"
+                            }
+                        ],
+                        "default": "userMessage",
+                        "id": "agentAgentflow_0-input-agentReturnResponseAs-options",
+                        "display": true
+                    },
+                    {
+                        "label": "Update Flow State",
+                        "name": "agentUpdateState",
+                        "description": "Update runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "asyncOptions",
+                                "loadMethod": "listRuntimeStateKeys",
+                                "freeSolo": true
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "acceptNodeOutputAsVariable": true
+                            }
+                        ],
+                        "id": "agentAgentflow_0-input-agentUpdateState-array",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "agentModel": "chatOpenAI",
+                    "agentMessages": [
+                        {
+                            "role": "system",
+                            "content": "<p>You are a helpful assistant. Using the provided context, answer the user's question to the best of your ability using the resources provided.</p><p>If there is nothing in the context relevant to the question at hand, just say \"Hmm, I'm not sure.\" Don't try to make up an answer.</p>"
+                        }
+                    ],
+                    "agentTools": "",
+                    "agentKnowledgeDocumentStores": [
+                        {
+                            "documentStore": "25429b8f-0377-4762-9cda-0d5366cf022c:AI-Paper",
+                            "docStoreDescription": "This paper provides an extensive overview of artificial intelligence-generated content (AIGC), including its definition, capabilities, applications, challenges, and future directions, serving as a valuable resource for researchers and industry professionals to understand and harness AIGC's potential.",
+                            "returnSourceDocuments": true
+                        }
+                    ],
+                    "agentKnowledgeVSEmbeddings": "",
+                    "agentEnableMemory": true,
+                    "agentMemoryType": "allMessages",
+                    "agentUserMessage": "",
+                    "agentReturnResponseAs": "userMessage",
+                    "agentUpdateState": "",
+                    "agentModelConfig": {
+                        "cache": "",
+                        "modelName": "gpt-4o-mini",
+                        "temperature": 0.9,
+                        "streaming": true,
+                        "maxTokens": "",
+                        "topP": "",
+                        "frequencyPenalty": "",
+                        "presencePenalty": "",
+                        "timeout": "",
+                        "strictToolCalling": "",
+                        "stopSequence": "",
+                        "basepath": "",
+                        "proxyUrl": "",
+                        "baseOptions": "",
+                        "allowImageUploads": "",
+                        "imageResolution": "low",
+                        "reasoningEffort": "",
+                        "agentModel": "chatOpenAI"
+                    }
+                },
+                "outputAnchors": [
+                    {
+                        "id": "agentAgentflow_0-output-agentAgentflow",
+                        "label": "Agent",
+                        "name": "agentAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "type": "agentFlow",
+            "width": 175,
+            "height": 72,
+            "selected": false,
+            "positionAbsolute": {
+                "x": 216.75,
+                "y": 96.5
+            },
+            "dragging": false
+        },
+        {
+            "id": "stickyNoteAgentflow_0",
+            "position": {
+                "x": 209.875,
+                "y": -61.25
+            },
+            "data": {
+                "id": "stickyNoteAgentflow_0",
+                "label": "Sticky Note",
+                "version": 1,
+                "name": "stickyNoteAgentflow",
+                "type": "StickyNote",
+                "color": "#fee440",
+                "baseClasses": ["StickyNote"],
+                "category": "Agent Flows",
+                "description": "Add notes to the agent flow",
+                "inputParams": [
+                    {
+                        "label": "",
+                        "name": "note",
+                        "type": "string",
+                        "rows": 1,
+                        "placeholder": "Type something here",
+                        "optional": true,
+                        "id": "stickyNoteAgentflow_0-input-note-string",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "note": "Agent can retrieve documents from upserted document store, and directly from vector database"
+                },
+                "outputAnchors": [
+                    {
+                        "id": "stickyNoteAgentflow_0-output-stickyNoteAgentflow",
+                        "label": "Sticky Note",
+                        "name": "stickyNoteAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "type": "stickyNote",
+            "width": 210,
+            "height": 143,
+            "selected": false,
+            "positionAbsolute": {
+                "x": 209.875,
+                "y": -61.25
+            },
+            "dragging": false
+        }
+    ],
+    "edges": [
+        {
+            "source": "startAgentflow_0",
+            "sourceHandle": "startAgentflow_0-output-startAgentflow",
+            "target": "agentAgentflow_0",
+            "targetHandle": "agentAgentflow_0",
+            "data": {
+                "sourceColor": "#7EE787",
+                "targetColor": "#4DD0E1",
+                "isHumanInput": false
+            },
+            "type": "agentFlow",
+            "id": "startAgentflow_0-startAgentflow_0-output-startAgentflow-agentAgentflow_0-agentAgentflow_0"
+        }
+    ]
+}

--- a/cogflow/agent/tests/fixtures/structured_output.json
+++ b/cogflow/agent/tests/fixtures/structured_output.json
@@ -1,0 +1,549 @@
+{
+    "description": "Return structured output from LLM",
+    "usecases": ["Extraction"],
+    "nodes": [
+        {
+            "id": "startAgentflow_0",
+            "type": "agentFlow",
+            "position": {
+                "x": 64,
+                "y": 98.5
+            },
+            "data": {
+                "id": "startAgentflow_0",
+                "label": "Start",
+                "version": 1.1,
+                "name": "startAgentflow",
+                "type": "Start",
+                "color": "#7EE787",
+                "hideInput": true,
+                "baseClasses": ["Start"],
+                "category": "Agent Flows",
+                "description": "Starting point of the agentflow",
+                "inputParams": [
+                    {
+                        "label": "Input Type",
+                        "name": "startInputType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "Chat Input",
+                                "name": "chatInput",
+                                "description": "Start the conversation with chat input"
+                            },
+                            {
+                                "label": "Form Input",
+                                "name": "formInput",
+                                "description": "Start the workflow with form inputs"
+                            }
+                        ],
+                        "default": "chatInput",
+                        "id": "startAgentflow_0-input-startInputType-options",
+                        "display": true
+                    },
+                    {
+                        "label": "Form Title",
+                        "name": "formTitle",
+                        "type": "string",
+                        "placeholder": "Please Fill Out The Form",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formTitle-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Description",
+                        "name": "formDescription",
+                        "type": "string",
+                        "placeholder": "Complete all fields below to continue",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formDescription-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Input Types",
+                        "name": "formInputTypes",
+                        "description": "Specify the type of form input",
+                        "type": "array",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "array": [
+                            {
+                                "label": "Type",
+                                "name": "type",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "String",
+                                        "name": "string"
+                                    },
+                                    {
+                                        "label": "Number",
+                                        "name": "number"
+                                    },
+                                    {
+                                        "label": "Boolean",
+                                        "name": "boolean"
+                                    },
+                                    {
+                                        "label": "Options",
+                                        "name": "options"
+                                    }
+                                ],
+                                "default": "string"
+                            },
+                            {
+                                "label": "Label",
+                                "name": "label",
+                                "type": "string",
+                                "placeholder": "Label for the input"
+                            },
+                            {
+                                "label": "Variable Name",
+                                "name": "name",
+                                "type": "string",
+                                "placeholder": "Variable name for the input (must be camel case)",
+                                "description": "Variable name must be camel case. For example: firstName, lastName, etc."
+                            },
+                            {
+                                "label": "Add Options",
+                                "name": "addOptions",
+                                "type": "array",
+                                "show": {
+                                    "formInputTypes[$index].type": "options"
+                                },
+                                "array": [
+                                    {
+                                        "label": "Option",
+                                        "name": "option",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-formInputTypes-array",
+                        "display": false
+                    },
+                    {
+                        "label": "Ephemeral Memory",
+                        "name": "startEphemeralMemory",
+                        "type": "boolean",
+                        "description": "Start fresh for every execution without past chat history",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startEphemeralMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Flow State",
+                        "name": "startState",
+                        "description": "Runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "string",
+                                "placeholder": "Foo"
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "placeholder": "Bar",
+                                "optional": true
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-startState-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Persist State",
+                        "name": "startPersistState",
+                        "type": "boolean",
+                        "description": "Persist the state in the same session",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startPersistState-boolean",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "startInputType": "chatInput",
+                    "formTitle": "",
+                    "formDescription": "",
+                    "formInputTypes": "",
+                    "startEphemeralMemory": "",
+                    "startState": "",
+                    "startPersistState": ""
+                },
+                "outputAnchors": [
+                    {
+                        "id": "startAgentflow_0-output-startAgentflow",
+                        "label": "Start",
+                        "name": "startAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "width": 103,
+            "height": 66,
+            "positionAbsolute": {
+                "x": 64,
+                "y": 98.5
+            },
+            "selected": false,
+            "dragging": false
+        },
+        {
+            "id": "llmAgentflow_0",
+            "position": {
+                "x": 234.5,
+                "y": 95.75
+            },
+            "data": {
+                "id": "llmAgentflow_0",
+                "label": "Strutured Output",
+                "version": 1,
+                "name": "llmAgentflow",
+                "type": "LLM",
+                "color": "#64B5F6",
+                "baseClasses": ["LLM"],
+                "category": "Agent Flows",
+                "description": "Large language models to analyze user-provided inputs and generate responses",
+                "inputParams": [
+                    {
+                        "label": "Model",
+                        "name": "llmModel",
+                        "type": "asyncOptions",
+                        "loadMethod": "listModels",
+                        "loadConfig": true,
+                        "id": "llmAgentflow_0-input-llmModel-asyncOptions",
+                        "display": true
+                    },
+                    {
+                        "label": "Messages",
+                        "name": "llmMessages",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Role",
+                                "name": "role",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "System",
+                                        "name": "system"
+                                    },
+                                    {
+                                        "label": "Assistant",
+                                        "name": "assistant"
+                                    },
+                                    {
+                                        "label": "Developer",
+                                        "name": "developer"
+                                    },
+                                    {
+                                        "label": "User",
+                                        "name": "user"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Content",
+                                "name": "content",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "generateInstruction": true,
+                                "rows": 4
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmMessages-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Enable Memory",
+                        "name": "llmEnableMemory",
+                        "type": "boolean",
+                        "description": "Enable memory for the conversation thread",
+                        "default": true,
+                        "optional": true,
+                        "id": "llmAgentflow_0-input-llmEnableMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Memory Type",
+                        "name": "llmMemoryType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "All Messages",
+                                "name": "allMessages",
+                                "description": "Retrieve all messages from the conversation"
+                            },
+                            {
+                                "label": "Window Size",
+                                "name": "windowSize",
+                                "description": "Uses a fixed window size to surface the last N messages"
+                            },
+                            {
+                                "label": "Conversation Summary",
+                                "name": "conversationSummary",
+                                "description": "Summarizes the whole conversation"
+                            },
+                            {
+                                "label": "Conversation Summary Buffer",
+                                "name": "conversationSummaryBuffer",
+                                "description": "Summarize conversations once token limit is reached. Default to 2000"
+                            }
+                        ],
+                        "optional": true,
+                        "default": "allMessages",
+                        "show": {
+                            "llmEnableMemory": true
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryType-options",
+                        "display": false
+                    },
+                    {
+                        "label": "Window Size",
+                        "name": "llmMemoryWindowSize",
+                        "type": "number",
+                        "default": "20",
+                        "description": "Uses a fixed window size to surface the last N messages",
+                        "show": {
+                            "llmMemoryType": "windowSize"
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryWindowSize-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Max Token Limit",
+                        "name": "llmMemoryMaxTokenLimit",
+                        "type": "number",
+                        "default": "2000",
+                        "description": "Summarize conversations once token limit is reached. Default to 2000",
+                        "show": {
+                            "llmMemoryType": "conversationSummaryBuffer"
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryMaxTokenLimit-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Input Message",
+                        "name": "llmUserMessage",
+                        "type": "string",
+                        "description": "Add an input message as user message at the end of the conversation",
+                        "rows": 4,
+                        "optional": true,
+                        "acceptVariable": true,
+                        "show": {
+                            "llmEnableMemory": true
+                        },
+                        "id": "llmAgentflow_0-input-llmUserMessage-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Return Response As",
+                        "name": "llmReturnResponseAs",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "User Message",
+                                "name": "userMessage"
+                            },
+                            {
+                                "label": "Assistant Message",
+                                "name": "assistantMessage"
+                            }
+                        ],
+                        "default": "userMessage",
+                        "id": "llmAgentflow_0-input-llmReturnResponseAs-options",
+                        "display": true
+                    },
+                    {
+                        "label": "JSON Structured Output",
+                        "name": "llmStructuredOutput",
+                        "description": "Instruct the LLM to give output in a JSON structured schema",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "string"
+                            },
+                            {
+                                "label": "Type",
+                                "name": "type",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "String",
+                                        "name": "string"
+                                    },
+                                    {
+                                        "label": "String Array",
+                                        "name": "stringArray"
+                                    },
+                                    {
+                                        "label": "Number",
+                                        "name": "number"
+                                    },
+                                    {
+                                        "label": "Boolean",
+                                        "name": "boolean"
+                                    },
+                                    {
+                                        "label": "Enum",
+                                        "name": "enum"
+                                    },
+                                    {
+                                        "label": "JSON Array",
+                                        "name": "jsonArray"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Enum Values",
+                                "name": "enumValues",
+                                "type": "string",
+                                "placeholder": "value1, value2, value3",
+                                "description": "Enum values. Separated by comma",
+                                "optional": true,
+                                "show": {
+                                    "llmStructuredOutput[$index].type": "enum"
+                                }
+                            },
+                            {
+                                "label": "JSON Schema",
+                                "name": "jsonSchema",
+                                "type": "code",
+                                "placeholder": "{\n    \"answer\": {\n        \"type\": \"string\",\n        \"description\": \"Value of the answer\"\n    },\n    \"reason\": {\n        \"type\": \"string\",\n        \"description\": \"Reason for the answer\"\n    },\n    \"optional\": {\n        \"type\": \"boolean\"\n    },\n    \"count\": {\n        \"type\": \"number\"\n    },\n    \"children\": {\n        \"type\": \"array\",\n        \"items\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"value\": {\n                    \"type\": \"string\",\n                    \"description\": \"Value of the children's answer\"\n                }\n            }\n        }\n    }\n}",
+                                "description": "JSON schema for the structured output",
+                                "optional": true,
+                                "show": {
+                                    "llmStructuredOutput[$index].type": "jsonArray"
+                                }
+                            },
+                            {
+                                "label": "Description",
+                                "name": "description",
+                                "type": "string",
+                                "placeholder": "Description of the key"
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmStructuredOutput-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Update Flow State",
+                        "name": "llmUpdateState",
+                        "description": "Update runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "asyncOptions",
+                                "loadMethod": "listRuntimeStateKeys",
+                                "freeSolo": true
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "acceptNodeOutputAsVariable": true
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmUpdateState-array",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "llmModel": "chatAnthropic",
+                    "llmMessages": [
+                        {
+                            "role": "system",
+                            "content": "<p>Given user query, return result only in JSON format, without exception.</p><p>When asked to self-correct, output only the corrected JSON and no other text.</p>"
+                        },
+                        {
+                            "role": "user",
+                            "content": "<p><span class=\"variable\" data-type=\"mention\" data-id=\"question\" data-label=\"question\">{{ question }}</span> </p>"
+                        }
+                    ],
+                    "llmEnableMemory": false,
+                    "llmReturnResponseAs": "userMessage",
+                    "llmStructuredOutput": [
+                        {
+                            "key": "output",
+                            "type": "jsonArray",
+                            "enumValues": "",
+                            "jsonSchema": "{\n    \"answer\": {\n        \"type\": \"string\",\n        \"description\": \"Value of the answer\"\n    },\n    \"reason\": {\n        \"type\": \"string\",\n        \"description\": \"Reason for the answer\"\n    }\n}",
+                            "description": "answer and its reason to the question"
+                        }
+                    ],
+                    "llmUpdateState": "",
+                    "llmModelConfig": {
+                        "credential": "",
+                        "modelName": "claude-sonnet-4-0",
+                        "temperature": 0.9,
+                        "streaming": true,
+                        "maxTokensToSample": "",
+                        "topP": "",
+                        "topK": "",
+                        "extendedThinking": "",
+                        "budgetTokens": 1024,
+                        "allowImageUploads": "",
+                        "llmModel": "chatAnthropic"
+                    }
+                },
+                "outputAnchors": [
+                    {
+                        "id": "llmAgentflow_0-output-llmAgentflow",
+                        "label": "LLM",
+                        "name": "llmAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "type": "agentFlow",
+            "width": 213,
+            "height": 72,
+            "selected": false,
+            "positionAbsolute": {
+                "x": 234.5,
+                "y": 95.75
+            },
+            "dragging": false
+        }
+    ],
+    "edges": [
+        {
+            "source": "startAgentflow_0",
+            "sourceHandle": "startAgentflow_0-output-startAgentflow",
+            "target": "llmAgentflow_0",
+            "targetHandle": "llmAgentflow_0",
+            "data": {
+                "sourceColor": "#7EE787",
+                "targetColor": "#64B5F6",
+                "isHumanInput": false
+            },
+            "type": "agentFlow",
+            "id": "startAgentflow_0-startAgentflow_0-output-startAgentflow-llmAgentflow_0-llmAgentflow_0"
+        }
+    ]
+}

--- a/cogflow/agent/tests/fixtures/translator.json
+++ b/cogflow/agent/tests/fixtures/translator.json
@@ -1,0 +1,544 @@
+{
+    "description": "Translate text from one language to another",
+    "usecases": ["Basic"],
+    "nodes": [
+        {
+            "id": "startAgentflow_0",
+            "type": "agentFlow",
+            "position": {
+                "x": 64,
+                "y": 98.5
+            },
+            "data": {
+                "id": "startAgentflow_0",
+                "label": "Start",
+                "version": 1.1,
+                "name": "startAgentflow",
+                "type": "Start",
+                "color": "#7EE787",
+                "hideInput": true,
+                "baseClasses": ["Start"],
+                "category": "Agent Flows",
+                "description": "Starting point of the agentflow",
+                "inputParams": [
+                    {
+                        "label": "Input Type",
+                        "name": "startInputType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "Chat Input",
+                                "name": "chatInput",
+                                "description": "Start the conversation with chat input"
+                            },
+                            {
+                                "label": "Form Input",
+                                "name": "formInput",
+                                "description": "Start the workflow with form inputs"
+                            }
+                        ],
+                        "default": "chatInput",
+                        "id": "startAgentflow_0-input-startInputType-options",
+                        "display": true
+                    },
+                    {
+                        "label": "Form Title",
+                        "name": "formTitle",
+                        "type": "string",
+                        "placeholder": "Please Fill Out The Form",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formTitle-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Description",
+                        "name": "formDescription",
+                        "type": "string",
+                        "placeholder": "Complete all fields below to continue",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "id": "startAgentflow_0-input-formDescription-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Form Input Types",
+                        "name": "formInputTypes",
+                        "description": "Specify the type of form input",
+                        "type": "array",
+                        "show": {
+                            "startInputType": "formInput"
+                        },
+                        "array": [
+                            {
+                                "label": "Type",
+                                "name": "type",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "String",
+                                        "name": "string"
+                                    },
+                                    {
+                                        "label": "Number",
+                                        "name": "number"
+                                    },
+                                    {
+                                        "label": "Boolean",
+                                        "name": "boolean"
+                                    },
+                                    {
+                                        "label": "Options",
+                                        "name": "options"
+                                    }
+                                ],
+                                "default": "string"
+                            },
+                            {
+                                "label": "Label",
+                                "name": "label",
+                                "type": "string",
+                                "placeholder": "Label for the input"
+                            },
+                            {
+                                "label": "Variable Name",
+                                "name": "name",
+                                "type": "string",
+                                "placeholder": "Variable name for the input (must be camel case)",
+                                "description": "Variable name must be camel case. For example: firstName, lastName, etc."
+                            },
+                            {
+                                "label": "Add Options",
+                                "name": "addOptions",
+                                "type": "array",
+                                "show": {
+                                    "formInputTypes[$index].type": "options"
+                                },
+                                "array": [
+                                    {
+                                        "label": "Option",
+                                        "name": "option",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-formInputTypes-array",
+                        "display": false
+                    },
+                    {
+                        "label": "Ephemeral Memory",
+                        "name": "startEphemeralMemory",
+                        "type": "boolean",
+                        "description": "Start fresh for every execution without past chat history",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startEphemeralMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Flow State",
+                        "name": "startState",
+                        "description": "Runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "string",
+                                "placeholder": "Foo"
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "placeholder": "Bar",
+                                "optional": true
+                            }
+                        ],
+                        "id": "startAgentflow_0-input-startState-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Persist State",
+                        "name": "startPersistState",
+                        "type": "boolean",
+                        "description": "Persist the state in the same session",
+                        "optional": true,
+                        "id": "startAgentflow_0-input-startPersistState-boolean",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "startInputType": "chatInput",
+                    "formTitle": "",
+                    "formDescription": "",
+                    "formInputTypes": "",
+                    "startEphemeralMemory": "",
+                    "startState": "",
+                    "startPersistState": ""
+                },
+                "outputAnchors": [
+                    {
+                        "id": "startAgentflow_0-output-startAgentflow",
+                        "label": "Start",
+                        "name": "startAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "width": 103,
+            "height": 66,
+            "positionAbsolute": {
+                "x": 64,
+                "y": 98.5
+            },
+            "selected": false,
+            "dragging": false
+        },
+        {
+            "id": "llmAgentflow_0",
+            "position": {
+                "x": 234.5,
+                "y": 96.25
+            },
+            "data": {
+                "id": "llmAgentflow_0",
+                "label": "Translator",
+                "version": 1,
+                "name": "llmAgentflow",
+                "type": "LLM",
+                "color": "#64B5F6",
+                "baseClasses": ["LLM"],
+                "category": "Agent Flows",
+                "description": "Large language models to analyze user-provided inputs and generate responses",
+                "inputParams": [
+                    {
+                        "label": "Model",
+                        "name": "llmModel",
+                        "type": "asyncOptions",
+                        "loadMethod": "listModels",
+                        "loadConfig": true,
+                        "id": "llmAgentflow_0-input-llmModel-asyncOptions",
+                        "display": true
+                    },
+                    {
+                        "label": "Messages",
+                        "name": "llmMessages",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Role",
+                                "name": "role",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "System",
+                                        "name": "system"
+                                    },
+                                    {
+                                        "label": "Assistant",
+                                        "name": "assistant"
+                                    },
+                                    {
+                                        "label": "Developer",
+                                        "name": "developer"
+                                    },
+                                    {
+                                        "label": "User",
+                                        "name": "user"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Content",
+                                "name": "content",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "generateInstruction": true,
+                                "rows": 4
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmMessages-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Enable Memory",
+                        "name": "llmEnableMemory",
+                        "type": "boolean",
+                        "description": "Enable memory for the conversation thread",
+                        "default": true,
+                        "optional": true,
+                        "id": "llmAgentflow_0-input-llmEnableMemory-boolean",
+                        "display": true
+                    },
+                    {
+                        "label": "Memory Type",
+                        "name": "llmMemoryType",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "All Messages",
+                                "name": "allMessages",
+                                "description": "Retrieve all messages from the conversation"
+                            },
+                            {
+                                "label": "Window Size",
+                                "name": "windowSize",
+                                "description": "Uses a fixed window size to surface the last N messages"
+                            },
+                            {
+                                "label": "Conversation Summary",
+                                "name": "conversationSummary",
+                                "description": "Summarizes the whole conversation"
+                            },
+                            {
+                                "label": "Conversation Summary Buffer",
+                                "name": "conversationSummaryBuffer",
+                                "description": "Summarize conversations once token limit is reached. Default to 2000"
+                            }
+                        ],
+                        "optional": true,
+                        "default": "allMessages",
+                        "show": {
+                            "llmEnableMemory": true
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryType-options",
+                        "display": false
+                    },
+                    {
+                        "label": "Window Size",
+                        "name": "llmMemoryWindowSize",
+                        "type": "number",
+                        "default": "20",
+                        "description": "Uses a fixed window size to surface the last N messages",
+                        "show": {
+                            "llmMemoryType": "windowSize"
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryWindowSize-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Max Token Limit",
+                        "name": "llmMemoryMaxTokenLimit",
+                        "type": "number",
+                        "default": "2000",
+                        "description": "Summarize conversations once token limit is reached. Default to 2000",
+                        "show": {
+                            "llmMemoryType": "conversationSummaryBuffer"
+                        },
+                        "id": "llmAgentflow_0-input-llmMemoryMaxTokenLimit-number",
+                        "display": false
+                    },
+                    {
+                        "label": "Input Message",
+                        "name": "llmUserMessage",
+                        "type": "string",
+                        "description": "Add an input message as user message at the end of the conversation",
+                        "rows": 4,
+                        "optional": true,
+                        "acceptVariable": true,
+                        "show": {
+                            "llmEnableMemory": true
+                        },
+                        "id": "llmAgentflow_0-input-llmUserMessage-string",
+                        "display": false
+                    },
+                    {
+                        "label": "Return Response As",
+                        "name": "llmReturnResponseAs",
+                        "type": "options",
+                        "options": [
+                            {
+                                "label": "User Message",
+                                "name": "userMessage"
+                            },
+                            {
+                                "label": "Assistant Message",
+                                "name": "assistantMessage"
+                            }
+                        ],
+                        "default": "userMessage",
+                        "id": "llmAgentflow_0-input-llmReturnResponseAs-options",
+                        "display": true
+                    },
+                    {
+                        "label": "JSON Structured Output",
+                        "name": "llmStructuredOutput",
+                        "description": "Instruct the LLM to give output in a JSON structured schema",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "string"
+                            },
+                            {
+                                "label": "Type",
+                                "name": "type",
+                                "type": "options",
+                                "options": [
+                                    {
+                                        "label": "String",
+                                        "name": "string"
+                                    },
+                                    {
+                                        "label": "String Array",
+                                        "name": "stringArray"
+                                    },
+                                    {
+                                        "label": "Number",
+                                        "name": "number"
+                                    },
+                                    {
+                                        "label": "Boolean",
+                                        "name": "boolean"
+                                    },
+                                    {
+                                        "label": "Enum",
+                                        "name": "enum"
+                                    },
+                                    {
+                                        "label": "JSON Array",
+                                        "name": "jsonArray"
+                                    }
+                                ]
+                            },
+                            {
+                                "label": "Enum Values",
+                                "name": "enumValues",
+                                "type": "string",
+                                "placeholder": "value1, value2, value3",
+                                "description": "Enum values. Separated by comma",
+                                "optional": true,
+                                "show": {
+                                    "llmStructuredOutput[$index].type": "enum"
+                                }
+                            },
+                            {
+                                "label": "JSON Schema",
+                                "name": "jsonSchema",
+                                "type": "code",
+                                "placeholder": "{\n    \"answer\": {\n        \"type\": \"string\",\n        \"description\": \"Value of the answer\"\n    },\n    \"reason\": {\n        \"type\": \"string\",\n        \"description\": \"Reason for the answer\"\n    },\n    \"optional\": {\n        \"type\": \"boolean\"\n    },\n    \"count\": {\n        \"type\": \"number\"\n    },\n    \"children\": {\n        \"type\": \"array\",\n        \"items\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"value\": {\n                    \"type\": \"string\",\n                    \"description\": \"Value of the children's answer\"\n                }\n            }\n        }\n    }\n}",
+                                "description": "JSON schema for the structured output",
+                                "optional": true,
+                                "show": {
+                                    "llmStructuredOutput[$index].type": "jsonArray"
+                                }
+                            },
+                            {
+                                "label": "Description",
+                                "name": "description",
+                                "type": "string",
+                                "placeholder": "Description of the key"
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmStructuredOutput-array",
+                        "display": true
+                    },
+                    {
+                        "label": "Update Flow State",
+                        "name": "llmUpdateState",
+                        "description": "Update runtime state during the execution of the workflow",
+                        "type": "array",
+                        "optional": true,
+                        "acceptVariable": true,
+                        "array": [
+                            {
+                                "label": "Key",
+                                "name": "key",
+                                "type": "asyncOptions",
+                                "loadMethod": "listRuntimeStateKeys",
+                                "freeSolo": true
+                            },
+                            {
+                                "label": "Value",
+                                "name": "value",
+                                "type": "string",
+                                "acceptVariable": true,
+                                "acceptNodeOutputAsVariable": true
+                            }
+                        ],
+                        "id": "llmAgentflow_0-input-llmUpdateState-array",
+                        "display": true
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "llmModel": "chatGoogleGenerativeAI",
+                    "llmMessages": [
+                        {
+                            "role": "system",
+                            "content": "<p>You are a helpful assistant that translates English to Japanese language. Return only Japanese language</p>"
+                        },
+                        {
+                            "role": "user",
+                            "content": "<p>English:</p><p><span class=\"variable\" data-type=\"mention\" data-id=\"question\" data-label=\"question\">{{ question }}</span> </p><p>Japanese:</p><p></p>"
+                        }
+                    ],
+                    "llmEnableMemory": false,
+                    "llmReturnResponseAs": "userMessage",
+                    "llmStructuredOutput": "",
+                    "llmUpdateState": "",
+                    "llmModelConfig": {
+                        "cache": "",
+                        "contextCache": "",
+                        "modelName": "gemini-2.0-flash",
+                        "customModelName": "",
+                        "temperature": 0.9,
+                        "streaming": true,
+                        "maxOutputTokens": "",
+                        "topP": "",
+                        "topK": "",
+                        "harmCategory": "",
+                        "harmBlockThreshold": "",
+                        "baseUrl": "",
+                        "allowImageUploads": "",
+                        "llmModel": "chatGoogleGenerativeAI"
+                    }
+                },
+                "outputAnchors": [
+                    {
+                        "id": "llmAgentflow_0-output-llmAgentflow",
+                        "label": "LLM",
+                        "name": "llmAgentflow"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            },
+            "type": "agentFlow",
+            "width": 200,
+            "height": 72,
+            "selected": false,
+            "positionAbsolute": {
+                "x": 234.5,
+                "y": 96.25
+            },
+            "dragging": false
+        }
+    ],
+    "edges": [
+        {
+            "source": "startAgentflow_0",
+            "sourceHandle": "startAgentflow_0-output-startAgentflow",
+            "target": "llmAgentflow_0",
+            "targetHandle": "llmAgentflow_0",
+            "data": {
+                "sourceColor": "#7EE787",
+                "targetColor": "#64B5F6",
+                "isHumanInput": false
+            },
+            "type": "agentFlow",
+            "id": "startAgentflow_0-startAgentflow_0-output-startAgentflow-llmAgentflow_0-llmAgentflow_0"
+        }
+    ]
+}

--- a/cogflow/agent/tests/test_compile_langgraph.py
+++ b/cogflow/agent/tests/test_compile_langgraph.py
@@ -1,0 +1,45 @@
+"""Build a tiny graph with the Python facade and invoke it via LangGraph."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from cogflow.agent import END, START, StateGraph, add_messages
+
+
+class _State(TypedDict, total=False):
+    messages: Annotated[list, add_messages]
+
+
+def _greet(state: _State) -> dict:
+    return {"messages": [AIMessage(content="hello")]}
+
+
+def test_simple_graph_invokes():
+    g = StateGraph(_State)
+    g.add_node("greet", _greet)
+    g.add_edge(START, "greet")
+    g.add_edge("greet", END)
+
+    app = g.compile()
+    result = app.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert isinstance(result, dict)
+    assert any(getattr(m, "content", "") == "hello" for m in result.get("messages", []))
+
+
+def test_state_graph_captures_ir():
+    g = StateGraph(_State)
+    g.add_node("greet", _greet)
+    g.add_edge(START, "greet")
+    g.add_edge("greet", END)
+
+    assert g.ir is not None
+    # Start node was synthesized + greet was recorded as a custom_function node.
+    types = sorted(n.type for n in g.ir.nodes)
+    assert "start" in types
+    assert "custom_function" in types
+    # Edge from start node to greet exists.
+    assert any(e.target == "greet" for e in g.ir.edges)

--- a/cogflow/agent/tests/test_compile_langgraph.py
+++ b/cogflow/agent/tests/test_compile_langgraph.py
@@ -43,3 +43,33 @@ def test_state_graph_captures_ir():
     assert "custom_function" in types
     # Edge from start node to greet exists.
     assert any(e.target == "greet" for e in g.ir.edges)
+
+
+def test_conditional_branch_to_end_does_not_force_other_branches():
+    """Regression: one branch routing to END must NOT terminate the whole node."""
+    from cogflow.agent.ir import END_SENTINEL
+
+    def _route(state: _State) -> str:
+        return "go"
+
+    def _other(state: _State) -> dict:
+        return {"messages": [AIMessage(content="other")]}
+
+    g = StateGraph(_State)
+    g.add_node("router", _greet)
+    g.add_node("other", _other)
+    g.add_edge(START, "router")
+    g.add_conditional_edges("router", _route, {"stop": END, "go": "other"})
+    g.add_edge("other", END)
+
+    # Router source must NOT be flagged as finish — only the "stop" branch
+    # should terminate. Branch "go" should still route to "other".
+    assert "router" not in g.ir.finish
+    targets_from_router = {e.target for e in g.ir.edges if e.source == "router"}
+    assert "other" in targets_from_router
+    assert END_SENTINEL in targets_from_router
+
+    # Compile must succeed (LangGraph would reject a node with both an
+    # unconditional END edge and a conditional router).
+    app = g.compile()
+    assert app is not None

--- a/cogflow/agent/tests/test_compile_langgraph.py
+++ b/cogflow/agent/tests/test_compile_langgraph.py
@@ -73,3 +73,28 @@ def test_conditional_branch_to_end_does_not_force_other_branches():
     # unconditional END edge and a conditional router).
     app = g.compile()
     assert app is not None
+
+
+def test_conditional_end_branch_does_not_leak_into_flowise_json():
+    """Regression: END_SENTINEL edges must not be serialized as Flowise edges."""
+    from cogflow.agent.compile.to_flowise import to_dict as ir_to_flowise
+
+    def _route(state: _State) -> str:
+        return "go"
+
+    def _other(state: _State) -> dict:
+        return {"messages": [AIMessage(content="other")]}
+
+    g = StateGraph(_State)
+    g.add_node("router", _greet)
+    g.add_node("other", _other)
+    g.add_edge(START, "router")
+    g.add_conditional_edges("router", _route, {"stop": END, "go": "other"})
+    g.add_edge("other", END)
+
+    flow = ir_to_flowise(g.ir)
+    # No edge should point at "__end__" — Flowise would reject such an id.
+    targets = [e["target"] for e in flow["edges"]]
+    assert "__end__" not in targets
+    # The non-END branch must survive into the exported canvas.
+    assert "other" in targets

--- a/cogflow/agent/tests/test_import_compat.py
+++ b/cogflow/agent/tests/test_import_compat.py
@@ -52,6 +52,18 @@ def test_checkpoint_re_exports():
 def test_interrupt_and_command():
     import cogflow.agent as cg
 
-    # Newer langgraph exposes these; assert they at least resolve to something.
-    assert cg.interrupt is not None
-    assert cg.Command is not None
+    # ``cogflow.agent.__init__`` sets these to ``None`` on older langgraph
+    # builds that don't expose ``langgraph.types.{interrupt,Command}``. Treat
+    # both states as acceptable so the supported version range stays
+    # consistent with ``ToolNode``'s fallback contract. The agent extra pins
+    # langgraph>=0.2,<0.5 — in that range these symbols exist, so a None here
+    # signals an unexpectedly-older langgraph that callers should update.
+    if cg.interrupt is None or cg.Command is None:
+        import langgraph
+
+        # Diagnostic: surface the installed version in the failure message.
+        version = getattr(langgraph, "__version__", "<unknown>")
+        raise AssertionError(
+            f"Expected langgraph.types.interrupt / Command to be importable; "
+            f"got None — installed langgraph version: {version!r}"
+        )

--- a/cogflow/agent/tests/test_import_compat.py
+++ b/cogflow/agent/tests/test_import_compat.py
@@ -1,0 +1,57 @@
+"""Drop-in import migration (plan §3a) — every row in the table must hold."""
+
+from __future__ import annotations
+
+import langgraph.graph as _lg_graph
+
+
+def test_state_graph_subclasses_langgraph():
+    import cogflow.agent as cg
+
+    assert issubclass(cg.StateGraph, _lg_graph.StateGraph)
+
+
+def test_sentinels_pass_through():
+    import cogflow.agent as cg
+
+    assert cg.START is _lg_graph.START
+    assert cg.END is _lg_graph.END
+
+
+def test_messages_state_and_add_messages_pass_through():
+    import cogflow.agent as cg
+
+    assert cg.MessagesState is _lg_graph.MessagesState
+    assert cg.add_messages is _lg_graph.add_messages
+
+
+def test_tools_re_exports_resolve():
+    from cogflow.agent.tools import ToolNode, tool
+
+    assert tool is not None
+    # ToolNode may be None on very old langgraph; allow that but flag in CI.
+    _ = ToolNode  # noqa: F841
+
+
+def test_prebuilt_create_react_agent():
+    from langgraph.prebuilt import create_react_agent as _lg_cra
+
+    from cogflow.agent.prebuilt import create_react_agent
+
+    assert create_react_agent is _lg_cra
+
+
+def test_checkpoint_re_exports():
+    from langgraph.checkpoint.memory import MemorySaver as _LG_Memory
+
+    from cogflow.agent.runtime.checkpoint import MemorySaver
+
+    assert MemorySaver is _LG_Memory
+
+
+def test_interrupt_and_command():
+    import cogflow.agent as cg
+
+    # Newer langgraph exposes these; assert they at least resolve to something.
+    assert cg.interrupt is not None
+    assert cg.Command is not None

--- a/cogflow/agent/tests/test_ir_roundtrip.py
+++ b/cogflow/agent/tests/test_ir_roundtrip.py
@@ -1,0 +1,48 @@
+"""Lossless round-trip: Flowise V2 JSON -> IR -> Flowise V2 JSON."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cogflow.agent.compile.to_flowise import to_dict as ir_to_flowise
+from cogflow.agent.parse.flowise import from_file
+
+
+def _normalize(value):
+    if isinstance(value, dict):
+        return {k: _normalize(v) for k, v in sorted(value.items())}
+    if isinstance(value, list):
+        return [_normalize(x) for x in value]
+    return value
+
+
+def _load(path: Path):
+    return json.loads(path.read_text())
+
+
+def test_simple_rag_roundtrips_losslessly(simple_rag_path: Path):
+    original = _load(simple_rag_path)
+    ir = from_file(simple_rag_path)
+    emitted = ir_to_flowise(ir)
+    # Nodes and edges deep-equal modulo dict ordering.
+    assert _normalize(emitted["nodes"]) == _normalize(original["nodes"])
+    assert _normalize(emitted["edges"]) == _normalize(original["edges"])
+    if "description" in original:
+        assert emitted.get("description") == original["description"]
+    if "usecases" in original:
+        assert emitted.get("usecases") == original["usecases"]
+
+
+@pytest.mark.parametrize("filename", ["Structured Output.json", "Translator.json"])
+def test_other_mvp7_fixtures_roundtrip(marketplace_dir: Path, filename: str):
+    path = marketplace_dir / filename
+    if not path.exists():
+        pytest.skip(f"fixture {filename} not present in this checkout")
+    original = _load(path)
+    ir = from_file(path)
+    emitted = ir_to_flowise(ir)
+    assert _normalize(emitted["nodes"]) == _normalize(original["nodes"])
+    assert _normalize(emitted["edges"]) == _normalize(original["edges"])

--- a/cogflow/agent/tests/test_ir_roundtrip.py
+++ b/cogflow/agent/tests/test_ir_roundtrip.py
@@ -36,7 +36,7 @@ def test_simple_rag_roundtrips_losslessly(simple_rag_path: Path):
         assert emitted.get("usecases") == original["usecases"]
 
 
-@pytest.mark.parametrize("filename", ["Structured Output.json", "Translator.json"])
+@pytest.mark.parametrize("filename", ["structured_output.json", "translator.json"])
 def test_other_mvp7_fixtures_roundtrip(marketplace_dir: Path, filename: str):
     path = marketplace_dir / filename
     if not path.exists():

--- a/cogflow/agent/tests/test_marketplace_simple_rag.py
+++ b/cogflow/agent/tests/test_marketplace_simple_rag.py
@@ -1,0 +1,23 @@
+"""Integration: load Simple RAG.json, compile to LangGraph, invoke."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from cogflow.agent.compile.to_langgraph import to_langgraph
+from cogflow.agent.parse.flowise import from_file
+
+
+def test_simple_rag_compiles_and_invokes(simple_rag_path: Path):
+    ir = from_file(simple_rag_path)
+    assert ir.entry is not None
+    assert any(n.type == "agent" for n in ir.nodes)
+
+    app = to_langgraph(ir)
+    out = app.invoke({"messages": [HumanMessage(content="what is RAG?")]})
+    # Without a live model the agent node is a passthrough; we just verify the
+    # graph runs to completion and returns the state dict it started with.
+    assert isinstance(out, dict)
+    assert "messages" in out

--- a/cogflow/agent/tests/test_python_first_emit.py
+++ b/cogflow/agent/tests/test_python_first_emit.py
@@ -1,0 +1,28 @@
+"""Direction B smoke: Python-first graph -> Flowise V2 JSON dict shape."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypedDict
+
+from cogflow.agent import END, START, StateGraph, add_messages
+from cogflow.agent.compile.to_flowise import to_dict as ir_to_flowise
+from cogflow.agent.nodes import agent
+
+
+class _State(TypedDict, total=False):
+    messages: Annotated[list, add_messages]
+
+
+def test_python_first_emits_valid_flowise_shape():
+    g = StateGraph(_State)
+    g.add_node("qna", agent(model="openai:gpt-4o-mini"))
+    g.add_edge(START, "qna")
+    g.add_edge("qna", END)
+
+    out = ir_to_flowise(g.ir)
+    names = [n["data"]["name"] for n in out["nodes"]]
+    assert "startAgentflow" in names
+    assert "agentAgentflow" in names
+    # At least one edge from the synthesized start.
+    sources = [e["source"] for e in out["edges"]]
+    assert any(s.startswith("__start__") or s == "__start__" for s in sources)

--- a/cogflow/agent/tests/test_state_synthesis.py
+++ b/cogflow/agent/tests/test_state_synthesis.py
@@ -1,0 +1,47 @@
+"""State channel introspection + TypedDict synthesis."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypedDict
+
+from cogflow.agent.state import (
+    add_messages,
+    introspect_state,
+    reducer_by_name,
+    synthesize_typeddict,
+)
+
+
+class _Schema(TypedDict, total=False):
+    messages: Annotated[list, add_messages]
+    user_id: str
+
+
+def test_introspect_extracts_add_messages_reducer():
+    fields = introspect_state(_Schema)
+    by_key = {f.key: f for f in fields}
+    assert by_key["messages"].reducer == "add_messages"
+    assert by_key["user_id"].reducer is None
+
+
+def test_messages_field_auto_upgraded_to_add_messages():
+    class _Bare(TypedDict, total=False):
+        messages: list
+
+    fields = introspect_state(_Bare)
+    by_key = {f.key: f for f in fields}
+    assert by_key["messages"].reducer == "add_messages"
+
+
+def test_synthesize_typeddict_roundtrips_through_introspect():
+    fields = introspect_state(_Schema)
+    synthesized = synthesize_typeddict(fields)
+    refields = introspect_state(synthesized)
+    assert sorted(f.key for f in refields) == sorted(f.key for f in fields)
+    by_key = {f.key: f for f in refields}
+    assert by_key["messages"].reducer == "add_messages"
+
+
+def test_reducer_registry_resolves_known_names():
+    assert reducer_by_name("add_messages") is add_messages
+    assert reducer_by_name(None) is None

--- a/cogflow/agent/tests/test_tracing_langsmith.py
+++ b/cogflow/agent/tests/test_tracing_langsmith.py
@@ -1,0 +1,75 @@
+"""LangSmith tracing adapter: env-var snapshot + restoration.
+
+These guard the security/ops-sensitive parts of ``LangSmithAdapter`` so a
+regression that, say, leaks an API key into the process environment after
+``disable()`` is caught here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from cogflow.agent.tracing import configure_tracing
+from cogflow.agent.tracing.langsmith import LangSmithAdapter, _MANAGED_ENV_VARS
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure every test starts with no LANGCHAIN_* env state."""
+    for var in _MANAGED_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_enable_sets_expected_env_vars():
+    adapter = LangSmithAdapter()
+    try:
+        adapter.enable(project="proj-a", api_key="sk-test")
+        assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
+        assert os.environ["LANGCHAIN_PROJECT"] == "proj-a"
+        assert os.environ["LANGCHAIN_API_KEY"] == "sk-test"
+    finally:
+        adapter.disable()
+
+
+def test_disable_restores_previously_unset():
+    adapter = LangSmithAdapter()
+    adapter.enable(project="proj-a", api_key="sk-test")
+    adapter.disable()
+    # Vars that did not exist before enable() must be popped, not left set.
+    for var in _MANAGED_ENV_VARS:
+        assert var not in os.environ, f"{var} leaked past disable()"
+
+
+def test_disable_restores_previously_set_values(monkeypatch):
+    monkeypatch.setenv("LANGCHAIN_TRACING_V2", "preserve-me")
+    monkeypatch.setenv("LANGCHAIN_PROJECT", "preexisting-project")
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "sk-original")
+
+    adapter = LangSmithAdapter()
+    adapter.enable(project="overridden", api_key="sk-test")
+    assert os.environ["LANGCHAIN_PROJECT"] == "overridden"
+
+    adapter.disable()
+    assert os.environ["LANGCHAIN_TRACING_V2"] == "preserve-me"
+    assert os.environ["LANGCHAIN_PROJECT"] == "preexisting-project"
+    assert os.environ["LANGCHAIN_API_KEY"] == "sk-original"
+
+
+def test_repeated_configure_tracing_does_not_corrupt_restore_state(monkeypatch):
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "sk-original")
+
+    # First enable through the public entry point.
+    configure_tracing(backend="langsmith", project="proj-a", api_key="sk-first")
+    assert os.environ["LANGCHAIN_API_KEY"] == "sk-first"
+
+    # Second enable must NOT snapshot the already-mutated state; the original
+    # value still survives the eventual disable.
+    configure_tracing(backend="langsmith", project="proj-b", api_key="sk-second")
+    assert os.environ["LANGCHAIN_PROJECT"] == "proj-b"
+    assert os.environ["LANGCHAIN_API_KEY"] == "sk-second"
+
+    configure_tracing(backend=None)
+    assert os.environ["LANGCHAIN_API_KEY"] == "sk-original"
+    assert "LANGCHAIN_TRACING_V2" not in os.environ

--- a/cogflow/agent/tests/test_tracing_mlflow.py
+++ b/cogflow/agent/tests/test_tracing_mlflow.py
@@ -1,0 +1,26 @@
+"""MLflow tracing adapter: autolog enabled without raising."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_configure_tracing_mlflow_enables_autolog(tmp_path, monkeypatch):
+    pytest.importorskip("mlflow")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", f"file://{tmp_path}")
+
+    from cogflow.agent.tracing import configure_tracing
+
+    adapter = configure_tracing(backend="mlflow", experiment="cogflow-agent-test", tracking_uri=f"file://{tmp_path}")
+    assert adapter is not None
+    # Disable cleanly.
+    configure_tracing(backend=None)
+
+
+def test_invalid_backend_raises():
+    from cogflow.agent.tracing import configure_tracing
+
+    with pytest.raises(ValueError):
+        configure_tracing(backend="nope")

--- a/cogflow/agent/tests/test_tracing_mlflow.py
+++ b/cogflow/agent/tests/test_tracing_mlflow.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-
 import pytest
 
 

--- a/cogflow/agent/tests/test_tracing_otel.py
+++ b/cogflow/agent/tests/test_tracing_otel.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import types
 
 import pytest
 
@@ -29,9 +30,20 @@ _SKIP_NO_OPENINFERENCE = pytest.mark.skipif(
 
 
 def test_missing_openinference_raises_with_install_hint(monkeypatch):
-    """Without openinference installed, enable() must raise a clear hint."""
-    # Hide the real openinference module if it's installed locally.
-    monkeypatch.setitem(sys.modules, "openinference.instrumentation.langchain", None)
+    """Without openinference installed, enable() must raise a clear hint.
+
+    We shadow the top-level ``openinference`` package with a plain (non-
+    package) module so any ``from openinference.instrumentation.langchain ...``
+    deterministically fails with ModuleNotFoundError — independent of whether
+    the real package is installed in this environment.
+    """
+    fake_root = types.ModuleType("openinference")  # no __path__ → not a package
+    monkeypatch.setitem(sys.modules, "openinference", fake_root)
+    # Also drop any cached subpackages so import resolution doesn't reuse them.
+    for name in list(sys.modules):
+        if name == "openinference" or name.startswith("openinference."):
+            if name != "openinference":
+                monkeypatch.delitem(sys.modules, name, raising=False)
 
     adapter = OTelAdapter()
     with pytest.raises(RuntimeError, match=r"cogflow\[agent-otel\]"):

--- a/cogflow/agent/tests/test_tracing_otel.py
+++ b/cogflow/agent/tests/test_tracing_otel.py
@@ -1,0 +1,70 @@
+"""OTel tracing adapter: install-hint paths and idempotency.
+
+Covers the error paths that are easy to miss in practice — silently dropped
+endpoints have historically been a footgun for tracing backends.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+import pytest
+
+from cogflow.agent.tracing.otel import OTelAdapter
+
+
+def _has_openinference() -> bool:
+    """find_spec raises on missing parent package — guard against that."""
+    try:
+        return importlib.util.find_spec("openinference.instrumentation.langchain") is not None
+    except (ModuleNotFoundError, ImportError, ValueError):
+        return False
+
+
+_SKIP_NO_OPENINFERENCE = pytest.mark.skipif(
+    not _has_openinference(),
+    reason="openinference-instrumentation-langchain not installed",
+)
+
+
+def test_missing_openinference_raises_with_install_hint(monkeypatch):
+    """Without openinference installed, enable() must raise a clear hint."""
+    # Hide the real openinference module if it's installed locally.
+    monkeypatch.setitem(sys.modules, "openinference.instrumentation.langchain", None)
+
+    adapter = OTelAdapter()
+    with pytest.raises(RuntimeError, match=r"cogflow\[agent-otel\]"):
+        adapter.enable()
+
+
+@_SKIP_NO_OPENINFERENCE
+def test_enable_disable_are_idempotent_when_deps_present():
+    adapter = OTelAdapter()
+    adapter.enable()
+    assert adapter._enabled is True
+    first_instrumentor = adapter._instrumentor
+
+    # Repeated enable() short-circuits — no re-instrumentation.
+    adapter.enable()
+    assert adapter._instrumentor is first_instrumentor
+
+    adapter.disable()
+    assert adapter._enabled is False
+    assert adapter._instrumentor is None
+
+    # disable() on an already-disabled adapter is a safe no-op.
+    adapter.disable()
+    assert adapter._enabled is False
+
+
+@_SKIP_NO_OPENINFERENCE
+def test_endpoint_without_otel_sdk_raises(monkeypatch):
+    """When endpoint is set but the OTel SDK/exporter is missing, raise."""
+    # Block the OTel SDK imports.
+    monkeypatch.setitem(sys.modules, "opentelemetry.sdk.trace", None)
+    monkeypatch.setitem(sys.modules, "opentelemetry.exporter.otlp.proto.http.trace_exporter", None)
+
+    adapter = OTelAdapter()
+    with pytest.raises(RuntimeError, match=r"OTel endpoint=.* was provided"):
+        adapter.enable(endpoint="http://collector:4318")

--- a/cogflow/agent/tools.py
+++ b/cogflow/agent/tools.py
@@ -1,0 +1,13 @@
+"""Tools: re-exports of LangChain's ``@tool`` decorator and LangGraph's ``ToolNode``.
+
+These pass through verbatim; users get drop-in behavior.
+"""
+
+from langchain_core.tools import tool
+
+try:
+    from langgraph.prebuilt import ToolNode
+except ImportError:  # pragma: no cover - older langgraph
+    ToolNode = None  # type: ignore[assignment]
+
+__all__ = ["ToolNode", "tool"]

--- a/cogflow/agent/tools.py
+++ b/cogflow/agent/tools.py
@@ -1,9 +1,18 @@
 """Tools: re-exports of LangChain's ``@tool`` decorator and LangGraph's ``ToolNode``.
 
-These pass through verbatim; users get drop-in behavior.
+These pass through verbatim; users get drop-in behavior. ``cogflow.agent``'s
+``__init__`` already enforces both ``langgraph`` and ``langchain_core`` are
+installed, but we still guard ``ToolNode`` for older langgraph builds that
+ship without the prebuilt module.
 """
 
-from langchain_core.tools import tool
+try:
+    from langchain_core.tools import tool
+except ModuleNotFoundError as _exc:  # pragma: no cover - belt-and-braces
+    raise ModuleNotFoundError(
+        "cogflow.agent.tools requires `langchain-core`. "
+        "Install with `pip install cogflow[agent]`."
+    ) from _exc
 
 try:
     from langgraph.prebuilt import ToolNode

--- a/cogflow/agent/tools.py
+++ b/cogflow/agent/tools.py
@@ -17,15 +17,18 @@ except ModuleNotFoundError as _exc:  # pragma: no cover - belt-and-braces
 try:
     from langgraph.prebuilt import ToolNode
 except ModuleNotFoundError as _exc:  # pragma: no cover
-    # Distinguish "langgraph not installed at all" from "langgraph installed
-    # without the prebuilt submodule". The former is a user-actionable error;
-    # the latter (older langgraph) gracefully falls back to ToolNode=None.
-    if _exc.name == "langgraph" or (_exc.name or "").startswith("langgraph."):
-        if _exc.name == "langgraph":
-            raise ModuleNotFoundError(
-                "cogflow.agent.tools requires `langgraph`. "
-                "Install with `pip install cogflow[agent]`."
-            ) from _exc
+    # Only swallow when the missing module is langgraph-related; anything else
+    # (e.g. a missing transitive dep, a broken installation) should bubble up
+    # with its original message so users can act on it.
+    _name = _exc.name or ""
+    if _name == "langgraph":
+        raise ModuleNotFoundError(
+            "cogflow.agent.tools requires `langgraph`. "
+            "Install with `pip install cogflow[agent]`."
+        ) from _exc
+    if not _name.startswith("langgraph."):
+        raise
+    # Older langgraph without the ``prebuilt`` submodule — graceful fallback.
     ToolNode = None  # type: ignore[assignment]
 
 __all__ = ["ToolNode", "tool"]

--- a/cogflow/agent/tools.py
+++ b/cogflow/agent/tools.py
@@ -16,7 +16,16 @@ except ModuleNotFoundError as _exc:  # pragma: no cover - belt-and-braces
 
 try:
     from langgraph.prebuilt import ToolNode
-except ImportError:  # pragma: no cover - older langgraph
+except ModuleNotFoundError as _exc:  # pragma: no cover
+    # Distinguish "langgraph not installed at all" from "langgraph installed
+    # without the prebuilt submodule". The former is a user-actionable error;
+    # the latter (older langgraph) gracefully falls back to ToolNode=None.
+    if _exc.name == "langgraph" or (_exc.name or "").startswith("langgraph."):
+        if _exc.name == "langgraph":
+            raise ModuleNotFoundError(
+                "cogflow.agent.tools requires `langgraph`. "
+                "Install with `pip install cogflow[agent]`."
+            ) from _exc
     ToolNode = None  # type: ignore[assignment]
 
 __all__ = ["ToolNode", "tool"]

--- a/cogflow/agent/tracing/__init__.py
+++ b/cogflow/agent/tracing/__init__.py
@@ -1,0 +1,48 @@
+"""Tracing adapters.
+
+Usage:
+
+    from cogflow.agent.tracing import configure_tracing
+    configure_tracing(backend="mlflow", experiment="agentflow")  # default
+    configure_tracing(backend="langsmith", project="agentflow")  # opt-in
+    configure_tracing(backend="otel", endpoint="http://collector:4318")
+    configure_tracing(backend=None)                              # disable all
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import TracingAdapter
+from .langsmith import LangSmithAdapter
+from .mlflow import MLflowAdapter
+from .otel import OTelAdapter
+
+_ADAPTERS: dict[str, TracingAdapter] = {
+    "mlflow": MLflowAdapter(),
+    "langsmith": LangSmithAdapter(),
+    "otel": OTelAdapter(),
+}
+
+
+def configure_tracing(backend: str | None = "mlflow", **kwargs: Any) -> TracingAdapter | None:
+    """Enable (or disable) a tracing backend. Backends are stackable —
+    successive calls with different backends compose."""
+    if backend is None:
+        for adapter in _ADAPTERS.values():
+            adapter.disable()
+        return None
+    if backend not in _ADAPTERS:
+        raise ValueError(f"unknown tracing backend {backend!r}; one of {sorted(_ADAPTERS)}")
+    adapter = _ADAPTERS[backend]
+    adapter.enable(**kwargs)
+    return adapter
+
+
+__all__ = [
+    "LangSmithAdapter",
+    "MLflowAdapter",
+    "OTelAdapter",
+    "TracingAdapter",
+    "configure_tracing",
+]

--- a/cogflow/agent/tracing/__init__.py
+++ b/cogflow/agent/tracing/__init__.py
@@ -26,8 +26,13 @@ _ADAPTERS: dict[str, TracingAdapter] = {
 
 
 def configure_tracing(backend: str | None = "mlflow", **kwargs: Any) -> TracingAdapter | None:
-    """Enable (or disable) a tracing backend. Backends are stackable —
-    successive calls with different backends compose."""
+    """Enable (or disable) a tracing backend.
+
+    Successive calls with *different* backends compose (mlflow + otel can both
+    be on). Successive calls with the *same* backend are idempotent: the
+    adapter is first disabled (restoring any saved state) then re-enabled with
+    the new kwargs, so callbacks/instrumentors never stack.
+    """
     if backend is None:
         for adapter in _ADAPTERS.values():
             adapter.disable()
@@ -35,6 +40,7 @@ def configure_tracing(backend: str | None = "mlflow", **kwargs: Any) -> TracingA
     if backend not in _ADAPTERS:
         raise ValueError(f"unknown tracing backend {backend!r}; one of {sorted(_ADAPTERS)}")
     adapter = _ADAPTERS[backend]
+    adapter.disable()  # idempotent — no-op when not currently enabled
     adapter.enable(**kwargs)
     return adapter
 

--- a/cogflow/agent/tracing/base.py
+++ b/cogflow/agent/tracing/base.py
@@ -1,0 +1,15 @@
+"""Abstract base for tracing adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class TracingAdapter(ABC):
+    name: str
+
+    @abstractmethod
+    def enable(self, **kwargs: object) -> None: ...
+
+    @abstractmethod
+    def disable(self) -> None: ...

--- a/cogflow/agent/tracing/langsmith.py
+++ b/cogflow/agent/tracing/langsmith.py
@@ -23,6 +23,17 @@ class LangSmithAdapter(TracingAdapter):
     def enable(self, *, project: str | None = None, api_key: str | None = None, **kwargs: Any) -> None:
         if self._enabled:
             return
+        # Verify the optional dep is present before we mutate any environment
+        # variables — otherwise tracing would silently appear enabled while
+        # LangChain has no LangSmith client to talk to.
+        try:
+            import langsmith  # noqa: F401
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "LangSmith tracing requires `langsmith`. "
+                "Install with `pip install cogflow[agent-langsmith]`."
+            ) from exc
+
         self._restore = {var: os.environ.get(var) for var in _MANAGED_ENV_VARS}
 
         os.environ["LANGCHAIN_TRACING_V2"] = "true"

--- a/cogflow/agent/tracing/langsmith.py
+++ b/cogflow/agent/tracing/langsmith.py
@@ -1,0 +1,27 @@
+"""LangSmith tracing adapter (opt-in)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .base import TracingAdapter
+
+
+class LangSmithAdapter(TracingAdapter):
+    name = "langsmith"
+
+    def __init__(self) -> None:
+        self._enabled = False
+
+    def enable(self, *, project: str | None = None, api_key: str | None = None, **kwargs: Any) -> None:
+        os.environ["LANGCHAIN_TRACING_V2"] = "true"
+        if project:
+            os.environ["LANGCHAIN_PROJECT"] = project
+        if api_key:
+            os.environ["LANGCHAIN_API_KEY"] = api_key
+        self._enabled = True
+
+    def disable(self) -> None:
+        os.environ.pop("LANGCHAIN_TRACING_V2", None)
+        self._enabled = False

--- a/cogflow/agent/tracing/langsmith.py
+++ b/cogflow/agent/tracing/langsmith.py
@@ -8,13 +8,21 @@ from typing import Any
 from .base import TracingAdapter
 
 
+_MANAGED_ENV_VARS = ("LANGCHAIN_TRACING_V2", "LANGCHAIN_PROJECT", "LANGCHAIN_API_KEY")
+
+
 class LangSmithAdapter(TracingAdapter):
     name = "langsmith"
 
     def __init__(self) -> None:
         self._enabled = False
+        # Snapshot of any env vars that existed *before* enable() — disable()
+        # restores them so this adapter is reversible across test runs.
+        self._restore: dict[str, str | None] = {}
 
     def enable(self, *, project: str | None = None, api_key: str | None = None, **kwargs: Any) -> None:
+        self._restore = {var: os.environ.get(var) for var in _MANAGED_ENV_VARS}
+
         os.environ["LANGCHAIN_TRACING_V2"] = "true"
         if project:
             os.environ["LANGCHAIN_PROJECT"] = project
@@ -23,5 +31,10 @@ class LangSmithAdapter(TracingAdapter):
         self._enabled = True
 
     def disable(self) -> None:
-        os.environ.pop("LANGCHAIN_TRACING_V2", None)
+        for var, prev in self._restore.items():
+            if prev is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = prev
+        self._restore = {}
         self._enabled = False

--- a/cogflow/agent/tracing/langsmith.py
+++ b/cogflow/agent/tracing/langsmith.py
@@ -21,6 +21,8 @@ class LangSmithAdapter(TracingAdapter):
         self._restore: dict[str, str | None] = {}
 
     def enable(self, *, project: str | None = None, api_key: str | None = None, **kwargs: Any) -> None:
+        if self._enabled:
+            return
         self._restore = {var: os.environ.get(var) for var in _MANAGED_ENV_VARS}
 
         os.environ["LANGCHAIN_TRACING_V2"] = "true"

--- a/cogflow/agent/tracing/mlflow.py
+++ b/cogflow/agent/tracing/mlflow.py
@@ -31,7 +31,7 @@ class MLflowAdapter(TracingAdapter):
         uri = tracking_uri
         if uri is None:
             try:
-                from cogflow import config as _cfg  # type: ignore  # noqa: WPS433
+                from cogflow.config import config as _cfg  # type: ignore  # noqa: WPS433
 
                 uri = getattr(_cfg, "MLFLOW_TRACKING_URI", None)
             except Exception:

--- a/cogflow/agent/tracing/mlflow.py
+++ b/cogflow/agent/tracing/mlflow.py
@@ -25,6 +25,8 @@ class MLflowAdapter(TracingAdapter):
         tracking_uri: str | None = None,
         **kwargs: Any,
     ) -> None:
+        if self._enabled:
+            return
         import mlflow
         import mlflow.langchain
 

--- a/cogflow/agent/tracing/mlflow.py
+++ b/cogflow/agent/tracing/mlflow.py
@@ -1,0 +1,54 @@
+"""MLflow Tracing adapter — the default backend.
+
+Calls ``mlflow.langchain.autolog()`` which registers a LangChain callback that
+emits a span for every LLM call, tool call, and chain step. Tracking URI is
+read from ``cogflow.config`` so traces land on the org's existing MLflow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import TracingAdapter
+
+
+class MLflowAdapter(TracingAdapter):
+    name = "mlflow"
+
+    def __init__(self) -> None:
+        self._enabled = False
+
+    def enable(
+        self,
+        *,
+        experiment: str | None = "cogflow-agent",
+        tracking_uri: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        import mlflow
+        import mlflow.langchain
+
+        uri = tracking_uri
+        if uri is None:
+            try:
+                from cogflow import config as _cfg  # type: ignore  # noqa: WPS433
+
+                uri = getattr(_cfg, "MLFLOW_TRACKING_URI", None)
+            except Exception:
+                uri = None
+
+        if uri:
+            mlflow.set_tracking_uri(uri)
+        if experiment:
+            mlflow.set_experiment(experiment)
+
+        mlflow.langchain.autolog(**kwargs)
+        self._enabled = True
+
+    def disable(self) -> None:
+        if not self._enabled:
+            return
+        import mlflow.langchain
+
+        mlflow.langchain.autolog(disable=True)
+        self._enabled = False

--- a/cogflow/agent/tracing/mlflow.py
+++ b/cogflow/agent/tracing/mlflow.py
@@ -32,11 +32,14 @@ class MLflowAdapter(TracingAdapter):
 
         uri = tracking_uri
         if uri is None:
+            # Only swallow the "config not importable" or "attribute missing"
+            # cases. A runtime error inside ``cogflow.config`` (e.g., bad
+            # settings evaluation) should bubble up — silently falling back
+            # to ``uri=None`` would mask real config bugs.
             try:
                 from cogflow.config import config as _cfg  # type: ignore  # noqa: WPS433
-
                 uri = getattr(_cfg, "MLFLOW_TRACKING_URI", None)
-            except Exception:
+            except (ImportError, AttributeError):
                 uri = None
 
         if uri:

--- a/cogflow/agent/tracing/otel.py
+++ b/cogflow/agent/tracing/otel.py
@@ -15,6 +15,8 @@ class OTelAdapter(TracingAdapter):
         self._instrumentor: Any = None
 
     def enable(self, *, endpoint: str | None = None, **kwargs: Any) -> None:
+        if self._enabled:
+            return
         try:
             from openinference.instrumentation.langchain import (  # type: ignore[import-not-found]
                 LangChainInstrumentor,
@@ -49,4 +51,5 @@ class OTelAdapter(TracingAdapter):
     def disable(self) -> None:
         if self._enabled and self._instrumentor is not None:
             self._instrumentor.uninstrument()
+        self._instrumentor = None
         self._enabled = False

--- a/cogflow/agent/tracing/otel.py
+++ b/cogflow/agent/tracing/otel.py
@@ -22,7 +22,7 @@ class OTelAdapter(TracingAdapter):
         except ImportError as exc:  # pragma: no cover - optional dep
             raise RuntimeError(
                 "OTel tracing requires `openinference-instrumentation-langchain`; "
-                "install with `pip install cogflow[agent]`."
+                "install with `pip install cogflow[agent-otel]`."
             ) from exc
 
         if endpoint:

--- a/cogflow/agent/tracing/otel.py
+++ b/cogflow/agent/tracing/otel.py
@@ -41,8 +41,17 @@ class OTelAdapter(TracingAdapter):
                 provider = TracerProvider()
                 provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
                 trace.set_tracer_provider(provider)
-            except ImportError:  # pragma: no cover
-                pass
+            except ImportError as exporter_exc:
+                # Loud failure: tracing would otherwise appear enabled but
+                # nothing would actually reach the endpoint. Raise so the user
+                # learns to install the SDK + exporter explicitly.
+                raise RuntimeError(
+                    f"OTel endpoint={endpoint!r} was provided, but the OpenTelemetry SDK and OTLP "
+                    "exporter packages are not installed. Install with "
+                    "`pip install cogflow[agent-otel]` (which now pulls in opentelemetry-sdk and "
+                    "opentelemetry-exporter-otlp), or set `endpoint=None` to keep the LangChain "
+                    "instrumentor active without span export."
+                ) from exporter_exc
 
         self._instrumentor = LangChainInstrumentor()
         self._instrumentor.instrument()

--- a/cogflow/agent/tracing/otel.py
+++ b/cogflow/agent/tracing/otel.py
@@ -1,0 +1,52 @@
+"""OpenTelemetry tracing adapter (opt-in)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import TracingAdapter
+
+
+class OTelAdapter(TracingAdapter):
+    name = "otel"
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._instrumentor: Any = None
+
+    def enable(self, *, endpoint: str | None = None, **kwargs: Any) -> None:
+        try:
+            from openinference.instrumentation.langchain import (  # type: ignore[import-not-found]
+                LangChainInstrumentor,
+            )
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise RuntimeError(
+                "OTel tracing requires `openinference-instrumentation-langchain`; "
+                "install with `pip install cogflow[agent]`."
+            ) from exc
+
+        if endpoint:
+            try:
+                from opentelemetry import trace  # type: ignore[import-not-found]
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore[import-not-found]
+                    OTLPSpanExporter,
+                )
+                from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import-not-found]
+                from opentelemetry.sdk.trace.export import (  # type: ignore[import-not-found]
+                    BatchSpanProcessor,
+                )
+
+                provider = TracerProvider()
+                provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+                trace.set_tracer_provider(provider)
+            except ImportError:  # pragma: no cover
+                pass
+
+        self._instrumentor = LangChainInstrumentor()
+        self._instrumentor.instrument()
+        self._enabled = True
+
+    def disable(self) -> None:
+        if self._enabled and self._instrumentor is not None:
+            self._instrumentor.uninstrument()
+        self._enabled = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,21 @@ docs = [
   "pdoc3>=0.11.0"
 ]
 
+agent = [
+  "langgraph >=0.2,<0.5",
+  "langchain-core >=0.3,<0.4"
+]
+
+agent-langsmith = [
+  "cogflow[agent]",
+  "langsmith>=0.1.0"
+]
+
+agent-otel = [
+  "cogflow[agent]",
+  "openinference-instrumentation-langchain>=0.1.0"
+]
+
 [project.urls]
 Homepage = "https://github.com/HIRO-MicroDataCenters-BV/cogflow"
 Issues = "https://github.com/HIRO-MicroDataCenters-BV/cogflow/issues"
@@ -105,7 +120,21 @@ license-files = ["LICENSE.md", "NOTICE", "kfp/LICENSE"]
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra -q --cov=cogflow --cov-report=term-missing"
-testpaths = ["tests"]
+testpaths = ["tests", "cogflow/agent/tests"]
+
+[tool.ruff]
+# Scoped to the agent submodule only; the rest of cogflow keeps black+autopep8+pylint.
+extend-exclude = ["kfp", "build", "dist"]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+ignore = ["E501"]
+per-file-ignores = { "cogflow/agent/tests/*" = ["B011"] }
+
+[tool.ruff.format]
+quote-style = "double"
 
 [tool.setuptools.dynamic]
 version = {attr = "cogflow.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,11 @@ addopts = "-ra -q --cov=cogflow --cov-report=term-missing"
 testpaths = ["tests", "cogflow/agent/tests"]
 
 [tool.ruff]
-# Scoped to the agent submodule only; the rest of cogflow keeps black+autopep8+pylint.
+# Restrict Ruff to the agent submodule so a bare ``ruff check`` doesn't try to
+# lint the rest of cogflow (which is on black+autopep8+pylint). To lint /
+# format only this submodule, run ``ruff check cogflow/agent`` or
+# ``ruff format cogflow/agent``.
+include = ["cogflow/agent/**/*.py"]
 extend-exclude = ["kfp", "build", "dist"]
 line-length = 120
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ agent-langsmith = [
 
 agent-otel = [
   "cogflow[agent]",
-  "openinference-instrumentation-langchain>=0.1.0"
+  "openinference-instrumentation-langchain>=0.1.0",
+  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-exporter-otlp>=1.20.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,12 @@ include = ["cogflow", "cogflow*", "kfp", "kfp*"]
 [tool.setuptools]
 license-files = ["LICENSE.md", "NOTICE", "kfp/LICENSE"]
 
+# Note: ``pytest.ini`` is the active config file for this repo — pytest prefers
+# it over ``[tool.pytest.ini_options]`` here. Agent-test discovery is driven
+# from ``pytest.ini`` (testpaths) so a plain ``pytest`` run picks them up
+# locally. Wiring the suite into CI (``.github/workflows/ci.yml`` currently
+# runs ``pytest tests/`` with only ``[dev]`` installed) is intentionally left
+# for a separate, explicitly-reviewed change.
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra -q --cov=cogflow --cov-report=term-missing"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
 pythonpath = .
+testpaths =
+    tests
+    cogflow/agent/tests
 filterwarnings =
     ignore::DeprecationWarning:pkg_resources
     ignore::DeprecationWarning:urllib3


### PR DESCRIPTION
## Summary

Introduces `cogflow.agent`, a LangGraph-shaped Python SDK whose graphs round-trip to Flowise V2 AgentFlow JSON. Same code can run in production on LangGraph **and** export to a Flowise canvas for visual review.

Two first-class workflows:

- **Direction A — Flowise POC → LangGraph production.** Import a marketplace JSON, get an executable `CompiledStateGraph`.
- **Direction B — Python-first → Flowise visualization.** Build with the `StateGraph` facade, emit valid Flowise V2 JSON.

A single pydantic `IRGraph` sits in the middle; both directions go through it.

## What's in Phase 1

- **IR + facade**: `cogflow/agent/ir/` (pydantic v2 models), `cogflow/agent/graph.py` (LangGraph-shaped `StateGraph` subclass that captures IR on every mutation).
- **MVP-7 node factories** + StickyNote in `cogflow/agent/nodes/`: Start, LLM, Agent, Tool, Condition, ConditionAgent, DirectReply.
- **Flowise V2 importer** (`parse.flowise.from_file`) and **emitter** (`compile.to_flowise.to_dict`/`to_file`) — lossless round-trip on MVP-7 via a `flowise_provenance` escape hatch on every node/edge.
- **LangGraph compiler** (`compile.to_langgraph`) producing a real `CompiledStateGraph`.
- **State synthesis**: TypedDict ↔ Flowise `startState`, with `add_messages` reducer preserved both directions.
- **MLflow Tracing adapter** (default) via `cogflow.config.MLFLOW_TRACKING_URI`; LangSmith and OTel adapters opt-in via `configure_tracing(backend=...)`.
- **20 tests**: drop-in import compat, IR round-trip on `Simple RAG.json` / `Structured Output.json` / `Translator.json`, LangGraph compile + invoke, state synthesis, MLflow autolog.

## Drop-in import migration (LangGraph → cogflow.agent)

| Original | cogflow.agent |
|---|---|
| `from langgraph.graph import StateGraph, START, END, MessagesState, add_messages` | `from cogflow.agent import StateGraph, START, END, MessagesState, add_messages` |
| `from langgraph.prebuilt import create_react_agent, ToolNode` | `from cogflow.agent import create_react_agent` / `from cogflow.agent.tools import ToolNode` |
| `from langgraph.types import interrupt, Command` | `from cogflow.agent import interrupt, Command` |
| `from langgraph.checkpoint.memory import MemorySaver` | `from cogflow.agent.runtime.checkpoint import MemorySaver` |
| `from langchain_core.tools import tool` | `from cogflow.agent.tools import tool` |

Provider SDKs (`langchain_openai`, `langchain_anthropic`, message classes) stay as direct deps — the SDK is provider-agnostic. `test_import_compat.py` enforces this table.

## Dependency surface

`langgraph` and `langchain-core` ship as the **`cogflow[agent]` optional extra**, not core deps — `pip install cogflow` is unaffected. `cogflow.agent.__init__` raises a clear install hint if the extras are missing. `cogflow[agent-langsmith]` and `cogflow[agent-otel]` are also available for the optional tracing backends.

## Out of scope (Phase 2)

The 8 bridged node types (Loop, Iteration, HTTP, Retriever, CustomFunction, HumanInput, ExecuteFlow) **parse to IR with full provenance for round-trip**, but their factories + runtime mappings land in Phase 2 (alongside `compile/to_python.py` source emit, LangSmith adapter wiring, and the checkpointer ergonomics). StickyNote ships now.

## Test plan

- [x] `pytest cogflow/agent/tests` → 20 passed, 0 failed locally
- [x] Re-ran the full pre-existing `cogflow/tests/` suite before vs. after — same `211 passed, 16 failed, 48 errors` (failures all `ModuleNotFoundError` in `test_serving.py`, pre-existing, unrelated to this PR)
- [x] Round-trip check on `Simple RAG.json` is byte-equivalent on the `nodes`/`edges` blocks (modulo dict key ordering)
- [ ] Reviewer: install with `pip install -e ".[dev,agent]"` and run `pytest cogflow/agent/tests`
- [ ] Reviewer: drop the emitter output from `test_python_first_emit.py` into a real Flowise canvas to sanity-check Direction B

## Files

- `cogflow/__init__.py` — adds `"agent"` to `_LAZY_SUBMODULES`
- `pyproject.toml` — three optional-deps groups (`agent`, `agent-langsmith`, `agent-otel`); ruff scoped to `cogflow/agent/**`; testpaths extended
- `cogflow/agent/**` — 38 new Python files across `ir/`, `nodes/`, `parse/`, `compile/`, `tracing/`, `runtime/`, plus tests

Architecture plan and rationale: see PR conversation if needed (also documented in commit message).