### PR TITLE
tests: fix async_serve_llm mock to patch async_register_llm_catalog_entry

### DIFF
--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -309,18 +309,20 @@ async def test_async_deploy_llm_emits_expected_spec(async_serving, fake_async_ap
 async def test_async_serve_llm_registers_and_deploys(
     async_serving, fake_async_api, monkeypatch
 ):
-    """async_serve_llm should register the catalog entry (sync, via
-    register_llm_catalog_entry) and then create the KServe ISVC async.
-    Annotations on the resulting ISVC must include model_id=run_id —
-    the uniform invariant that keeps GET /models/{id} working for LLM
-    rows without any type branching."""
+    """async_serve_llm should register the catalog entry (async, via
+    async_register_llm_catalog_entry — sync version would deadlock the
+    event loop when caller and /models/log share a worker) and then
+    create the KServe ISVC async. Annotations on the resulting ISVC
+    must include model_id=run_id — the uniform invariant that keeps
+    GET /models/{id} working for LLM rows without any type branching.
+    """
     import cogflow.core.models as core_models_module
 
     fake_run_id = "deadbeef0000deadbeef0000deadbeef"
-    register_mock = MagicMock(return_value=fake_run_id)
+    register_mock = AsyncMock(return_value=fake_run_id)
     monkeypatch.setattr(
         core_models_module,
-        "register_llm_catalog_entry",
+        "async_register_llm_catalog_entry",
         register_mock,
         raising=True,
     )


### PR DESCRIPTION
## Summary
- PR #91 (\`async_serve_llm: use httpx for /models/log callback\`) switched the async path to call \`async_register_llm_catalog_entry\` instead of the sync \`register_llm_catalog_entry\`, but \`test_async_serve_llm_registers_and_deploys\` still patched the sync symbol. The mock recorded zero calls and the real async helper tried to reach cog-api in CI, failing the assertion.
- Swap \`MagicMock\` for \`AsyncMock\` and patch \`async_register_llm_catalog_entry\` so the test matches the post-#91 code path.
- Same diff already shipped on \`release/v2.0.1b12\` (commit \`aaf8932\`); bringing it forward to \`refactor\` so the default-branch test passes.

Observed failure (from the release/v3.0.0b1 build, run 26158075777):
\`\`\`
FAILED tests/test_async_serving.py::test_async_serve_llm_registers_and_deploys
AssertionError: Expected 'mock' to have been called once. Called 0 times.
\`\`\`

## Test plan
- [x] \`pytest tests/test_async_serving.py\` — 11 passed locally
- [x] \`pytest tests/\` — 275 passed, 1 skipped locally