### PR TITLE
docs: bootstrap mkdocs site for the agent SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# mkdocs build output
+/site/
+
 # C extensions
 *.so
 

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -1,0 +1,148 @@
+# Architecture
+
+The SDK is one idea applied consistently: **the IR is the source of truth**,
+the runtime is the upstream LangGraph stack, and three emit/import paths
+plug into the IR.
+
+## The shape
+
+```text
+                              parse.flowise.from_file
+        Flowise V2 JSON  ──────────────────────────►  ┌───────────┐
+        Flowise V2 JSON  ◄──────────────────────────  │           │
+                              compile.to_flowise      │           │
+                                                      │    IR     │
+        Python (StateGraph)  ────► add_node/edge ───► │ (IRGraph) │
+                                                      │           │
+        compile.to_langgraph ◄───────────────────────│           │
+                ─►  CompiledStateGraph                └───────────┘
+                                                            │
+                                                  compile.to_python
+                                                            ▼
+                                                  standalone .py file
+```
+
+## Why an IR
+
+The naive design — wrap LangGraph internals at the runtime layer — would
+have forced us to maintain a parallel runtime, drift from LangGraph's
+own changes, and re-implement features (subgraphs, interrupts,
+checkpoints) that already exist.
+
+Instead, the SDK's `StateGraph` is a **subclass** of
+`langgraph.graph.StateGraph` whose mutator methods (`add_node`,
+`add_edge`, `add_conditional_edges`, `set_entry_point`,
+`set_finish_point`) override the parent to do two things:
+
+1. Mutate an in-memory `IRGraph` to record what was added.
+2. Delegate to `super()` so the runtime side is identical to LangGraph's.
+
+`g.compile()` calls `langgraph.graph.StateGraph.compile()` unmodified
+and returns the same `CompiledStateGraph` object. There is no transpile
+step, no proxy, no wrapping. The IR is a side-channel.
+
+## The IR shape
+
+```python
+class IRGraph(BaseModel):
+    schema_version: Literal["1.0"]
+    name: str
+    description: str | None
+    state: list[IRStateField]      # the TypedDict / startState fields
+    nodes: list[IRNode]
+    edges: list[IREdge]
+    entry: str | None              # node id or None
+    finish: list[str]              # nodes that route to END
+    viewport: dict[str, float] | None
+    flowise_provenance: dict[str, Any] | None   # round-trip escape hatch
+```
+
+Every `IRNode` and `IREdge` also has its own `flowise_provenance` slot —
+when a graph comes from a Flowise JSON, the parser stashes the raw node
+/ edge dict there. Emitters use it to reconstruct the JSON byte-for-byte
+for MVP-7 nodes (lossless round-trip).
+
+For nodes whose runtime semantics we don't fully model (Loop,
+Iteration, HTTP, Retriever, CustomFunction, HumanInput, ExecuteFlow,
+Unknown), provenance still preserves the structural fields so the JSON
+re-emit stays correct even when the runtime mapping is best-effort.
+
+## The three emit paths
+
+### `compile.to_langgraph(ir, *, factories=None, ctx=None, ...)`
+
+Walks the IR, registers a runtime callable for each non-skipped node,
+wires entry/finish/conditional/loop edges, and returns a
+`CompiledStateGraph`. Skip types: `sticky_note`. `start` nodes have no
+runtime body — `START` fans out from their outgoing edges.
+
+`ctx` is a shared mapping passed to every factory's `to_callable(node,
+ctx=...)`. Bridge nodes use it for runtime dependencies they couldn't
+capture at construction time:
+
+```python
+to_langgraph(
+    ir,
+    ctx={
+        "httpx": stub_or_real_client,        # HTTP node
+        "retriever": my_vectorstore,         # Retriever node
+        "flows": {"id": child_graph},        # ExecuteFlow node
+        "allow_custom_code": False,          # CustomFunction gate (default False)
+        "runtime_node_ids": ...,             # auto-seeded by the compiler
+    },
+)
+```
+
+### `compile.to_flowise.to_dict(ir, *, analytics=None) / to_file(ir, path, ...)`
+
+Reconstructs the Flowise V2 AgentFlow JSON. Provenance-backed nodes/edges
+re-emit verbatim; Python-built ones get a synthesized minimal-but-valid
+block. The `analytics` kwarg injects Flowise's own analytic config — use
+it to point a re-imported flow at the same MLflow your runtime uses.
+
+Round-trip on the MVP-7 marketplace fixtures (`Simple RAG.json`,
+`Structured Output.json`, `Translator.json`) is byte-identical on the
+`nodes` / `edges` blocks; the `Iterations.json` and `Human In The
+Loop.json` bridge-node fixtures round-trip with `flowise_provenance`
+preserving everything we don't explicitly model.
+
+### `compile.to_python.to_source(ir) / to_file(ir, path)`
+
+One-way **Flowise → Python migration tool**, not a parallel runtime.
+For Python-first graphs this is redundant — `g.compile()` already
+returns a real `CompiledStateGraph`. Use it to lift a Flowise-authored
+agent out of the canvas into a maintainable codebase. See
+[Migration guide](migration.md) for what's emitted, what's stubbed,
+and the secret-redaction behaviour.
+
+## Validation
+
+`compile.to_langgraph` runs `ir.validate.validate(graph)` first, which
+enforces:
+
+- At most one Start node
+- Either a Start node exists OR `graph.entry` overrides
+- `graph.entry` / `graph.finish` reference real nodes
+- No duplicate node or edge ids
+- Edge `source` / `target` point at real nodes (except for the
+  `END_SENTINEL` target, which encodes branch-level termination on
+  conditional edges)
+
+## Drop-in import compatibility
+
+The agent SDK's public surface re-exports LangGraph symbols where they
+exist:
+
+| LangGraph / LangChain | cogflow.agent equivalent |
+|---|---|
+| `langgraph.graph.StateGraph` | `cogflow.agent.StateGraph` (subclass) |
+| `langgraph.graph.START`, `END` | `cogflow.agent.START`, `END` (identity) |
+| `langgraph.graph.MessagesState`, `add_messages` | `cogflow.agent.MessagesState`, `add_messages` |
+| `langgraph.prebuilt.create_react_agent`, `ToolNode` | `cogflow.agent.create_react_agent`, `cogflow.agent.tools.ToolNode` |
+| `langgraph.types.interrupt`, `Command` | `cogflow.agent.interrupt`, `Command` |
+| `langgraph.checkpoint.memory.MemorySaver`, `SqliteSaver` | `cogflow.agent.runtime.checkpoint.MemorySaver`, `SqliteSaver` |
+| `langchain_core.tools.tool` | `cogflow.agent.tools.tool` |
+
+Provider SDKs (`langchain_openai`, `langchain_anthropic`, message
+classes, runnables) stay as direct deps — the SDK is provider-agnostic
+and doesn't try to abstract them.

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -101,10 +101,13 @@ block. The `analytics` kwarg injects Flowise's own analytic config — use
 it to point a re-imported flow at the same MLflow your runtime uses.
 
 Round-trip on the MVP-7 marketplace fixtures (`Simple RAG.json`,
-`Structured Output.json`, `Translator.json`) is byte-identical on the
-`nodes` / `edges` blocks; the `Iterations.json` and `Human In The
-Loop.json` bridge-node fixtures round-trip with `flowise_provenance`
-preserving everything we don't explicitly model.
+`Structured Output.json`, `Translator.json`) is **structurally
+identical** on the `nodes` / `edges` blocks — the round-trip tests
+normalize dict/list ordering and compare for deep equality, so field
+order may differ from the original but every field and value matches.
+The `Iterations.json` and `Human In The Loop.json` bridge-node
+fixtures round-trip with `flowise_provenance` preserving everything we
+don't explicitly model.
 
 ### `compile.to_python.to_source(ir) / to_file(ir, path)`
 
@@ -117,8 +120,8 @@ and the secret-redaction behaviour.
 
 ## Validation
 
-`compile.to_langgraph` runs `ir.validate.validate(graph)` first, which
-enforces:
+`compile.to_langgraph` runs `cogflow.agent.ir.validate.validate(graph)`
+first, which enforces:
 
 - At most one Start node
 - Either a Start node exists OR `graph.entry` overrides

--- a/docs/agent/getting-started.md
+++ b/docs/agent/getting-started.md
@@ -1,0 +1,136 @@
+# Getting started
+
+This page walks two paths in five minutes: build an agent in Python,
+then import the same shape from a Flowise canvas export.
+
+## Install
+
+```bash
+pip install "cogflow[agent]"
+```
+
+This pulls in `langgraph` and `langchain-core`. Plain `pip install
+cogflow` won't import `cogflow.agent` and will give you a clear hint
+pointing back here.
+
+For MLflow tracing through cogflow's existing tracking backend, no
+additional install is needed — `mlflow` is part of base cogflow. For
+OpenTelemetry: `pip install "cogflow[agent-otel]"`.
+
+## Path A: Python-first
+
+Build with `StateGraph` exactly as you would in LangGraph; the import
+path is the only difference.
+
+```python
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from cogflow.agent import END, START, StateGraph, add_messages
+
+
+class State(TypedDict, total=False):
+    messages: Annotated[list, add_messages]
+
+
+def greet(state: State) -> dict:
+    return {"messages": [AIMessage(content="hello")]}
+
+
+g = StateGraph(State)
+g.add_node("greet", greet)
+g.add_edge(START, "greet")
+g.add_edge("greet", END)
+
+app = g.compile()                                  # langgraph.graph.CompiledStateGraph
+result = app.invoke({"messages": [HumanMessage(content="hi")]})
+print([m.content for m in result["messages"]])
+# → ['hi', 'hello']
+```
+
+What just happened:
+
+- `StateGraph(State)` is `langgraph.graph.StateGraph`'s subclass — no proxy, no transpile.
+- `g.compile()` returns the same object LangGraph would. `app.invoke` is LangGraph's `invoke`.
+- An IR was captured on the side as you called `add_node` / `add_edge`. Reach it via `g.ir`.
+
+### Export to Flowise
+
+```python
+from cogflow.agent.compile import to_flowise
+
+to_flowise.to_file(g.ir, "agent.json")   # AgentFlow V2 JSON, import in Flowise
+```
+
+The JSON is loadable by Flowise's V2 canvas. Use this when stakeholders
+need a visual view of the agent or when handing off to a non-developer
+to edit.
+
+## Path B: Import from Flowise
+
+Got a Flowise V2 AgentFlow JSON (marketplace, your team's canvas, a
+customer flow)? Run it on LangGraph in one step:
+
+```python
+from cogflow.agent.parse import flowise
+from cogflow.agent.compile import to_langgraph
+
+ir = flowise.from_file("agent.json")
+app = to_langgraph(ir)                    # real CompiledStateGraph
+result = app.invoke({"messages": [("user", "hi")]})
+```
+
+### Wiring runtime objects into a JSON-loaded graph
+
+JSON doesn't carry live chat models, tool callables, retriever stores,
+or compiled child flows. Two injection points cover that:
+
+- **`factories=`** — per-node, when you want to bind a specific
+  factory instance to a single node id.
+- **`ctx=`** — shared with every node, threaded through to each
+  factory's `to_callable(node, ctx=ctx)`. Bridge nodes (HTTP, Retriever,
+  ExecuteFlow, CustomFunction, …) read their runtime dependencies from
+  here.
+
+```python
+from langchain_openai import ChatOpenAI
+
+app = to_langgraph(
+    ir,
+    ctx={
+        "retriever": my_vectorstore.as_retriever(),
+        "flows": {"child_flow_id": child_compiled_graph},
+        "allow_custom_code": False,   # default — CustomFunction Python bodies refuse to exec
+    },
+)
+```
+
+## Path C: One-way migration off Flowise
+
+If you want to **leave Flowise entirely** and continue in plain Python,
+emit a standalone source file:
+
+```python
+from cogflow.agent.parse import flowise
+from cogflow.agent.compile import to_python
+
+ir = flowise.from_file("agent.json")
+to_python.to_file(ir, "my_agent.py")
+```
+
+`my_agent.py` has no `cogflow` import — just `langgraph` and
+`langchain_core`. You can hand-edit it, ship it, fork it. See the
+[Migration guide](migration.md) for the full details on what's emitted
+and what's stubbed.
+
+## Tracing in one line
+
+```python
+from cogflow.agent.tracing import configure_tracing
+
+configure_tracing(backend="mlflow", experiment="my-agent")
+```
+
+Spans now flow to the MLflow tracking URI from `cogflow.config`. See
+[Tracing](tracing.md) for OpenTelemetry and stacking.

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -21,7 +21,7 @@ to **Flowise V2 AgentFlow JSON**. Two starting points are first-class:
 
 | Audience | Pain | What this gives them |
 |---|---|---|
-| Python engineer | Wants real LangGraph runtime, but also wants their agent visible to non-developers | `g.compile()` returns vanilla LangGraph; `compile.to_flowise(g.ir, path)` ships a Flowise-importable JSON |
+| Python engineer | Wants real LangGraph runtime, but also wants their agent visible to non-developers | `g.compile()` returns vanilla LangGraph; `compile.to_flowise.to_file(g.ir, path)` ships a Flowise-importable JSON |
 | Visual designer | Built an agent in Flowise but needs to deploy it without the canvas | `parse.flowise.from_file(path)` → real LangGraph runtime; or `compile.to_python.to_file(...)` for a cogflow-free `.py` they can maintain in code |
 | Platform team | Wants self-hosted observability, no vendor lock-in | MLflow Tracing via cogflow's existing kubeflow infra |
 

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -1,0 +1,52 @@
+# Agent SDK overview
+
+`cogflow.agent` is a **LangGraph-shaped Python SDK** whose graphs round-trip
+to **Flowise V2 AgentFlow JSON**. Two starting points are first-class:
+
+```text
+┌──────────────────┐                         ┌──────────────────────┐
+│  Python source   │  ── compile() ─────►   │  langgraph runtime   │
+│ (StateGraph DSL) │                         │  (real CompiledStateGraph) │
+└──────────────────┘                         └──────────────────────┘
+        ▲                                              ▲
+        │  to_flowise.to_dict                          │  compile.to_langgraph
+        ▼                                              │
+┌──────────────────┐    parse.flowise.from_file   ┌──────────────────────┐
+│  Flowise V2 JSON │ ─────────────────────────►   │  IR  (single source  │
+│  (canvas export) │ ◄─────────────────────────   │      of truth)       │
+└──────────────────┘     compile.to_flowise        └──────────────────────┘
+```
+
+## Why it exists
+
+| Audience | Pain | What this gives them |
+|---|---|---|
+| Python engineer | Wants real LangGraph runtime, but also wants their agent visible to non-developers | `g.compile()` returns vanilla LangGraph; `compile.to_flowise(g.ir, path)` ships a Flowise-importable JSON |
+| Visual designer | Built an agent in Flowise but needs to deploy it without the canvas | `parse.flowise.from_file(path)` → real LangGraph runtime; or `compile.to_python.to_file(...)` for a cogflow-free `.py` they can maintain in code |
+| Platform team | Wants self-hosted observability, no vendor lock-in | MLflow Tracing via cogflow's existing kubeflow infra |
+
+## The contract
+
+The SDK's `StateGraph` is a literal subclass of `langgraph.graph.StateGraph`.
+`add_node`, `add_edge`, `add_conditional_edges`, `set_entry_point` and
+`set_finish_point` are overridden to capture an in-memory **IR**
+(intermediate representation) on the side; `compile()` does no extra
+work — it returns the same `CompiledStateGraph` LangGraph itself would
+produce.
+
+The IR — separate from the runtime — is what enables Flowise JSON emit,
+JSON import, and one-way migration to standalone Python source.
+
+## Status (as of writing)
+
+- **All 15 Flowise V2 AgentFlow node types** representable in IR
+- **Three emit targets**: LangGraph runtime, Flowise V2 JSON, standalone Python source
+- **MLflow Tracing** ships as the default observability backend; OpenTelemetry is an opt-in extra
+- **LangSmith is not bundled** — it's a commercial service. Users who want it can set `LANGCHAIN_TRACING_V2=true` + `LANGCHAIN_API_KEY` themselves and LangChain will wire it up at runtime
+
+## Where to next
+
+- New here? → **[Getting started](getting-started.md)**
+- Want to understand why the design looks like this? → **[Architecture](architecture.md)**
+- Looking up a specific node type? → **[Node types](nodes.md)**
+- Migrating off Flowise? → **[Migration guide](migration.md)**

--- a/docs/agent/migration.md
+++ b/docs/agent/migration.md
@@ -87,8 +87,17 @@ catches:
 - Nested dict values: `httpHeaders.x-api-key`, `headers.Authorization`
 - List elements with secret-keyed siblings
 
-Non-secret config (URL, method, output key, model name) stays visible
-so the TODO stub is still informative.
+Non-secret config (URL, method, model name, etc.) stays visible so the
+TODO stub is still informative.
+
+!!! note "Conservative over-redaction"
+
+    Matching is by **substring**, so any config key containing
+    `key`/`token`/`secret`/`password`/`auth`/… is redacted — including
+    legitimately non-sensitive fields like `httpOutputKey` or
+    `customFunctionOutputKey`. This is intentional: leaking a token is
+    worse than hiding an output-key. If you need an over-redacted value
+    in the emitted TODO stub, recover it from the original Flowise JSON.
 
 ## What this doesn't do
 

--- a/docs/agent/migration.md
+++ b/docs/agent/migration.md
@@ -1,0 +1,117 @@
+# Migrating off Flowise
+
+`compile.to_python` is a **one-way migration tool**, not a parallel
+runtime. Use it to move a Flowise-authored agent out of the visual
+canvas into a maintainable Python codebase with **no runtime dependency
+on cogflow** — just `langgraph` and `langchain_core`.
+
+## When to use this
+
+```python
+# Got a Flowise JSON (visual designer, marketplace, customer flow)?
+# Lift it to maintainable code:
+from cogflow.agent.parse import flowise
+from cogflow.agent.compile import to_python
+
+ir = flowise.from_file("my_flow.json")
+to_python.to_file(ir, "my_agent.py")
+```
+
+`my_agent.py` is now a self-contained module the team can fork, modify,
+ship to environments that don't have cogflow installed, and run through
+`black`/`ruff` cleanly.
+
+## When *not* to use this
+
+If you authored the graph in Python with `cogflow.agent.StateGraph`,
+this is redundant. Your `StateGraph` is a literal subclass of
+`langgraph.graph.StateGraph`; `g.compile()` already returns a real
+`CompiledStateGraph`. Just call it:
+
+```python
+g = StateGraph(MyState)
+g.add_node(...)
+g.add_edge(START, END)
+app = g.compile()                       # real CompiledStateGraph
+app.invoke({"messages": [...]})        # runs on LangGraph directly
+```
+
+No emit step needed.
+
+## What gets emitted
+
+The emitted file is **always syntactically valid Python that execs
+cleanly** for every Flowise V2 node type.
+
+| Class | Nodes | Emitted body |
+|---|---|---|
+| MVP-7 + Loop + HumanInput | Start, LLM, Agent, Tool, Condition, ConditionAgent, DirectReply, Loop, HumanInput | Working — references user-supplied `MODEL` / `TOOLS` symbols where needed |
+| Bridge stubs | HTTP, Retriever, CustomFunction body, ExecuteFlow, Iteration | `TODO: cogflow.agent bridge node <type> — implement manually` + IR config dump (secrets redacted) |
+| Sticky note | StickyNote | Skipped entirely |
+| Unknown | Unknown | Passthrough — keeps surrounding edges flowing |
+
+## Wiring after emit
+
+The emitted module declares:
+
+```python
+MODEL: Any = None
+TOOLS: list[Any] = []
+```
+
+Before invoking `app`, set these to your real chat model and tools:
+
+```python
+import my_agent
+from langchain_openai import ChatOpenAI
+
+my_agent.MODEL = ChatOpenAI(model="gpt-4o-mini")
+my_agent.TOOLS = [my_search_tool, my_calculator_tool]
+
+result = my_agent.app.invoke({"messages": [...]})
+```
+
+For bridge-node stubs, replace the `TODO` body with your implementation
+referencing the IR config dump that's already inlined as a comment.
+
+## Secret redaction
+
+Flowise inputs legitimately include API keys, bearer tokens, auth
+headers, and passwords. The emitter walks `IRNode.config` recursively
+and replaces any value whose key contains (case-insensitive) `key`,
+`token`, `secret`, `password`, `passwd`, `auth`, `authorization`,
+`credential`, `apikey`, `bearer`, or `private` with `<REDACTED>`. This
+catches:
+
+- Top-level keys: `apiKey`, `bearerToken`, `password`
+- Nested dict values: `httpHeaders.x-api-key`, `headers.Authorization`
+- List elements with secret-keyed siblings
+
+Non-secret config (URL, method, output key, model name) stays visible
+so the TODO stub is still informative.
+
+## What this doesn't do
+
+- It doesn't run the agent — the emitted file does that.
+- It doesn't preserve Flowise-only artefacts that LangGraph has no
+  equivalent for (canvas layout, sticky-note text, analytics blocks).
+  Use the IR's `flowise_provenance` if you need those — they live in
+  the IR, just not the emit.
+- It doesn't replace `compile.to_langgraph`. For most users, the JSON
+  → LangGraph runtime path is faster and doesn't require hand-tuning.
+
+## Custom `app_var` name
+
+```python
+to_python.to_source(ir, app_var="customer_support_agent")
+```
+
+The output's final line becomes `customer_support_agent = builder.compile()`.
+The argument is validated as a Python identifier (and not a keyword)
+so the "always valid Python" contract holds.
+
+## Round-trip implications
+
+`compile.to_python` is **one-way**. Emitting Python doesn't write back
+to a Flowise JSON automatically. If you need both, keep the original
+JSON around and emit Python only when you're ready to leave Flowise.

--- a/docs/agent/nodes.md
+++ b/docs/agent/nodes.md
@@ -145,9 +145,15 @@ falls back to the first scenario.
 
 ### `direct_reply`
 
-Terminal node — writes an `AIMessage` and routes to `END`. The message
-is `.format(**state)`-templated and falls back to the raw template when
-a referenced key is missing (catches `KeyError` / `IndexError`).
+Writes an `AIMessage` into state and returns. Termination is governed
+by graph edges: when a `direct_reply` node has no outgoing edge to a
+runtime node, `compile.to_langgraph` auto-wires it to `END`. If you
+add explicit outgoing edges it will continue to those instead — the
+factory itself doesn't enforce termination.
+
+The message is `.format(**state)`-templated and falls back to the raw
+template when a referenced key is missing (catches `KeyError` /
+`IndexError`).
 
 ```python
 g.add_node("reply", direct_reply(message="Hi {user_name}, here's your summary."))

