### PR TITLE
agent: Phase 3 — compile/to_python source emit

### DIFF
--- a/cogflow/agent/compile/__init__.py
+++ b/cogflow/agent/compile/__init__.py
@@ -1,6 +1,6 @@
-"""IR compilers (IR -> LangGraph, IR -> Flowise JSON)."""
+"""IR compilers (IR -> LangGraph runtime, IR -> Flowise JSON, IR -> Python source)."""
 
-from . import to_flowise
+from . import to_flowise, to_python
 from .to_langgraph import to_langgraph
 
-__all__ = ["to_flowise", "to_langgraph"]
+__all__ = ["to_flowise", "to_langgraph", "to_python"]

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -53,35 +53,46 @@ _PY_TYPE_FOR_STATE: dict[str, str] = {
 }
 
 
+def _state_field_annotation(f: IRStateField) -> str:
+    py = _PY_TYPE_FOR_STATE.get(f.type_, "Any")
+    if f.reducer == "add_messages" or f.type_ == "messages":
+        return "Annotated[list, add_messages]"
+    if f.reducer == "operator.add":
+        return f"Annotated[{py}, operator.add]"
+    return py
+
+
 def _state_typeddict(fields: list[IRStateField]) -> str:
-    """Render the IR state as a TypedDict class definition."""
+    """Render the IR state as a TypedDict.
+
+    Uses the **functional** ``TypedDict('FlowState', {...}, total=False)``
+    form so keys can be arbitrary strings — Flowise's ``startState`` JSON
+    permits keys like ``"user id"`` or ``"foo-bar"`` that would otherwise
+    produce invalid Python with the class syntax.
+    """
     if not fields:
         return (
-            "class FlowState(TypedDict, total=False):\n"
-            "    messages: Annotated[list, add_messages]\n"
+            'FlowState = TypedDict(\n'
+            '    "FlowState",\n'
+            '    {"messages": Annotated[list, add_messages]},\n'
+            '    total=False,\n'
+            ')\n'
         )
-    lines = ["class FlowState(TypedDict, total=False):"]
-    for f in fields:
-        py = _PY_TYPE_FOR_STATE.get(f.type_, "Any")
-        if f.reducer == "add_messages" or f.type_ == "messages":
-            lines.append(f"    {f.key}: Annotated[list, add_messages]")
-        elif f.reducer == "operator.add":
-            lines.append(f"    {f.key}: Annotated[{py}, operator.add]")
-        else:
-            lines.append(f"    {f.key}: {py}")
-    return "\n".join(lines) + "\n"
+    items = ",\n".join(f'        {f.key!r}: {_state_field_annotation(f)}' for f in fields)
+    return (
+        'FlowState = TypedDict(\n'
+        '    "FlowState",\n'
+        '    {\n'
+        f'{items},\n'
+        '    },\n'
+        '    total=False,\n'
+        ')\n'
+    )
 
 
 # ---------------------------------------------------------------------------
 # Per-node-type body renderers
 # ---------------------------------------------------------------------------
-
-
-def _py_literal(value: Any) -> str:
-    """Best-effort repr for emitting into source. Falls back to repr()."""
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return repr(value)
-    return repr(value)
 
 
 def _render_passthrough(node: IRNode) -> str:
@@ -234,8 +245,9 @@ _SKIP_TYPES = {"sticky_note", "start"}
 _CONDITION_TYPES = {"condition", "condition_agent"}
 
 
-def _render_edges(graph: IRGraph, runtime_ids: set[str]) -> list[str]:
+def _render_edges(graph: IRGraph, runtime_nodes: list[IRNode]) -> list[str]:
     lines: list[str] = []
+    runtime_ids = {n.id for n in runtime_nodes}
 
     # Entry edge from START.
     start_id = graph.entry
@@ -251,11 +263,13 @@ def _render_edges(graph: IRGraph, runtime_ids: set[str]) -> list[str]:
             lines.append(f"builder.add_edge(START, {start_id!r})")
             start_wired = True
 
-    if not start_wired and not runtime_ids:
+    if not start_wired and not runtime_nodes:
         lines.append("builder.add_edge(START, END)")
-    elif not start_wired and runtime_ids:
-        first = sorted(runtime_ids)[0]
-        lines.append(f"builder.add_edge(START, {first!r})")
+    elif not start_wired and runtime_nodes:
+        # Mirror ``compile.to_langgraph``: use declaration order (the first
+        # runtime node in ``graph.nodes``), not alphabetical sort. The two
+        # emit paths should agree on entry behaviour for malformed graphs.
+        lines.append(f"builder.add_edge(START, {runtime_nodes[0].id!r})")
 
     routed: set[str] = set()
     ended: set[str] = set()
@@ -389,7 +403,6 @@ def to_source(graph: IRGraph, *, app_var: str = "app") -> str:
     validate(graph)
 
     runtime_nodes = [n for n in graph.nodes if n.type not in _SKIP_TYPES]
-    runtime_ids = {n.id for n in runtime_nodes}
 
     parts: list[str] = [_HEADER, _state_typeddict(graph.state), "\n"]
 
@@ -403,7 +416,7 @@ def to_source(graph: IRGraph, *, app_var: str = "app") -> str:
         parts.append(f"builder.add_node({node.id!r}, {_node_fn(node.id)})\n")
     parts.append("\n")
 
-    edge_lines = _render_edges(graph, runtime_ids)
+    edge_lines = _render_edges(graph, runtime_nodes)
     for line in edge_lines:
         parts.append(line + "\n")
     parts.append("\n")

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -109,15 +109,21 @@ def _render_direct_reply(node: IRNode) -> str:
     # emitted code would otherwise call ``None.format(...)`` and crash.
     raw = node.config.get("directReplyMessage")
     message = raw if isinstance(raw, str) else ""
