### PR TITLE
extras: add cogflow[full] meta-extra

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,14 @@ The agent SDK ships as an optional extra of cogflow:
 
 ```bash
 pip install "cogflow[agent]"        # core: langgraph + langchain-core
-pip install "cogflow[agent-otel]"   # adds OpenTelemetry tracing (agent-otel already depends on agent)
+pip install "cogflow[agent-otel]"   # adds OpenTelemetry tracing (already depends on agent)
+pip install "cogflow[full]"         # one-shot: everything above in a single command
 ```
 
-Plain `pip install cogflow` works too — the agent submodule just refuses
-to import without the extra installed and tells you what to install.
+Plain `pip install cogflow` works too — the base install gives you
+pipelines, models, datasets, serving, etc., but the agent submodule
+refuses to import without one of the agent extras installed and tells
+you which one to install.
 
 ## Quick example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,12 @@ agent-otel = [
 # tracing extras together. Keeps the base ``pip install cogflow`` lean
 # (pipeline-only users don't pull LangChain) while giving "everything"
 # users one command instead of two extras to remember.
+#
+# Only ``agent-otel`` is listed — it already self-references ``cogflow[agent]``
+# (see above), so explicitly listing ``agent`` here would duplicate the
+# self-requirement in the generated metadata. If the agent-otel graph ever
+# stops including ``agent`` transitively, add it back.
 full = [
-  "cogflow[agent]",
   "cogflow[agent-otel]"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,15 @@ agent-otel = [
   "opentelemetry-exporter-otlp>=1.20.0"
 ]
 
+# Single-command install for users who want the agent SDK *and* the OTel
+# tracing extras together. Keeps the base ``pip install cogflow`` lean
+# (pipeline-only users don't pull LangChain) while giving "everything"
+# users one command instead of two extras to remember.
+full = [
+  "cogflow[agent]",
+  "cogflow[agent-otel]"
+]
+
 [project.urls]
 Homepage = "https://github.com/HIRO-MicroDataCenters-BV/cogflow"
 Issues = "https://github.com/HIRO-MicroDataCenters-BV/cogflow/issues"


### PR DESCRIPTION
## Summary

Adds a `cogflow[full]` meta-extra that pulls in both `cogflow[agent]` (LangGraph + LangChain-core) and `cogflow[agent-otel]` (OpenTelemetry tracing) in a single command.

```toml
full = [
  "cogflow[agent]",
  "cogflow[agent-otel]"
]
```

## Why

- The base `pip install cogflow` stays lean — pipeline-only users (kfp, MLflow, model registry) keep a ~50 MB-smaller install without LangChain transitive deps.
- The `agent` SDK stays opt-in via its own extra, same as today.
- Users who want "everything" now have one command instead of remembering which extras compose: `pip install "cogflow[full]"`.

## Install matrix after this lands

| Command | Gets |
|---|---|
| `pip install cogflow` | Base only — pipelines, models, datasets, serving (lean) |
| `pip install "cogflow[agent]"` | + langgraph + langchain-core |
| `pip install "cogflow[agent-otel]"` | + OpenTelemetry SDK + exporters + openinference instrumentation |
| `pip install "cogflow[full]"` | All of the above in one command |

## Docs

`docs/index.md` now lists all three lines side-by-side and notes that `agent-otel` already depends on `agent`. `mkdocs build --strict` passes.

## Out of scope

- No version bump in this PR. Lands as part of whatever comes after v3.0.0b1.