--- a/docs/agent/nodes.md
+++ b/docs/agent/nodes.md
@@ -12,7 +12,7 @@ Flowise-native config keys.
 | `startAgentflow` | `start` | `nodes.start(...)` | Native (no body — `START` fan-out) |
 | `llmAgentflow` | `llm` | `nodes.llm(...)` | Native (ChatModel `.invoke`) |
 | `agentAgentflow` | `agent` | `nodes.agent(...)` | Native (`bind_tools` + `.invoke`) |
-| `toolAgentflow` | `tool` | `nodes.tool_node(...)` | Native (`@tool` wrapper) |
+| `toolAgentflow` | `tool` | `nodes.tool_node(...)` | Native (calls a Python fn with `state["tool_input"]`, writes `tool_output`) |
 | `conditionAgentflow` | `condition` | `nodes.condition(...)` | Native (`add_conditional_edges`) |
 | `conditionAgentAgentflow` | `condition_agent` | `nodes.condition_agent(...)` | Native (LLM-driven router) |
 | `directReplyAgentflow` | `direct_reply` | `nodes.direct_reply(...)` | Native (writes `AIMessage`) |
@@ -65,13 +65,19 @@ g.add_node("llm_0", llm(
 ))
 ```
 
+The runtime calls the model with `messages` prepended to the chat
+history and returns `{"messages": [response]}`. Flowise keys
+`llmUpdateState` and `llmReturnResponseAs` are **preserved for
+Flowise round-trip** but the LangGraph runtime does not currently
+apply them — the node always returns its update under the `messages`
+channel.
+
 Flowise keys: `llmModel`, `llmMessages`, `llmUpdateState`, `llmReturnResponseAs`.
 
 ### `agent`
 
-ReAct-style loop: a chat model with tools bound. Prepends configured
-`agentMessages` to the model invocation; tool calls execute through
-LangGraph's built-in tool resolution.
+A chat model with tools **bound** (via `model.bind_tools`) and invoked
+once per call. `agentMessages` is prepended to the chat history.
 
 ```python
 from cogflow.agent.nodes import agent