-    # Catch ValueError too — str.format raises it for malformed templates
-    # (unmatched braces, replacement-field syntax errors), which happens
-    # whenever the user's reply text legitimately contains a ``{`` or ``}``.
+    # ``.format(**state)`` can raise:
+    #   - KeyError / IndexError: template references a missing key
+    #   - ValueError: malformed template (unmatched braces — common when the
+    #     user's reply text literally contains a ``{`` or ``}``)
+    #   - TypeError: ``state`` contains keys that aren't valid Python
+    #     identifiers (Flowise startState legitimately allows ``"user id"`` /
+    #     ``"step-count"`` since R3 switched to the functional TypedDict).
+    # In every case, fall back to the unrendered template — the node still
+    # produces output and the graph doesn't crash.
     return (
         f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
         f"    rendered = {message!r}\n"
         f"    try:\n"
         f"        rendered = {message!r}.format(**state)\n"
-        f"    except (KeyError, IndexError, ValueError):\n"
+        f"    except (KeyError, IndexError, ValueError, TypeError):\n"
         f"        pass\n"
         f"    return {{'messages': [AIMessage(content=rendered)] }} if rendered else {{}}\n"
     )

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -1,0 +1,379 @@
+"""IR -> standalone LangGraph Python source.
+
+Emits a self-contained ``.py`` file that builds the same graph using only
+``langgraph`` and ``langchain_core`` — no runtime dependency on
+``cogflow.agent``. Useful for:
+
+  - shipping an agent to an environment that has only the upstream
+    LangGraph stack installed;
+  - inspecting the generated structure during debugging;
+  - serving as a starting point for hand-tuning (the output is ordinary
+    Python that runs through ``black``/``ruff`` cleanly).
+
+The contract is best-effort, not lossless: the emitted file always
+produces a valid ``CompiledStateGraph`` for the MVP-7 nodes (Start, LLM,
+Agent, Tool, Condition, ConditionAgent, DirectReply) plus Loop and
+HumanInput, which have clean LangGraph mappings. Bridge nodes with
+opaque runtime semantics (HTTP, Retriever, CustomFunction body, ExecuteFlow,
+Iteration) emit a clearly-marked TODO stub so the user knows where to
+wire their own implementation. StickyNote / Unknown nodes are skipped.
+
+Public entry points:
+
+    cogflow.agent.compile.to_python.to_source(graph) -> str
+    cogflow.agent.compile.to_python.to_file(graph, path) -> Path
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from ..ir.model import IRGraph, IRNode, IRStateField
+from ..ir.validate import END_SENTINEL, validate
+from .topo import edges_from
+
+
+# ---------------------------------------------------------------------------
+# State schema
+# ---------------------------------------------------------------------------
+
+
+_PY_TYPE_FOR_STATE: dict[str, str] = {
+    "str": "str",
+    "int": "int",
+    "float": "float",
+    "bool": "bool",
+    "list": "list",
+    "dict": "dict",
+    "messages": "list",
+}
+
+
+def _state_typeddict(fields: list[IRStateField]) -> str:
+    """Render the IR state as a TypedDict class definition."""
+    if not fields:
+        return (
+            "class FlowState(TypedDict, total=False):\n"
+            "    messages: Annotated[list, add_messages]\n"
+        )
+    lines = ["class FlowState(TypedDict, total=False):"]
+    for f in fields:
+        py = _PY_TYPE_FOR_STATE.get(f.type_, "Any")
+        if f.reducer == "add_messages" or f.type_ == "messages":
+            lines.append(f"    {f.key}: Annotated[list, add_messages]")
+        elif f.reducer == "operator.add":
+            lines.append(f"    {f.key}: Annotated[{py}, operator.add]")
+        else:
+            lines.append(f"    {f.key}: {py}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-node-type body renderers
+# ---------------------------------------------------------------------------
+
+
+def _py_literal(value: Any) -> str:
+    """Best-effort repr for emitting into source. Falls back to repr()."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return repr(value)
+    return repr(value)
+
+
+def _render_passthrough(node: IRNode) -> str:
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"{node.type} node — runtime is a no-op.\"\"\"\n"
+        f"    return {{}}\n"
+    )
+
+
+def _render_direct_reply(node: IRNode) -> str:
+    message = node.config.get("directReplyMessage", "")
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    rendered = {message!r}\n"
+        f"    try:\n"
+        f"        rendered = {message!r}.format(**state)\n"
+        f"    except (KeyError, IndexError):\n"
+        f"        pass\n"
+        f"    return {{'messages': [AIMessage(content=rendered)] }} if rendered else {{}}\n"
+    )
+
+
+def _render_llm(node: IRNode) -> str:
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"LLM node — wire your ChatModel via the ``MODEL`` symbol.\"\"\"\n"
+        f"    if MODEL is None:\n"
+        f"        return {{}}\n"
+        f"    history = list(state.get('messages') or [])\n"
+        f"    response = MODEL.invoke(history)\n"
+        f"    return {{'messages': [response]}}\n"
+    )
+
+
+def _render_agent(node: IRNode) -> str:
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"Agent node — bind tools via ``TOOLS`` and a model via ``MODEL``.\"\"\"\n"
+        f"    if MODEL is None:\n"
+        f"        return {{}}\n"
+        f"    bound = MODEL.bind_tools(TOOLS) if TOOLS and hasattr(MODEL, 'bind_tools') else MODEL\n"
+        f"    response = bound.invoke(list(state.get('messages') or []))\n"
+        f"    return {{'messages': [response]}}\n"
+    )
+
+
+def _render_tool(node: IRNode) -> str:
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"Tool node — replace with your @tool function.\"\"\"\n"
+        f"    return {{}}\n"
+    )
+
+
+def _render_condition(node: IRNode) -> str:
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"Condition node — populates `_condition_branch` for routing.\"\"\"\n"
+        f"    # TODO: implement rule evaluation; ``add_conditional_edges`` reads\n"
+        f"    # the returned ``_condition_branch`` value.\n"
+        f"    return {{'_condition_branch': 'default'}}\n"
+    )
+
+
+def _render_loop(node: IRNode) -> str:
+    counter_key = f"_loop_count__{node.id}"
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"Loop node — increments a per-node counter; routing wired below.\"\"\"\n"
+        f"    current = int(state.get({counter_key!r}, 0) or 0)\n"
+        f"    return {{{counter_key!r}: current + 1}}\n"
+    )
+
+
+def _render_human_input(node: IRNode) -> str:
+    prompt = node.config.get("humanInputPrompt") or node.config.get("humanInputDescription") or ""
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    \"\"\"HumanInput node — pauses for user input via ``interrupt``.\"\"\"\n"
+        f"    reply = interrupt({{'prompt': {prompt!r}, 'node': {node.id!r}}})\n"
+        f"    return {{'human_input': reply}}\n"
+    )
+
+
+def _render_todo(node: IRNode) -> str:
+    """Bridge nodes whose runtime body is too domain-specific to auto-emit."""
+    return (
+        f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
+        f"    # TODO: cogflow.agent bridge node `{node.type}` — implement manually.\n"
+        f"    # IR config: {dict(node.config)!r}\n"
+        f"    return {{}}\n"
+    )
+
+
+_RENDERERS: dict[str, Callable[[IRNode], str]] = {
+    "llm": _render_llm,
+    "agent": _render_agent,
+    "tool": _render_tool,
+    "condition": _render_condition,
+    "condition_agent": _render_condition,  # same shape: writes _condition_branch
+    "direct_reply": _render_direct_reply,
+    "loop": _render_loop,
+    "human_input": _render_human_input,
+    "iteration": _render_todo,
+    "http": _render_todo,
+    "retriever": _render_todo,
+    "custom_function": _render_todo,
+    "execute_flow": _render_todo,
+}
+
+
+def _node_fn(node_id: str) -> str:
+    """Convert an IR node id to a valid Python identifier."""
+    sanitized = "".join(c if c.isalnum() or c == "_" else "_" for c in node_id)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "n_" + sanitized
+    return f"node_{sanitized}"
+
+
+# ---------------------------------------------------------------------------
+# Edge wiring
+# ---------------------------------------------------------------------------
+
+
+_SKIP_TYPES = {"sticky_note", "unknown", "start"}
+_CONDITION_TYPES = {"condition", "condition_agent"}
+
+
+def _render_edges(graph: IRGraph, runtime_ids: set[str]) -> list[str]:
+    lines: list[str] = []
+
+    # Entry edge from START.
+    start_id = graph.entry
+    start_wired = False
+    if start_id is not None:
+        entry_node = graph.node_by_id(start_id)
+        if entry_node is not None and entry_node.type == "start":
+            for e in edges_from(graph, start_id):
+                if e.target in runtime_ids:
+                    lines.append(f"builder.add_edge(START, {e.target!r})")
+                    start_wired = True
+        elif start_id in runtime_ids:
+            lines.append(f"builder.add_edge(START, {start_id!r})")
+            start_wired = True
+
+    if not start_wired and not runtime_ids:
+        lines.append("builder.add_edge(START, END)")
+    elif not start_wired and runtime_ids:
+        first = sorted(runtime_ids)[0]
+        lines.append(f"builder.add_edge(START, {first!r})")
+
+    routed: set[str] = set()
+    ended: set[str] = set()
+
+    for node in graph.nodes:
+        if node.id not in runtime_ids:
+            continue
+
+        if node.type == "loop":
+            target = (
+                node.config.get("loopTarget")
+                or node.config.get("loopBackToNode")
+                or ""
+            )
+            if target and "-" in target and target not in runtime_ids:
+                target = target.split("-", 1)[0]
+            if target and target not in runtime_ids:
+                target = ""
+            max_iters = int(
+                node.config.get("loopMaxIterations") or node.config.get("maxLoopCount") or 5
+            )
+            counter_key = f"_loop_count__{node.id}"
+            exit_target_repr = "END"
+            for e in edges_from(graph, node.id):
+                if e.target in runtime_ids and e.target != target:
+                    exit_target_repr = repr(e.target)
+                    break
+            lines.append(
+                f"def _{_node_fn(node.id)}_router(state, "
+                f"_k={counter_key!r}, _max={max_iters!r}, _t={target!r}, _exit={exit_target_repr}):\n"
+                f"    return _t if (_t and int(state.get(_k, 0) or 0) < _max) else _exit"
+            )
+            lines.append(f"builder.add_conditional_edges({node.id!r}, _{_node_fn(node.id)}_router)")
+            routed.add(node.id)
+            if exit_target_repr == "END":
+                ended.add(node.id)
+            continue
+
+        outs = [e for e in edges_from(graph, node.id) if e.target in runtime_ids or e.target == END_SENTINEL]
+        if not outs:
+            lines.append(f"builder.add_edge({node.id!r}, END)")
+            ended.add(node.id)
+            continue
+
+        if node.type in _CONDITION_TYPES and len(outs) > 1:
+            mapping_items = []
+            for e in outs:
+                key = e.label or e.target_handle or e.target
+                value = "END" if e.target == END_SENTINEL else repr(e.target)
+                mapping_items.append(f"    {key!r}: {value}")
+            mapping_body = ",\n".join(mapping_items)
+            router_name = f"_{_node_fn(node.id)}_router"
+            lines.append(
+                f"def {router_name}(state):\n"
+                f"    _mapping = {{\n{mapping_body},\n    }}\n"
+                f"    branch = state.get('_condition_branch')\n"
+                f"    return _mapping[branch] if isinstance(branch, str) and branch in _mapping else next(iter(_mapping.values()))"
+            )
+            lines.append(f"builder.add_conditional_edges({node.id!r}, {router_name})")
+            routed.add(node.id)
+        else:
+            for e in outs:
+                target_repr = "END" if e.target == END_SENTINEL else repr(e.target)
+                lines.append(f"builder.add_edge({node.id!r}, {target_repr})")
+                if e.target == END_SENTINEL:
+                    ended.add(node.id)
+
+    for fid in graph.finish:
+        if fid in runtime_ids and fid not in ended and fid not in routed:
+            lines.append(f"builder.add_edge({fid!r}, END)")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Top-level emit
+# ---------------------------------------------------------------------------
+
+
+_HEADER = '''\
+"""Auto-generated from a cogflow.agent IRGraph via compile.to_python.
+
+Edit by hand at your own risk — re-emitting will overwrite this file.
+"""
+
+# Note: no ``from __future__ import annotations`` — LangGraph's TypedDict
+# introspection (``get_type_hints``) needs the ``Annotated`` symbol bound
+# in the module's globalns at evaluation time, which only works when
+# annotations stay non-string at class-definition time.
+
+import operator
+from typing import Annotated, Any, TypedDict
+
+from langchain_core.messages import AIMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph import add_messages
+
+try:
+    from langgraph.types import interrupt
+except ImportError:  # older langgraph
+    def interrupt(payload):
+        raise RuntimeError("langgraph.types.interrupt not available")
+
+
+# Wire your model / tools here before invoking ``app``.
+MODEL: Any = None
+TOOLS: list[Any] = []
+
+'''
+
+
+def to_source(graph: IRGraph, *, app_var: str = "app") -> str:
+    """Render an IRGraph as a self-contained Python module string."""
+    validate(graph)
+
+    runtime_nodes = [n for n in graph.nodes if n.type not in _SKIP_TYPES]
+    runtime_ids = {n.id for n in runtime_nodes}
+
+    parts: list[str] = [_HEADER, _state_typeddict(graph.state), "\n"]
+
+    for node in runtime_nodes:
+        renderer = _RENDERERS.get(node.type, _render_passthrough)
+        parts.append(renderer(node))
+        parts.append("\n")
+
+    parts.append("builder = StateGraph(FlowState)\n")
+    for node in runtime_nodes:
+        parts.append(f"builder.add_node({node.id!r}, {_node_fn(node.id)})\n")
+    parts.append("\n")
+
+    edge_lines = _render_edges(graph, runtime_ids)
+    for line in edge_lines:
+        parts.append(line + "\n")
+    parts.append("\n")
+    parts.append(f"{app_var} = builder.compile()\n")
+
+    return "".join(parts)
+
+
+def to_file(graph: IRGraph, path: str | Path, *, app_var: str = "app") -> Path:
+    """Write the rendered source to ``path`` and return the Path."""
+    out = Path(path)
+    out.write_text(to_source(graph, app_var=app_var))
+    return out
+
+
+__all__ = ["to_source", "to_file"]

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -16,7 +16,10 @@ Agent, Tool, Condition, ConditionAgent, DirectReply) plus Loop and
 HumanInput, which have clean LangGraph mappings. Bridge nodes with
 opaque runtime semantics (HTTP, Retriever, CustomFunction body, ExecuteFlow,
 Iteration) emit a clearly-marked TODO stub so the user knows where to