@@ -80,10 +86,17 @@ g.add_node("agent_0", agent(
     model=ChatOpenAI(model="gpt-4o-mini"),
     tools=[search, calculator],
     messages=[{"role": "system", "content": "You are helpful."}],
-    enable_memory=True,
-    memory_type="allMessages",
 ))
 ```
+
+The runtime does a **single** `model.invoke(...)` call and returns
+`{"messages": [response]}`. If the model emits tool calls, they are
+*not* executed by this node — wire a separate `ToolNode` /
+`langgraph.prebuilt.ToolNode` or `nodes.tool_node(...)` and a
+conditional edge to get full ReAct semantics. Likewise `agentEnableMemory`,
+`agentMemoryType`, `agentReturnResponseAs`, and `agentUpdateState` are
+preserved for Flowise round-trip but **not** honoured by the LangGraph
+runtime today.
 
 Flowise keys: `agentModel`, `agentMessages`, `agentTools`, `agentEnableMemory`, `agentMemoryType`, `agentReturnResponseAs`, `agentUpdateState`.
 

--- a/docs/agent/nodes.md
+++ b/docs/agent/nodes.md
@@ -1,0 +1,277 @@
+# Node types
+
+All 15 Flowise V2 AgentFlow node types have a `cogflow.agent.nodes.*`
+factory. The factory's `__init__` carries Python-first kwargs; the same
+factory hydrates from JSON via `from_ir(ir_node)` using the
+Flowise-native config keys.
+
+## At a glance
+
+| Flowise `data.name` | IR type | Python factory | Runtime |
+|---|---|---|---|
+| `startAgentflow` | `start` | `nodes.start(...)` | Native (no body — `START` fan-out) |
+| `llmAgentflow` | `llm` | `nodes.llm(...)` | Native (ChatModel `.invoke`) |
+| `agentAgentflow` | `agent` | `nodes.agent(...)` | Native (`bind_tools` + `.invoke`) |
+| `toolAgentflow` | `tool` | `nodes.tool_node(...)` | Native (`@tool` wrapper) |
+| `conditionAgentflow` | `condition` | `nodes.condition(...)` | Native (`add_conditional_edges`) |
+| `conditionAgentAgentflow` | `condition_agent` | `nodes.condition_agent(...)` | Native (LLM-driven router) |
+| `directReplyAgentflow` | `direct_reply` | `nodes.direct_reply(...)` | Native (writes `AIMessage`) |
+| `loopAgentflow` | `loop` | `nodes.loop(...)` | Bridged (counter channel + back-edge router) |
+| `iterationAgentflow` | `iteration` | `nodes.iteration(...)` | Bridged (`langgraph.types.Send` fan-out) |
+| `httpAgentflow` | `http` | `nodes.http(...)` | Bridged (`httpx`) |
+| `retrieverAgentflow` | `retriever` | `nodes.retriever(...)` | Bridged (LangChain Retriever) |
+| `customFunctionAgentflow` | `custom_function` | `nodes.custom_function(...)` | Bridged (Python-only, gated) |
+| `humanInputAgentflow` | `human_input` | `nodes.human_input(...)` | Bridged (`langgraph.types.interrupt`) |
+| `executeFlowAgentflow` | `execute_flow` | `nodes.execute_flow(...)` | Bridged (nested `CompiledStateGraph.invoke`) |
+| `stickyNoteAgentflow` | `sticky_note` | `nodes.sticky_note(...)` | Skipped at compile |
+
+Unknown node types (not in the table) are preserved in IR with full
+`flowise_provenance` and compile to a passthrough runtime body so
+surrounding edges keep flowing.
+
+## MVP-7 nodes
+
+The seven "native" nodes have a clean LangGraph mapping.
+
+### `start`
+
+The entry point of an agentflow. No runtime body — `compile.to_langgraph`
+wires `START` to whatever the Start node fans out to.
+
+```python
+from cogflow.agent.nodes import start
+
+g.add_node("start_0", start(
+    input_type="chatInput",
+    ephemeral_memory=False,
+    persist_state=False,
+    state=[{"key": "user_id", "value": ""}],   # synthesises the FlowState
+))
+```
+
+Flowise keys: `startInputType`, `startEphemeralMemory`, `startPersistState`, `startState`.
+
+### `llm`
+
+Single chat-model call, no tools.
+
+```python
+from cogflow.agent.nodes import llm
+
+g.add_node("llm_0", llm(
+    model=ChatOpenAI(model="gpt-4o-mini"),
+    messages=[{"role": "system", "content": "You are concise."}],
+    update_state=[{"key": "summary", "value": "{{output}}"}],
+))
+```
+
+Flowise keys: `llmModel`, `llmMessages`, `llmUpdateState`, `llmReturnResponseAs`.
+
+### `agent`
+
+ReAct-style loop: a chat model with tools bound. Prepends configured
+`agentMessages` to the model invocation; tool calls execute through
+LangGraph's built-in tool resolution.
+
+```python
+from cogflow.agent.nodes import agent
+
+g.add_node("agent_0", agent(
+    model=ChatOpenAI(model="gpt-4o-mini"),
+    tools=[search, calculator],
+    messages=[{"role": "system", "content": "You are helpful."}],
+    enable_memory=True,
+    memory_type="allMessages",
+))
+```
+
+Flowise keys: `agentModel`, `agentMessages`, `agentTools`, `agentEnableMemory`, `agentMemoryType`, `agentReturnResponseAs`, `agentUpdateState`.
+
+### `tool`
+
+Exposes a callable for an Agent to invoke. For Python-first use, the
+LangChain `@tool` decorator is usually the simpler path:
+
+```python
+from cogflow.agent.tools import tool
+
+@tool
+def search(query: str) -> str:
+    "Search the web."
+    return f"results for {query}"
+
+# pass to an Agent: g.add_node("agent_0", agent(model=..., tools=[search]))
+```
+
+### `condition`
+
+Deterministic rule-based router. Rules are evaluated in order; first
+match writes the `_condition_branch` key that drives the conditional
+edges.
+
+```python
+from cogflow.agent.nodes import condition
+
+g.add_node("route_0", condition(rules=[
+    {"variable": "sentiment", "operation": "Equal", "value": "positive", "output": "happy_path"},
+    {"variable": "sentiment", "operation": "Equal", "value": "negative", "output": "support"},
+]))
+```
+
+Operators: `Equal`, `NotEqual`, `Contains`, `NotContains`, `StartsWith`,
+`EndsWith`, `RegexMatch`, `Greater`, `Less`. Operators coerce values to
+strings where appropriate and swallow `re.error` / `TypeError` so a bad
+rule yields no-match rather than crashing the graph.
+
+### `condition_agent`
+
+LLM-driven router. The model is asked to pick one scenario name; the
+returned `_condition_branch` is the matched name.
+
+```python
+g.add_node("triage", condition_agent(
+    model=ChatOpenAI(model="gpt-4o-mini"),
+    instructions="Categorize the user request.",
+    scenarios=[
+        {"name": "billing", "description": "Anything money-related."},
+        {"name": "technical", "description": "Bug reports, errors."},
+        {"name": "other", "description": "Catch-all."},
+    ],
+))
+```
+
+Matching is casefold-equality first, then whole-word containment, then
+falls back to the first scenario.
+
+### `direct_reply`
+
+Terminal node — writes an `AIMessage` and routes to `END`. The message
+is `.format(**state)`-templated and falls back to the raw template on
+any `KeyError`/`IndexError`/`ValueError`/`TypeError`.
+
+```python
+g.add_node("reply", direct_reply(message="Hi {user_name}, here's your summary."))
+```
+
+## Bridge nodes
+
+These have no direct LangGraph primitive; the SDK bridges them to
+LangGraph patterns. Runtime behaviour is documented per node.
+
+### `loop`
+
+Conditional back-edge with a synthesized `_loop_count__<node_id>`
+channel.
+
+```python
+g.add_node("loop_0", loop(target="agent_0", max_iterations=5))
+```
+
+The compiler reads both Python-first (`loopTarget`, `loopMaxIterations`)
+and Flowise-native (`loopBackToNode`, `maxLoopCount`) keys. Flowise's
+`loopBackToNode` encodes `{node_id}-{label}`; the label suffix is
+stripped if the raw value doesn't resolve to a registered runtime id.
+Unresolvable targets fall through to the exit edge (or `END`) so the
+compiled graph never returns an unknown node id.
+
+### `iteration`
+
+Fan-out via `langgraph.types.Send`. Reads `iterationOver` from state
+(list or callable); for JSON imports the parser also walks Flowise's
+`parentNode` references and stashes the body node id under
+`flowise_provenance.iteration_body_id`.
+
+```python
+g.add_node("for_each", iteration(over="items", body="worker_node"))
+```
+
+Body ids are validated against the compiler's runtime node set; an
+unresolvable body silently degrades to a no-op rather than emitting
+`Send(missing_id, ...)`.
+
+### `http`
+
+Single REST call via `httpx`. URL is `.format(**state)`-templated;
+missing keys fall back to the unrendered URL.
+
+```python
+g.add_node("call_api", http(
+    method="POST",
+    url="https://api.example.com/v1/{endpoint}",
+    headers={"Authorization": "Bearer {token}"},
+    body={"q": 1},
+    output_key="response",
+))
+```
+
+Inject a stub client for tests: `ctx={"httpx": stub_module}`.
+
+### `retriever`
+
+Wraps a LangChain Retriever. Inject the live retriever either at
+construction (`retriever=...`) or via `ctx={"retriever": ...}` for
+JSON-loaded graphs.
+
+```python
+g.add_node("rag", retriever(
+    retriever=my_vectorstore.as_retriever(),
+    k=4,
+    output_key="docs",
+))
+```
+
+### `custom_function`
+
+**Python-only, gated.** JavaScript bodies are rejected at construction
+(or hydration) with `UnsupportedNodeError`. Python string bodies only
+execute when the caller opts in via `ctx={"allow_custom_code": True}`,
+and the namespace is restricted to a small set of safe builtins — **not
+a security sandbox**.
+
+```python
+def double_x(state: dict) -> int:
+    return state["x"] * 2
+
+g.add_node("calc", custom_function(fn=double_x, output_key="doubled"))
+```
+
+When `fn=` is supplied, `customFunctionPython` is left empty and the
+function name is stored in `customFunctionName` for canvas display.
+This prevents a re-import from accidentally trying to `exec` the
+function's name as code.
+
+### `human_input`
+
+Wraps `langgraph.types.interrupt`. Requires a checkpointer on
+`compile()` (e.g., `MemorySaver`) so the suspended state can be
+resumed via `Command(resume=...)`.
+
+```python
+g.add_node("approve", human_input(
+    prompt="Approve {action}?",
+    output_key="user_decision",
+))
+```
+
+Honours both `humanInputPrompt` (Python-first) and `humanInputDescription`
+(Flowise-native) for the prompt text. Prompt is `.format(**state)`-templated
+with the same exception fallback as `direct_reply`.
+
+### `execute_flow`
+
+Invokes a nested `CompiledStateGraph`. Inject the child graph at
+construction (`graph=...`) or via `ctx={"flows": {flow_id: graph}}`
+for JSON-loaded graphs.
+
+```python
+g.add_node("sub", execute_flow(
+    flow_id="child_flow_id",
+    input_keys=["query"],            # filter state down to these keys, or omit for full state
+    output_key="subflow_result",
+))
+```
+
+### `sticky_note`
+
+Pure documentation node. Preserved in IR for round-trip; skipped at
+LangGraph compile.

--- a/docs/agent/nodes.md
+++ b/docs/agent/nodes.md
@@ -146,8 +146,8 @@ falls back to the first scenario.
 ### `direct_reply`
 
 Terminal node — writes an `AIMessage` and routes to `END`. The message
-is `.format(**state)`-templated and falls back to the raw template on
-any `KeyError`/`IndexError`/`ValueError`/`TypeError`.
+is `.format(**state)`-templated and falls back to the raw template when
+a referenced key is missing (catches `KeyError` / `IndexError`).
 
 ```python
 g.add_node("reply", direct_reply(message="Hi {user_name}, here's your summary."))
@@ -198,11 +198,15 @@ missing keys fall back to the unrendered URL.
 g.add_node("call_api", http(
     method="POST",
     url="https://api.example.com/v1/{endpoint}",
-    headers={"Authorization": "Bearer {token}"},
+    headers={"Authorization": f"Bearer {API_TOKEN}"},   # literal, set at construction time
     body={"q": 1},
     output_key="response",
 ))
 ```
+
+Only the `url` is `.format(**state)`-templated at runtime. Headers and
+body are passed through verbatim — render any per-request values into
+them at construction time (as above) or via a wrapper node.
 
 Inject a stub client for tests: `ctx={"httpx": stub_module}`.
 
@@ -255,7 +259,8 @@ g.add_node("approve", human_input(
 
 Honours both `humanInputPrompt` (Python-first) and `humanInputDescription`
 (Flowise-native) for the prompt text. Prompt is `.format(**state)`-templated
-with the same exception fallback as `direct_reply`.
+with a `KeyError` / `IndexError` fallback to the raw template (matches
+`direct_reply`).
 
 ### `execute_flow`
 

--- a/docs/agent/state.md
+++ b/docs/agent/state.md
@@ -46,9 +46,10 @@ A Flowise Start node's `startState` is a list of `{key, value}` entries:
 ```
 
 `parse.flowise.from_file` reads that into a list of `IRStateField`s.