-wire their own implementation. StickyNote / Unknown nodes are skipped.
+wire their own implementation. StickyNote nodes are skipped entirely.
+Unknown nodes compile as passthrough runtime nodes so surrounding edges
+keep flowing — same contract as ``compile.to_langgraph`` and documented
+on the IR.
 
 Public entry points:
 
@@ -90,7 +93,11 @@ def _render_passthrough(node: IRNode) -> str:
 
 
 def _render_direct_reply(node: IRNode) -> str:
-    message = node.config.get("directReplyMessage", "")
+    # Coerce to ``str`` — partially-populated IRs (or imported flows with
+    # an explicit ``null``) can carry ``directReplyMessage: None``, and the
+    # emitted code would otherwise call ``None.format(...)`` and crash.
+    raw = node.config.get("directReplyMessage")
+    message = raw if isinstance(raw, str) else ""
     # Catch ValueError too — str.format raises it for malformed templates
     # (unmatched braces, replacement-field syntax errors), which happens
     # whenever the user's reply text legitimately contains a ``{`` or ``}``.
@@ -195,8 +202,20 @@ _RENDERERS: dict[str, Callable[[IRNode], str]] = {
 
 
 def _node_fn(node_id: str) -> str:
-    """Convert an IR node id to a valid Python identifier."""
+    """Convert an IR node id to a valid Python identifier.
+
+    Naive char-replacement collides on ids like ``a-b`` vs ``a_b`` (both
+    become ``node_a_b``). Append a short deterministic hash of the raw id
+    whenever sanitization changes anything, so distinct ids always produce
+    distinct function names.
+    """
     sanitized = "".join(c if c.isalnum() or c == "_" else "_" for c in node_id)
+    if sanitized != node_id:
+        # Use blake2b for a short, stable, dependency-free suffix.
+        import hashlib
+
+        suffix = hashlib.blake2b(node_id.encode("utf-8"), digest_size=4).hexdigest()
+        sanitized = f"{sanitized}__{suffix}"
     if sanitized and sanitized[0].isdigit():
         sanitized = "n_" + sanitized
     return f"node_{sanitized}"
@@ -355,8 +374,18 @@ TOOLS: list[Any] = []
 '''
 
 
+import keyword as _kw
+
+
 def to_source(graph: IRGraph, *, app_var: str = "app") -> str:
     """Render an IRGraph as a self-contained Python module string."""
+    # ``app_var`` is interpolated verbatim into the emitted source; refuse
+    # anything that isn't a bare identifier so the contract ("output is
+    # always valid Python") holds even if the caller passes a hostile value.
+    if not isinstance(app_var, str) or not app_var.isidentifier() or _kw.iskeyword(app_var):
+        raise ValueError(
+            f"app_var must be a valid non-keyword Python identifier; got {app_var!r}"
+        )
     validate(graph)
 
     runtime_nodes = [n for n in graph.nodes if n.type not in _SKIP_TYPES]

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -91,12 +91,15 @@ def _render_passthrough(node: IRNode) -> str:
 
 def _render_direct_reply(node: IRNode) -> str:
     message = node.config.get("directReplyMessage", "")
+    # Catch ValueError too — str.format raises it for malformed templates
+    # (unmatched braces, replacement-field syntax errors), which happens
+    # whenever the user's reply text legitimately contains a ``{`` or ``}``.
     return (
         f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
         f"    rendered = {message!r}\n"
         f"    try:\n"
         f"        rendered = {message!r}.format(**state)\n"
-        f"    except (KeyError, IndexError):\n"
+        f"    except (KeyError, IndexError, ValueError):\n"
         f"        pass\n"
         f"    return {{'messages': [AIMessage(content=rendered)] }} if rendered else {{}}\n"
     )
@@ -204,7 +207,11 @@ def _node_fn(node_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-_SKIP_TYPES = {"sticky_note", "unknown", "start"}
+# Mirror ``compile.to_langgraph``: only ``sticky_note`` and ``start`` are
+# excluded from the runtime set. ``unknown`` nodes get a passthrough body so
+# surrounding edges keep flowing (matches the IR contract documented in
+# ``ir/model.py`` and the parse/import path).
+_SKIP_TYPES = {"sticky_note", "start"}
 _CONDITION_TYPES = {"condition", "condition_agent"}
 
 
@@ -252,8 +259,15 @@ def _render_edges(graph: IRGraph, runtime_ids: set[str]) -> list[str]:
                 node.config.get("loopMaxIterations") or node.config.get("maxLoopCount") or 5
             )
             counter_key = f"_loop_count__{node.id}"
+            # Walk outgoing edges in order, accepting the first eligible exit:
+            # an explicit END edge (END_SENTINEL) or a non-target runtime edge.
+            # Mirrors ``compile.to_langgraph``'s scan so the two emit paths
+            # don't diverge based on edge ordering.
             exit_target_repr = "END"
             for e in edges_from(graph, node.id):
+                if e.target == END_SENTINEL:
+                    exit_target_repr = "END"
+                    break
                 if e.target in runtime_ids and e.target != target:
                     exit_target_repr = repr(e.target)
                     break

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -1,27 +1,51 @@
-"""IR -> standalone LangGraph Python source.
+"""IR -> standalone LangGraph Python source. **Migration tool, not a runtime.**
 
-Emits a self-contained ``.py`` file that builds the same graph using only
-``langgraph`` and ``langchain_core`` — no runtime dependency on
-``cogflow.agent``. Useful for:
+Scope
+-----
 
-  - shipping an agent to an environment that has only the upstream
-    LangGraph stack installed;
-  - inspecting the generated structure during debugging;
-  - serving as a starting point for hand-tuning (the output is ordinary
-    Python that runs through ``black``/``ruff`` cleanly).
+This module exists for **one** use case: porting a Flowise-authored agent
+out of Flowise into a maintainable Python codebase. It is *not* a parallel
+runtime — for graphs built in Python with ``cogflow.agent.StateGraph``,
+calling ``g.compile()`` already returns a real
+``langgraph.graph.CompiledStateGraph`` (the SDK's ``StateGraph`` is a
+literal subclass of LangGraph's, IR is captured as a side-effect via
+``add_node``/``add_edge`` overrides). Calling ``to_python`` on a
+Python-first graph would just hand you a less-readable version of your
+own source.
 
-The contract is best-effort, not lossless: the emitted file always
-produces a valid ``CompiledStateGraph`` for the MVP-7 nodes (Start, LLM,
-Agent, Tool, Condition, ConditionAgent, DirectReply) plus Loop and
-HumanInput, which have clean LangGraph mappings. Bridge nodes with
-opaque runtime semantics (HTTP, Retriever, CustomFunction body, ExecuteFlow,
-Iteration) emit a clearly-marked TODO stub so the user knows where to
+When this is useful::
+
+    # Got a Flowise JSON from a visual designer? Migrate to maintainable code:
+    from cogflow.agent.parse import flowise
+    from cogflow.agent.compile import to_python
+    ir = flowise.from_file("my_flow.json")
+    to_python.to_file(ir, "my_agent.py")  # cogflow-free, langgraph-only source
+
+When this is *not* useful::
+
+    # Already authored in Python — you don't need this, ``g.compile()`` is enough:
+    g = StateGraph(MyState)
+    g.add_node(...)
+    g.add_edge(START, END)
+    app = g.compile()         # ← real CompiledStateGraph, no further emit needed
+    app.invoke({...})         # ← runs on LangGraph directly
+
+Coverage and semantics
+----------------------
+
+The emitted file always produces a valid ``CompiledStateGraph`` (the
+"output is always syntactically valid Python that execs cleanly" contract
+holds for every Flowise V2 node type). MVP-7 nodes (Start, LLM, Agent,
+Tool, Condition, ConditionAgent, DirectReply) plus Loop and HumanInput
+emit working bodies because they have clean LangGraph mappings. Bridge
+nodes with opaque runtime semantics (HTTP, Retriever, CustomFunction
+body, ExecuteFlow, Iteration) emit a clearly-marked ``TODO`` stub —
+secrets in the dumped config are redacted — so the user knows where to
 wire their own implementation. StickyNote nodes are skipped entirely.
 Unknown nodes compile as passthrough runtime nodes so surrounding edges
-keep flowing — same contract as ``compile.to_langgraph`` and documented
-on the IR.
+keep flowing (matches ``compile.to_langgraph`` and the IR contract).
 
-Public entry points:
+Public entry points::
 
     cogflow.agent.compile.to_python.to_source(graph) -> str
     cogflow.agent.compile.to_python.to_file(graph, path) -> Path

--- a/cogflow/agent/compile/to_python.py
+++ b/cogflow/agent/compile/to_python.py
@@ -183,20 +183,71 @@ def _render_loop(node: IRNode) -> str:
 
 def _render_human_input(node: IRNode) -> str:
     prompt = node.config.get("humanInputPrompt") or node.config.get("humanInputDescription") or ""
+    # Honour the configured output key (defaulting to ``human_input``) so the
+    # emitted graph agrees with ``HumanInputFactory.to_callable``.
+    output_key = node.config.get("humanInputOutputKey") or "human_input"
     return (
         f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
         f"    \"\"\"HumanInput node — pauses for user input via ``interrupt``.\"\"\"\n"
-        f"    reply = interrupt({{'prompt': {prompt!r}, 'node': {node.id!r}}})\n"
-        f"    return {{'human_input': reply}}\n"
+        f"    rendered = {prompt!r}\n"
+        f"    try:\n"
+        f"        rendered = {prompt!r}.format(**state)\n"
+        f"    except (KeyError, IndexError, ValueError, TypeError):\n"
+        f"        pass\n"
+        f"    reply = interrupt({{'prompt': rendered, 'node': {node.id!r}}})\n"
+        f"    return {{{output_key!r}: reply}}\n"
     )
 
 
+# Substrings (case-insensitive) that mark a config key as potentially holding
+# a secret. Conservative: better to redact something harmless than leak a token.
+_SECRET_HINTS = (
+    "key", "token", "secret", "password", "passwd",
+    "auth", "authorization", "credential", "apikey",
+    "bearer", "private",
+)
+
+
+def _looks_like_secret(key: str) -> bool:
+    k = key.lower()
+    return any(hint in k for hint in _SECRET_HINTS)
+
+
+def _redact_value(key: str, value: Any) -> Any:
+    """Replace a single field with ``<REDACTED>`` when its key looks sensitive.
+
+    Recurses into dicts and lists so nested secrets (``httpHeaders.x-api-key``)
+    are caught too. Lists are walked element-wise; non-string keys in nested
+    structures are passed through untouched.
+    """
+    if _looks_like_secret(key) and value not in (None, "", [], {}):
+        return "<REDACTED>"
+    if isinstance(value, dict):
+        return {k: _redact_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(key, item) for item in value]
+    return value
+
+
+def _redacted_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Replace likely-secret values with ``<REDACTED>`` for emit (recursive)."""
+    return {k: _redact_value(k, v) for k, v in config.items()}
+
+
 def _render_todo(node: IRNode) -> str:
-    """Bridge nodes whose runtime body is too domain-specific to auto-emit."""
+    """Bridge nodes whose runtime body is too domain-specific to auto-emit.
+
+    The original IR config is dumped into a comment so the user can port
+    the body manually, but values keyed on ``*key``/``*token``/``*secret``/
+    ``*auth``/``*password``/``*credential`` are redacted. Flowise inputs
+    legitimately contain auth headers + API keys; emitting them verbatim
+    into checked-in files would leak credentials.
+    """
+    redacted = _redacted_config(dict(node.config))
     return (
         f"def {_node_fn(node.id)}(state: FlowState) -> dict:\n"
         f"    # TODO: cogflow.agent bridge node `{node.type}` — implement manually.\n"
-        f"    # IR config: {dict(node.config)!r}\n"
+        f"    # IR config (secrets redacted): {redacted!r}\n"
         f"    return {{}}\n"
     )
 

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -253,7 +253,6 @@ def test_conditional_branch_to_end_emits_END_in_mapping():
 
 def test_human_input_emit_honours_custom_output_key():
     """HumanInput's emitted source must use the configured output key."""
-    _require = pytest  # alias just so the import-skip is on the import line
     start = IRNode(id="s0", type="start", label="Start")
     hi = IRNode(
         id="hi0",

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -53,9 +53,10 @@ def exec_module():
         sys.modules.pop(name, None)
 
 
-# Backwards-compat shim for tests that still call _exec_module directly; uses
-# the fixture's body but does no cleanup (used only in tests where the exec'd
-# module is short-lived and the caller doesn't keep a reference).
+# Same behaviour as the ``exec_module`` fixture above, but callable directly
+# from tests that don't take a fixture argument. The fake module is popped
+# from ``sys.modules`` in a ``finally`` block so the suite never accumulates
+# stale entries — only the returned namespace dict keeps the live refs.
 def _exec_module(source: str) -> dict[str, Any]:
     import sys
     import types
@@ -135,6 +136,34 @@ def test_to_file_writes_to_disk(tmp_path: Path):
 def test_state_synthesis_emits_add_messages_reducer():
     src = to_python.to_source(_basic_graph())
     assert "Annotated[list, add_messages]" in src
+
+
+def test_state_keys_with_non_identifier_chars_emit_valid_python():
+    """Flowise ``startState`` keys can be arbitrary strings (``foo bar``, ``foo-bar``).
+
+    The class-syntax TypedDict would have produced a SyntaxError; the
+    functional form (``TypedDict('FlowState', {...}, total=False)``) handles
+    arbitrary string keys cleanly.
+    """
+    start = IRNode(id="s0", type="start", label="Start")
+    reply = IRNode(id="r0", type="direct_reply", label="Reply", config={"directReplyMessage": "ok"})
+    graph = IRGraph(
+        state=[
+            IRStateField(key="user id", type="str"),
+            IRStateField(key="step-count", type="int"),
+            IRStateField(key="messages", type="messages", reducer="add_messages"),
+        ],
+        nodes=[start, reply],
+        edges=[IREdge(id="e0", source="s0", target="r0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)
+    # The functional form preserves the literal keys as dict keys.
+    assert "'user id'" in src
+    assert "'step-count'" in src
+    ns = _exec_module(src)
+    assert hasattr(ns["app"], "invoke")
 
 
 def test_simple_rag_fixture_compiles_to_python(simple_rag_path: Path):

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -251,6 +251,62 @@ def test_conditional_branch_to_end_emits_END_in_mapping():
     assert hasattr(ns["app"], "invoke")
 
 
+def test_human_input_emit_honours_custom_output_key():
+    """HumanInput's emitted source must use the configured output key."""
+    _require = pytest  # alias just so the import-skip is on the import line
+    start = IRNode(id="s0", type="start", label="Start")
+    hi = IRNode(
+        id="hi0",
+        type="human_input",
+        label="Ask",
+        config={"humanInputDescription": "approve?", "humanInputOutputKey": "user_reply"},
+    )
+    graph = IRGraph(
+        nodes=[start, hi],
+        edges=[IREdge(id="e0", source="s0", target="hi0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)
+    # Emitted return should use the custom key, not the hardcoded "human_input".
+    assert "'user_reply': reply" in src
+    assert "'human_input': reply" not in src
+
+
+def test_bridge_node_todo_redacts_secret_config_values():
+    """Bridge-node TODO stubs must not leak API keys / tokens / passwords."""
+    start = IRNode(id="s0", type="start", label="Start")
+    http_node = IRNode(
+        id="h0",
+        type="http",
+        label="Call",
+        config={
+            "httpUrl": "https://api.example.com/v1/thing",
+            "httpHeaders": {"x-api-key": "sk-LIVE-supersecret"},
+            "apiKey": "sk-also-secret",
+            "bearerToken": "eyJraWQ-not-actually",
+            "password": "hunter2",
+            "httpMethod": "GET",
+        },
+    )
+    graph = IRGraph(
+        nodes=[start, http_node],
+        edges=[IREdge(id="e0", source="s0", target="h0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    # The literal secret values must not appear in the emitted source.
+    assert "sk-LIVE-supersecret" not in src
+    assert "sk-also-secret" not in src
+    assert "eyJraWQ-not-actually" not in src
+    assert "hunter2" not in src
+    # Non-secret keys still appear (so the TODO stub is informative).
+    assert "httpUrl" in src
+    assert "https://api.example.com/v1/thing" in src
+    # The redaction marker appears.
+    assert "<REDACTED>" in src
+
+
 def test_direct_reply_survives_non_identifier_state_keys():
     """``state`` can contain Flowise-style keys like ``"user id"``; ``.format(**state)`` would otherwise TypeError."""
     start = IRNode(id="s0", type="start", label="Start")

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -1,0 +1,181 @@
+"""Tests for cogflow.agent.compile.to_python source emit.
+
+Each test renders the IR to a Python module string, ensures it parses
+(``compile()``), then ``exec``s it in a clean namespace and asserts the
+resulting ``app`` is a real ``CompiledStateGraph`` you can invoke without
+cogflow.agent imported.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cogflow.agent.compile import to_python
+from cogflow.agent.ir.model import IREdge, IRGraph, IRNode, IRPort, IRStateField
+from cogflow.agent.parse.flowise import from_file
+
+
+_FAKE_MODULE_COUNTER = 0
+
+
+def _exec_module(source: str) -> dict[str, Any]:
+    """Compile + exec the rendered source in a fresh module-style namespace.
+
+    LangGraph's ``get_type_hints`` resolves forward refs through the class's
+    ``__module__``, so a bare ``exec(src, {})`` fails to find ``Annotated``
+    even when it's imported in the source. We register the namespace as a
+    fake module in ``sys.modules`` so name resolution works.
+    """
+    import sys
+    import types
+
+    global _FAKE_MODULE_COUNTER
+    _FAKE_MODULE_COUNTER += 1
+    mod_name = f"_cogflow_to_python_emitted_{_FAKE_MODULE_COUNTER}"
+    module = types.ModuleType(mod_name)
+    sys.modules[mod_name] = module
+    code = compile(source, mod_name, "exec")
+    exec(code, module.__dict__)
+    return module.__dict__
+
+
+def _basic_graph() -> IRGraph:
+    """Minimal IR: Start → DirectReply (returns 'hi')."""
+    start = IRNode(
+        id="start_0",
+        type="start",
+        label="Start",
+        outputs=[IRPort(id="start_0-output-start", name="startAgentflow", type="start")],
+    )
+    reply = IRNode(
+        id="reply_0",
+        type="direct_reply",
+        label="Reply",
+        config={"directReplyMessage": "hi"},
+    )
+    edge = IREdge(id="e0", source="start_0", target="reply_0")
+    return IRGraph(
+        state=[IRStateField(key="messages", type="messages", reducer="add_messages")],
+        nodes=[start, reply],
+        edges=[edge],
+        entry="start_0",
+    )
+
+
+def test_to_source_is_syntactically_valid_python():
+    src = to_python.to_source(_basic_graph())
+    # Parse-only check first so any syntax issue surfaces with a clear error.
+    ast.parse(src)
+
+
+def test_to_source_produces_compiled_state_graph():
+    src = to_python.to_source(_basic_graph())
+    ns = _exec_module(src)
+    assert "app" in ns
+    assert "FlowState" in ns
+    # The compiled object has an ``invoke`` method (LangGraph runnable).
+    assert hasattr(ns["app"], "invoke")
+
+
+def test_emitted_module_runs_end_to_end():
+    """Invoke the exec'd app and verify the DirectReply message lands."""
+    src = to_python.to_source(_basic_graph())
+    ns = _exec_module(src)
+    result = ns["app"].invoke({"messages": []})
+    out_messages = result.get("messages", [])
+    contents = [getattr(m, "content", "") for m in out_messages]
+    assert "hi" in contents
+
+
+def test_to_file_writes_to_disk(tmp_path: Path):
+    out = to_python.to_file(_basic_graph(), tmp_path / "agent.py")
+    assert out.is_file()
+    text = out.read_text()
+    assert "builder = StateGraph(FlowState)" in text
+    assert "app = builder.compile()" in text
+
+
+def test_state_synthesis_emits_add_messages_reducer():
+    src = to_python.to_source(_basic_graph())
+    assert "Annotated[list, add_messages]" in src
+
+
+def test_simple_rag_fixture_compiles_to_python(simple_rag_path: Path):
+    """A real Flowise marketplace fixture should emit valid Python."""
+    ir = from_file(simple_rag_path)
+    src = to_python.to_source(ir)
+    ast.parse(src)  # syntactic validity
+    ns = _exec_module(src)
+    assert hasattr(ns["app"], "invoke")
+
+
+def test_iterations_fixture_emits_todo_for_bridge_nodes(iterations_path: Path):
+    """Bridge-node types must emit a TODO marker so users see what's stubbed."""
+    ir = from_file(iterations_path)
+    src = to_python.to_source(ir)
+    assert "TODO: cogflow.agent bridge node `iteration`" in src
+    # And the file is still syntactically valid Python.
+    ast.parse(src)
+
+
+def test_sticky_note_and_unknown_nodes_are_skipped():
+    """Sticky notes and unknown types must not generate node functions or edges."""
+    start = IRNode(id="s0", type="start", label="Start")
+    sticky = IRNode(id="sticky_0", type="sticky_note", label="Note", config={"note": "hello"})
+    reply = IRNode(id="r0", type="direct_reply", label="Reply", config={"directReplyMessage": "bye"})
+    graph = IRGraph(
+        nodes=[start, sticky, reply],
+        edges=[IREdge(id="e0", source="s0", target="r0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    assert "sticky_0" not in src  # not registered as a node
+    assert "node_r0" in src       # the real reply node IS rendered
+
+
+def test_conditional_branch_to_end_emits_END_in_mapping():
+    """Conditional routing with an END branch must translate to LangGraph's END."""
+    from cogflow.agent.ir.validate import END_SENTINEL
+
+    start = IRNode(id="s0", type="start", label="Start")
+    cond = IRNode(id="c0", type="condition", label="Route")
+    other = IRNode(id="o0", type="direct_reply", label="Other", config={"directReplyMessage": "x"})
+    graph = IRGraph(
+        nodes=[start, cond, other],
+        edges=[
+            IREdge(id="e0", source="s0", target="c0"),
+            IREdge(id="e1", source="c0", target="o0", label="go"),
+            IREdge(id="e2", source="c0", target=END_SENTINEL, label="stop"),
+        ],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    assert "'go': 'o0'" in src
+    assert "'stop': END" in src
+    # Confirm the emitted source still parses + execs cleanly.
+    ns = _exec_module(src)
+    assert hasattr(ns["app"], "invoke")
+
+
+def test_node_id_with_special_chars_is_sanitized():
+    """Function names must be valid Python identifiers regardless of node id shape."""
+    start = IRNode(id="start", type="start", label="Start")
+    weird = IRNode(
+        id="agent-with-dashes.and.dots",
+        type="direct_reply",
+        label="W",
+        config={"directReplyMessage": "ok"},
+    )
+    graph = IRGraph(
+        nodes=[start, weird],
+        edges=[IREdge(id="e0", source="start", target="agent-with-dashes.and.dots")],
+        entry="start",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)  # no SyntaxError from invalid identifiers
+    # Underscored version appears as the function name.
+    assert "def node_agent_with_dashes_and_dots" in src

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -22,14 +22,41 @@ from cogflow.agent.parse.flowise import from_file
 _FAKE_MODULE_COUNTER = 0
 
 
-def _exec_module(source: str) -> dict[str, Any]:
-    """Compile + exec the rendered source in a fresh module-style namespace.
+@pytest.fixture
+def exec_module():
+    """Compile + exec rendered source in a fresh module; auto-clean sys.modules.
 
     LangGraph's ``get_type_hints`` resolves forward refs through the class's
-    ``__module__``, so a bare ``exec(src, {})`` fails to find ``Annotated``
-    even when it's imported in the source. We register the namespace as a
-    fake module in ``sys.modules`` so name resolution works.
+    ``__module__``, so a bare ``exec(src, {})`` fails to find ``Annotated``.
+    We register a real module so name resolution works, and tear it down in
+    the fixture's finalizer so the suite doesn't leak modules.
     """
+    import sys
+    import types
+
+    created: list[str] = []
+
+    def _run(source: str) -> dict[str, Any]:
+        global _FAKE_MODULE_COUNTER
+        _FAKE_MODULE_COUNTER += 1
+        mod_name = f"_cogflow_to_python_emitted_{_FAKE_MODULE_COUNTER}"
+        module = types.ModuleType(mod_name)
+        sys.modules[mod_name] = module
+        created.append(mod_name)
+        code = compile(source, mod_name, "exec")
+        exec(code, module.__dict__)
+        return module.__dict__
+
+    yield _run
+
+    for name in created:
+        sys.modules.pop(name, None)
+
+
+# Backwards-compat shim for tests that still call _exec_module directly; uses
+# the fixture's body but does no cleanup (used only in tests where the exec'd
+# module is short-lived and the caller doesn't keep a reference).
+def _exec_module(source: str) -> dict[str, Any]:
     import sys
     import types
 
@@ -38,9 +65,15 @@ def _exec_module(source: str) -> dict[str, Any]:
     mod_name = f"_cogflow_to_python_emitted_{_FAKE_MODULE_COUNTER}"
     module = types.ModuleType(mod_name)
     sys.modules[mod_name] = module
-    code = compile(source, mod_name, "exec")
-    exec(code, module.__dict__)
-    return module.__dict__
+    try:
+        code = compile(source, mod_name, "exec")
+        exec(code, module.__dict__)
+        return module.__dict__
+    finally:
+        # Pop from sys.modules so the test suite doesn't accumulate fake
+        # modules; the returned dict still holds the live references the
+        # caller needs.
+        sys.modules.pop(mod_name, None)
 
 
 def _basic_graph() -> IRGraph:
@@ -187,6 +220,58 @@ def test_conditional_branch_to_end_emits_END_in_mapping():
     # Confirm the emitted source still parses + execs cleanly.
     ns = _exec_module(src)
     assert hasattr(ns["app"], "invoke")
+
+
+def test_direct_reply_with_none_message_does_not_crash():
+    """Partially-populated IRs can carry ``directReplyMessage=None``."""
+    start = IRNode(id="s0", type="start", label="Start")
+    reply = IRNode(id="r0", type="direct_reply", label="Reply", config={"directReplyMessage": None})
+    graph = IRGraph(
+        nodes=[start, reply],
+        edges=[IREdge(id="e0", source="s0", target="r0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)
+    ns = _exec_module(src)
+    # No message → no AIMessage emitted; just an empty state update.
+    assert ns["app"].invoke({"messages": []}).get("messages", []) == []
+
+
+def test_node_fn_avoids_collisions_on_different_special_char_ids():
+    """``a-b`` and ``a_b`` must not collapse to the same emitted function."""
+    start = IRNode(id="s0", type="start", label="Start")
+    a = IRNode(id="a-b", type="direct_reply", label="A", config={"directReplyMessage": "A"})
+    b = IRNode(id="a_b", type="direct_reply", label="B", config={"directReplyMessage": "B"})
+    graph = IRGraph(
+        nodes=[start, a, b],
+        edges=[
+            IREdge(id="e0", source="s0", target="a-b"),
+            IREdge(id="e1", source="a-b", target="a_b"),
+        ],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)
+    # ``a-b`` gets a hash-suffixed identifier; ``a_b`` keeps its bare form.
+    # No matter what, the two ``def node_*`` lines must be distinct.
+    fn_defs = [line for line in src.splitlines() if line.startswith("def node_")]
+    assert len(fn_defs) == len(set(fn_defs)), f"function name collision: {fn_defs}"
+
+
+def test_to_source_rejects_invalid_app_var():
+    """``app_var`` must be a Python identifier (not a keyword, not arbitrary code)."""
+    g = _basic_graph()
+    for bad in ("not an identifier", "1nope", "app; print('hi')", "class", ""):
+        with pytest.raises(ValueError, match="app_var"):
+            to_python.to_source(g, app_var=bad)
+
+
+def test_to_source_accepts_custom_valid_app_var():
+    g = _basic_graph()
+    src = to_python.to_source(g, app_var="my_agent")
+    assert "my_agent = builder.compile()" in src
+    ast.parse(src)
 
 
 def test_node_id_with_special_chars_is_sanitized():

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -122,8 +122,8 @@ def test_iterations_fixture_emits_todo_for_bridge_nodes(iterations_path: Path):
     ast.parse(src)
 
 
-def test_sticky_note_and_unknown_nodes_are_skipped():
-    """Sticky notes and unknown types must not generate node functions or edges."""
+def test_sticky_note_is_skipped():
+    """Sticky notes must not generate node functions or edges."""
     start = IRNode(id="s0", type="start", label="Start")
     sticky = IRNode(id="sticky_0", type="sticky_note", label="Note", config={"note": "hello"})
     reply = IRNode(id="r0", type="direct_reply", label="Reply", config={"directReplyMessage": "bye"})
@@ -135,6 +135,34 @@ def test_sticky_note_and_unknown_nodes_are_skipped():
     src = to_python.to_source(graph)
     assert "sticky_0" not in src  # not registered as a node
     assert "node_r0" in src       # the real reply node IS rendered
+
+
+def test_unknown_node_is_passthrough_keeping_topology_flowing():
+    """Unknown types compile as passthrough so surrounding edges keep flowing.
+
+    Mirrors the IR contract documented in ir/model.py and the parse path —
+    ``unknown`` nodes must be reachable, not silently dropped like StickyNote.
+    """
+    start = IRNode(id="s0", type="start", label="Start")
+    mystery = IRNode(id="m0", type="unknown", label="Mystery")
+    reply = IRNode(id="r0", type="direct_reply", label="Reply", config={"directReplyMessage": "hi"})
+    graph = IRGraph(
+        nodes=[start, mystery, reply],
+        edges=[
+            IREdge(id="e0", source="s0", target="m0"),
+            IREdge(id="e1", source="m0", target="r0"),
+        ],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    # The unknown node must be present (passthrough fn + node registration).
+    assert "node_m0" in src
+    assert "builder.add_node('m0'" in src
+    # And the edge through it must be preserved.
+    assert "builder.add_edge('m0', 'r0')" in src
+    # The whole module still execs cleanly.
+    ns = _exec_module(src)
+    assert hasattr(ns["app"], "invoke")
 
 
 def test_conditional_branch_to_end_emits_END_in_mapping():

--- a/cogflow/agent/tests/test_to_python.py
+++ b/cogflow/agent/tests/test_to_python.py
@@ -251,6 +251,34 @@ def test_conditional_branch_to_end_emits_END_in_mapping():
     assert hasattr(ns["app"], "invoke")
 
 
+def test_direct_reply_survives_non_identifier_state_keys():
+    """``state`` can contain Flowise-style keys like ``"user id"``; ``.format(**state)`` would otherwise TypeError."""
+    start = IRNode(id="s0", type="start", label="Start")
+    reply = IRNode(
+        id="r0",
+        type="direct_reply",
+        label="Reply",
+        # Template doesn't reference the weird key, but ``**state`` still
+        # unpacks it — must not crash.
+        config={"directReplyMessage": "hello world"},
+    )
+    graph = IRGraph(
+        state=[
+            IRStateField(key="user id", type="str"),
+            IRStateField(key="messages", type="messages", reducer="add_messages"),
+        ],
+        nodes=[start, reply],
+        edges=[IREdge(id="e0", source="s0", target="r0")],
+        entry="s0",
+    )
+    src = to_python.to_source(graph)
+    ast.parse(src)
+    ns = _exec_module(src)
+    result = ns["app"].invoke({"user id": "alice", "messages": []})
+    contents = [getattr(m, "content", "") for m in result.get("messages", [])]
+    assert "hello world" in contents
+
+
 def test_direct_reply_with_none_message_does_not_crash():
     """Partially-populated IRs can carry ``directReplyMessage=None``."""
     start = IRNode(id="s0", type="start", label="Start")


### PR DESCRIPTION
## Summary

**`to_python` is a Flowise → Python migration tool, not a parallel runtime.** This PR adds it so a team that prototyped an agent in Flowise can move it out of the visual canvas into maintainable code, with zero runtime dependency on `cogflow.agent`.

For graphs authored in Python via `cogflow.agent.StateGraph`, this module is redundant: `StateGraph` literally subclasses `langgraph.graph.StateGraph` and captures IR as a side-effect via `add_node`/`add_edge` overrides — `g.compile()` already returns a real `CompiledStateGraph` you can `.invoke()` on LangGraph. No transpilation, no proxy, no second runtime.

## When to use this

| Starting point | Already have | `to_python` adds |
|---|---|---|
| You wrote Python with `cogflow.agent.StateGraph` | `.py` source + working `g.compile().invoke()` | **nothing** — already covered |
| You got a Flowise JSON (visual designer, marketplace, customer flow) | An `IRGraph` + working runtime via `compile.to_langgraph` | **A maintainable `.py` file** you can fork, modify, ship without cogflow |

So this PR closes the migration path off Flowise. Phase 1 added Flowise → runtime; this adds Flowise → source.

## Coverage

The emitted file is **always syntactically valid Python that execs cleanly** for every Flowise V2 node type. The runtime behaviour split:

| Class | Nodes | Emitted body |
|---|---|---|
| MVP-7 + Loop + HumanInput | Start, LLM, Agent, Tool, Condition, ConditionAgent, DirectReply, Loop, HumanInput | Working — references user-supplied `MODEL` / `TOOLS` where needed |
| Bridge stubs | HTTP, Retriever, CustomFunction body, ExecuteFlow, Iteration | Clearly-marked `TODO` stub + IR config dump (secrets redacted) so the user knows where to wire their own implementation |
| Sticky note | StickyNote | Skipped entirely |
| Unknown | Unknown | Passthrough — keeps surrounding edges flowing (matches `compile.to_langgraph` and the IR contract) |

## Notable correctness work over the review loop

Six Copilot rounds surfaced and fixed:

- `unknown` was wrongly in `_SKIP_TYPES`, diverging from `compile.to_langgraph`
- `DirectReply` could crash on user text containing `{`/`}` (ValueError), on `None` message (AttributeError), or on non-identifier state keys after the functional TypedDict landed (TypeError) — now all four caught
- `_node_fn` collisions (`a-b` vs `a_b` → same name → silent overwrite) — fixed with blake2b suffix
- `app_var` interpolated verbatim → could break "always valid Python" — now validated as identifier
- Class-syntax TypedDict broke on `"user id"` / `"foo-bar"` state keys → switched to functional `TypedDict("FlowState", {...})`
- HumanInput emit ignored `humanInputOutputKey` and didn't format the prompt with state → now matches the runtime factory
- **Bridge-node TODO stubs were leaking secrets** — Flowise inputs legitimately include API keys / bearer tokens / auth headers, and the TODO stub dumped them into the source comment. Fixed with a recursive redactor that walks dicts/lists and replaces values keyed on `key`/`token`/`secret`/`password`/`auth`/`credential`/`apikey`/`bearer`/`private` with `<REDACTED>`. Caught nested `httpHeaders.x-api-key` alongside top-level fields.
- `_exec_module` was leaking fake modules into `sys.modules` across the test suite — `finally`-pop added.

## Tests

74 passing locally, 2 skipped. New tests include regressions for every bug above plus a marketplace smoke test that loads `Simple RAG.json` from the vendored fixtures, emits Python, ast-parses it, exec's it in a fake module, and asserts the resulting `app` has `invoke`.

## Out of scope

- `prebuilt.create_react_agent` IR wrapper
- mkdocs site
- Fluent builders