-`compile.to_langgraph` then calls `state.synthesize_typeddict(fields)`
-which builds an actual `TypedDict` class at runtime, reattaching any
-known reducers (`add_messages`, `operator.add`).
+`compile.to_langgraph` then calls
+`cogflow.agent.state.synthesize_typeddict(fields)` which builds an
+actual `TypedDict` class at runtime, reattaching any known reducers
+(`add_messages`, `operator.add`).
 
 The `messages` field is always upgraded to `type="messages" + reducer="add_messages"`
 even if the user didn't declare it in `startState`, so chat semantics

--- a/docs/agent/state.md
+++ b/docs/agent/state.md
@@ -72,8 +72,14 @@ Registered reducers (declared once, reusable across graphs):
 | `add_messages` | `langgraph.graph.add_messages` (intelligent message-list merger) |
 | `operator.add` | `operator.add` (list/int concatenation) |
 
-Register a custom one with `state.register_reducer("name", fn)` and it
-becomes available to both directions of state synthesis.
+Register a custom one and it becomes available to both directions of
+state synthesis:
+
+```python
+from cogflow.agent.state import register_reducer
+
+register_reducer("my_reducer", my_reducer_fn)
+```
 
 ## What survives Flowise round-trip
 

--- a/docs/agent/state.md
+++ b/docs/agent/state.md
@@ -8,6 +8,7 @@ both ends.
 ## TypedDict in, TypedDict out
 
 ```python
+import operator
 from typing import Annotated, TypedDict
 
 from cogflow.agent import StateGraph, MessagesState, add_messages
@@ -16,7 +17,7 @@ from cogflow.agent import StateGraph, MessagesState, add_messages
 class State(TypedDict, total=False):
     messages: Annotated[list, add_messages]
     user_id: str
-    step_count: Annotated[int, lambda a, b: a + b]
+    step_count: Annotated[int, operator.add]
 
 
 g = StateGraph(State)
@@ -27,6 +28,17 @@ extract the reducers, records them as `IRStateField(reducer="add_messages")`
 etc., and normalizes the `messages` key to
 `type="messages" + reducer="add_messages"` regardless of whether the
 user annotated the reducer.
+
+!!! note "Reducers must be **named** to round-trip"
+
+    `introspect_state` only records reducers it can identify by name
+    via the registry — `add_messages`, `operator.add`, and anything
+    registered via [`register_reducer(...)`](#reducers). A bare lambda
+    (`Annotated[int, lambda a, b: a + b]`) **runs correctly at
+    runtime** but won't carry through IR / Flowise — the IR field gets
+    no `reducer` and downstream emit paths fall back to overwrite
+    semantics. Use `operator.add` / a `register_reducer`-named
+    function for round-trip-safe reducers.
 
 ## Synthesizing a TypedDict from Flowise state
 

--- a/docs/agent/state.md
+++ b/docs/agent/state.md
@@ -1,0 +1,94 @@
+# State & channels
+
+Graph state has the same shape LangGraph users expect: a TypedDict whose
+fields can carry reducer annotations (`Annotated[T, reducer]`). The SDK
+bridges this to Flowise's `startState` list-of-`{key, value}` form on
+both ends.
+
+## TypedDict in, TypedDict out
+
+```python
+from typing import Annotated, TypedDict
+
+from cogflow.agent import StateGraph, MessagesState, add_messages
+
+
+class State(TypedDict, total=False):
+    messages: Annotated[list, add_messages]
+    user_id: str
+    step_count: Annotated[int, lambda a, b: a + b]
+
+
+g = StateGraph(State)
+```
+
+The SDK calls `typing.get_type_hints(State, include_extras=True)` to
+extract the reducers, records them as `IRStateField(reducer="add_messages")`
+etc., and normalizes the `messages` key to
+`type="messages" + reducer="add_messages"` regardless of whether the
+user annotated the reducer.
+
+## Synthesizing a TypedDict from Flowise state
+
+A Flowise Start node's `startState` is a list of `{key, value}` entries:
+
+```json
+{
+  "data": {
+    "inputs": {
+      "startState": [
+        {"key": "user_id", "value": ""},
+        {"key": "step_count", "value": 0}
+      ]
+    }
+  }
+}
+```
+
+`parse.flowise.from_file` reads that into a list of `IRStateField`s.
+`compile.to_langgraph` then calls `state.synthesize_typeddict(fields)`
+which builds an actual `TypedDict` class at runtime, reattaching any
+known reducers (`add_messages`, `operator.add`).
+
+The `messages` field is always upgraded to `type="messages" + reducer="add_messages"`
+even if the user didn't declare it in `startState`, so chat semantics
+work regardless of whether the Flowise designer remembered to add it.
+
+## Round-trip
+
+| Direction | What happens |
+|---|---|
+| `StateGraph(TypedDict)` → IR | `introspect_state(...)` extracts fields + reducers via `get_type_hints` |
+| Flowise JSON → IR | `_state_from_start(...)` reads the Start node's `startState` array |
+| IR → LangGraph runtime | `synthesize_typeddict(...)` builds a real TypedDict; reducers reattached |
+| IR → Flowise JSON | `_start_state_payload(...)` materialises the array back onto the Start node's `data.inputs.startState` (only for Python-built Start nodes — provenance-backed ones keep their original `startState` untouched for lossless round-trip) |
+
+## Reducers
+
+Registered reducers (declared once, reusable across graphs):
+
+| Name | Maps to |
+|---|---|
+| `add_messages` | `langgraph.graph.add_messages` (intelligent message-list merger) |
+| `operator.add` | `operator.add` (list/int concatenation) |
+
+Register a custom one with `state.register_reducer("name", fn)` and it
+becomes available to both directions of state synthesis.
+
+## What survives Flowise round-trip
+
+For an IR field with `reducer="add_messages"`, the emitted Flowise
+`startState` entry contains `{"key": "messages", "value": ""}`. Flowise
+doesn't model reducers — but the SDK's importer always re-upgrades the
+`messages` field on the way back in, so a Python → Flowise → Python
+round-trip preserves chat semantics. Custom reducers (e.g.,
+`operator.add` on a counter) need to be re-declared in the receiving
+codebase; they don't survive Flowise as data.
+
+## Functional vs class-syntax TypedDict (emit path)
+
+`compile.to_python.to_source` emits the **functional**
+`TypedDict("FlowState", {...}, total=False)` form (not class syntax) so
+state keys like `"user id"` or `"step-count"` — legal in Flowise's JSON
+— produce valid Python. The class-syntax form would have rejected those
+keys at parse time.

--- a/docs/agent/tracing.md
+++ b/docs/agent/tracing.md
@@ -66,7 +66,11 @@ enabled" while exporting nothing.
 
 ## Stacking
 
-The two backends are independent LangChain callback registrations:
+The two backends register through different LangChain hook surfaces —
+MLflow via `mlflow.langchain.autolog()` (a LangChain *callback*
+registration) and OTel via
+`openinference.instrumentation.langchain.LangChainInstrumentor().instrument()`
+(global *instrumentation*). They're independent and can run together:
 
 ```python
 configure_tracing(backend="mlflow", experiment="prod")

--- a/docs/agent/tracing.md
+++ b/docs/agent/tracing.md
@@ -1,12 +1,15 @@
 # Tracing & observability
 
-The SDK supports two tracing backends, stackable, both opt-in by an
-explicit `configure_tracing(...)` call. The default is **MLflow**
-(self-hosted, reuses cogflow's existing kubeflow infrastructure). The
-opt-in is **OpenTelemetry**.
+Tracing is **disabled** until you call `configure_tracing(...)`
+explicitly — `compile()` doesn't auto-enable anything because library
+code shouldn't have surprise global side-effects.
 
-`compile()` does **not** auto-enable tracing — library code shouldn't
-have surprise global side-effects.
+When you do enable tracing, the SDK supports two stackable backends:
+
+- **MLflow** is the default backend (self-hosted, reuses cogflow's
+  existing kubeflow infrastructure). It's what you get when you call
+  `configure_tracing()` with no `backend=` argument.
+- **OpenTelemetry** is opt-in via `backend="otel"`.
 
 ## MLflow (default backend)
 
@@ -83,10 +86,10 @@ the autolog callback. Internally each adapter:
 
 ## LangSmith is intentionally not bundled
 
-LangSmith is a commercial hosted service from LangChain Inc. CF does
-not ship a LangSmith adapter; if you want LangSmith tracing, set the
-environment variables yourself and LangChain will pick it up at
-runtime — no CF-side wiring needed:
+LangSmith is a commercial hosted service from LangChain Inc. cogflow
+does not ship a LangSmith adapter; if you want LangSmith tracing, set
+the environment variables yourself and LangChain will pick it up at
+runtime — no cogflow-side wiring needed:
 
 ```bash
 export LANGCHAIN_TRACING_V2=true

--- a/docs/agent/tracing.md
+++ b/docs/agent/tracing.md
@@ -1,0 +1,104 @@
+# Tracing & observability
+
+The SDK supports two tracing backends, stackable, both opt-in by an
+explicit `configure_tracing(...)` call. The default is **MLflow**
+(self-hosted, reuses cogflow's existing kubeflow infrastructure). The
+opt-in is **OpenTelemetry**.
+
+`compile()` does **not** auto-enable tracing — library code shouldn't
+have surprise global side-effects.
+
+## MLflow (default backend)
+
+```python
+from cogflow.agent.tracing import configure_tracing
+
+configure_tracing(backend="mlflow", experiment="my-agent")
+```
+
+What this does:
+
+1. Imports `mlflow` (already pinned by base cogflow at `2.22.0`).
+2. Reads `cogflow.config.config.MLFLOW_TRACKING_URI` and calls
+   `mlflow.set_tracking_uri(...)` — your kubeflow MLflow gets the spans.
+3. Calls `mlflow.set_experiment(experiment)` so traces land in a
+   named experiment.
+4. Calls `mlflow.langchain.autolog()` which registers a LangChain
+   callback that emits a span for every LLM call, tool invocation, and
+   chain step.
+
+Override the URI inline if you need to point at a non-default MLflow:
+
+```python
+configure_tracing(backend="mlflow", experiment="local-dev",
+                  tracking_uri="http://localhost:5000")
+```
+
+Disable cleanly:
+
+```python
+configure_tracing(backend=None)
+```
+
+## OpenTelemetry (opt-in)
+
+```bash
+pip install "cogflow[agent-otel]"
+```
+
+This pulls in `openinference-instrumentation-langchain` plus
+`opentelemetry-sdk` and `opentelemetry-exporter-otlp`.
+
+```python
+configure_tracing(
+    backend="otel",
+    endpoint="http://my-otel-collector:4318/v1/traces",
+)
+```
+
+If `endpoint` is passed but the OTel SDK + OTLP exporter aren't
+installed, you get a clear `RuntimeError` pointing at
+`pip install cogflow[agent-otel]` — not a silent fallback that "looks
+enabled" while exporting nothing.
+
+## Stacking
+
+The two backends are independent LangChain callback registrations:
+
+```python
+configure_tracing(backend="mlflow", experiment="prod")
+configure_tracing(backend="otel", endpoint="http://collector:4318/v1/traces")
+# both active — spans flow to both
+```
+
+## Repeated configure calls (idempotency)
+
+`configure_tracing(backend="mlflow", ...)` called twice doesn't stack
+the autolog callback. Internally each adapter:
+
+- `enable()` short-circuits when `self._enabled` is True
+- `configure_tracing(...)` calls `adapter.disable()` then
+  `adapter.enable(**kwargs)` for the same backend — so you can safely
+  re-configure with different kwargs
+
+## LangSmith is intentionally not bundled
+
+LangSmith is a commercial hosted service from LangChain Inc. CF does
+not ship a LangSmith adapter; if you want LangSmith tracing, set the
+environment variables yourself and LangChain will pick it up at
+runtime — no CF-side wiring needed:
+
+```bash
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=ls-...
+export LANGCHAIN_PROJECT=my-agent
+```
+
+## Flowise-side tracing
+
+When the same agent runs inside a Flowise canvas (not on LangGraph),
+the canvas has its own analytics hooks. `compile.to_flowise.to_dict(...,
+analytics={"mlflow": {...}})` injects a matching analytics block into
+the exported JSON so the canvas can be wired to the same MLflow your
+LangGraph runtime uses. The Flowise side is configured per Flowise's
+documentation; the SDK just passes the block through.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+# cogflow
+
+Cognitive Framework — modular ML workflow management plus a LangGraph-shaped agent SDK.
+
+## What's in this site (today)
+
+The Agent SDK (`cogflow.agent`). The pipeline/ML side of cogflow is
+documented from docstrings in the source for now; that may join this
+site later.
+
+- **[Agent SDK Overview](agent/index.md)** — what it is, why it exists
+- **[Getting started](agent/getting-started.md)** — Python-first walkthrough + Flowise import in five minutes
+- **[Architecture](agent/architecture.md)** — IR-centred design, three emit targets
+- **[Node types](agent/nodes.md)** — all 15 Flowise V2 AgentFlow node types, their Python factories, and the Flowise config keys they read
+- **[State & channels](agent/state.md)** — TypedDict ↔ Flowise `startState`, reducers, `add_messages`
+- **[Tracing](agent/tracing.md)** — MLflow default (self-hosted), OpenTelemetry opt-in
+- **[Migrating off Flowise](agent/migration.md)** — using `compile.to_python` to lift an agent out of the visual canvas
+
+## Install
+
+The agent SDK ships as an optional extra of cogflow:
+
+```bash
+pip install "cogflow[agent]"          # core: langgraph + langchain-core
+pip install "cogflow[agent,agent-otel]"   # add OpenTelemetry tracing
+```
+
+Plain `pip install cogflow` works too — the agent submodule just refuses
+to import without the extra installed and tells you what to install.
+
+## Quick example
+
+```python
+from cogflow.agent import StateGraph, MessagesState, START, END
+from cogflow.agent.tools import tool
+
+
+@tool
+def search(query: str) -> str:
+    "Search the web."
+    return f"results for {query}"
+
+
+g = StateGraph(MessagesState)
+g.add_node("agent", lambda state: {"messages": []})
+g.add_edge(START, "agent")
+g.add_edge("agent", END)
+
+app = g.compile()                 # real langgraph.graph.CompiledStateGraph
+result = app.invoke({"messages": [("user", "hi")]})
+```
+
+If you've used LangGraph, that's literally the same code with a different
+import path. The SDK's `StateGraph` is a subclass that captures an IR
+on the side, which unlocks Flowise JSON emit / import — see
+[Architecture](agent/architecture.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ site later.
 The agent SDK ships as an optional extra of cogflow:
 
 ```bash
-pip install "cogflow[agent]"          # core: langgraph + langchain-core
-pip install "cogflow[agent,agent-otel]"   # add OpenTelemetry tracing
+pip install "cogflow[agent]"        # core: langgraph + langchain-core
+pip install "cogflow[agent-otel]"   # adds OpenTelemetry tracing (agent-otel already depends on agent)
 ```
 
 Plain `pip install cogflow` works too — the agent submodule just refuses

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: cogflow
+site_description: Cognitive Framework — ML workflow + agent SDK.
+repo_url: https://github.com/HIRO-MicroDataCenters-BV/cogflow
+repo_name: HIRO-MicroDataCenters-BV/cogflow
+edit_uri: edit/refactor/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+
+nav:
+  - Home: index.md
+  - Agent SDK:
+      - Overview: agent/index.md
+      - Getting started: agent/getting-started.md
+      - Architecture: agent/architecture.md
+      - Node types: agent/nodes.md
+      - State & channels: agent/state.md
+      - Tracing & observability: agent/tracing.md
+      - Migrating off Flowise: agent/migration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,9 @@ site_name: cogflow
 site_description: Cognitive Framework — ML workflow + agent SDK.
 repo_url: https://github.com/HIRO-MicroDataCenters-BV/cogflow
 repo_name: HIRO-MicroDataCenters-BV/cogflow
-edit_uri: edit/refactor/docs/
+# ``edit_uri`` intentionally omitted until a publish flow + canonical
+# branch for docs are decided. When that lands, set this to
+# e.g. ``edit/main/docs/`` so the "Edit on GitHub" links resolve.
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

First documentation site for cogflow. Scoped to the **Agent SDK** only — pipeline / ML side stays in docstrings for now; can join later.

The `docs` extras group (`mkdocs` + `mkdocs-material` + `pdoc3`) was already declared in `pyproject.toml`; this PR just wires up the actual site.

## What's in it

| Page | Covers |
|---|---|
| `index.md` | Landing — install, 5-line quick example, link tree |
| `agent/index.md` | Overview, the bidirectional Python↔Flowise diagram, when to use what |
| `agent/getting-started.md` | Three paths: Python-first, JSON-import, migration |
| `agent/architecture.md` | IR-centred design, three emit targets, drop-in LangGraph import table |
| `agent/nodes.md` | All 15 Flowise V2 node types — factory signature + Flowise config keys + runtime mapping |
| `agent/state.md` | TypedDict ↔ Flowise `startState`, reducers, functional-TypedDict for special-char keys |
| `agent/tracing.md` | MLflow default, OTel opt-in, stacking, why LangSmith isn't bundled |
| `agent/migration.md` | `to_python` as the one-way Flowise→Python migration tool (per PR #96 reframing) |

## Verification

```
$ mkdocs build --strict
INFO - Documentation built in 0.72 seconds
```

Local serve via `mkdocs serve` renders cleanly with light/dark toggle, code-copy buttons, and the Material navigation features (sections, top button, search highlighting).

## Out of scope (CI integration)

No GitHub Actions changes in this PR. Adding a Pages publish step or a docs-build check belongs in a separate, explicitly-reviewed `.github/workflows/` change per the CI/CD review policy. For now `mkdocs build --strict` runs locally; that gate can be wired to CI once you sign off on the workflow shape.

## Also

`/site/` (mkdocs's default build output) added to `.gitignore` so the built HTML doesn't accidentally land in a commit.