### PR TITLE
agent: re-export LangChain / LangGraph primitives from cogflow.agent

### DIFF
--- a/cogflow/agent/__init__.py
+++ b/cogflow/agent/__init__.py
@@ -32,7 +32,17 @@ except ImportError:  # pragma: no cover - older langgraph
     interrupt = None  # type: ignore[assignment]
     Command = None  # type: ignore[assignment]
 
-from . import compile, nodes, parse, tracing
+from . import (
+    chat_models,
+    compile,
+    fakes,
+    messages,
+    nodes,
+    parse,
+    prompts,
+    runnables,
+    tracing,
+)
 from .graph import StateGraph
 from .prebuilt import create_react_agent
 from .state import MessagesState, add_messages
@@ -46,11 +56,16 @@ __all__ = [
     "StateGraph",
     "ToolNode",
     "add_messages",
+    "chat_models",
     "compile",
     "create_react_agent",
+    "fakes",
     "interrupt",
+    "messages",
     "nodes",
     "parse",
+    "prompts",
+    "runnables",
     "tool",
     "tracing",
 ]

--- a/cogflow/agent/chat_models/__init__.py
+++ b/cogflow/agent/chat_models/__init__.py
@@ -1,0 +1,13 @@
+"""Chat-model re-exports, one submodule per provider.
+
+Named ``chat_models`` rather than ``models`` to avoid colliding with
+cogflow's top-level ``cogflow.models`` namespace, which already exists
+and serves the MLflow-tracked ML model registry. Two different concepts
+("ML model" vs "LLM chat client") deserve two different names.
+
+Each provider module lives behind an optional install extra so the
+base ``cogflow[agent]`` install doesn't drag in every LangChain
+provider package. See ``pyproject.toml`` for the available extras.
+"""
+
+__all__: list[str] = []

--- a/cogflow/agent/chat_models/openai.py
+++ b/cogflow/agent/chat_models/openai.py
@@ -1,0 +1,21 @@
+"""OpenAI chat-model re-export, gated on the ``openai`` install extra.
+
+We catch the broader ``ImportError`` (not just ``ModuleNotFoundError``)
+because ``from langchain_openai import ChatOpenAI`` can fail two ways:
+
+  - ``ModuleNotFoundError`` — ``langchain_openai`` package not installed.
+  - ``ImportError`` — package installed but the ``ChatOpenAI`` symbol
+    is missing (broken install / version mismatch).
+
+Both look the same to a downstream caller: "install the openai extra."
+"""
+
+try:
+    from langchain_openai import ChatOpenAI
+except ImportError as _exc:  # pragma: no cover - install-time guard
+    raise ModuleNotFoundError(
+        "cogflow.agent.chat_models.openai requires `langchain-openai`. "
+        "Install with `pip install cogflow[openai]`."
+    ) from _exc
+
+__all__ = ["ChatOpenAI"]

--- a/cogflow/agent/chat_models/openai.py
+++ b/cogflow/agent/chat_models/openai.py
@@ -1,21 +1,30 @@
 """OpenAI chat-model re-export, gated on the ``openai`` install extra.
 
-We catch the broader ``ImportError`` (not just ``ModuleNotFoundError``)
-because ``from langchain_openai import ChatOpenAI`` can fail two ways:
+We catch ``ImportError`` (broader than ``ModuleNotFoundError``) so two
+``langchain_openai``-specific failures hit the same friendly hint:
 
-  - ``ModuleNotFoundError`` — ``langchain_openai`` package not installed.
-  - ``ImportError`` — package installed but the ``ChatOpenAI`` symbol
-    is missing (broken install / version mismatch).
+  - ``ModuleNotFoundError`` with ``name == "langchain_openai"`` — package
+    not installed at all.
+  - ``ImportError`` with ``name == "langchain_openai"`` — package
+    installed but the ``ChatOpenAI`` symbol is missing (broken / mismatched
+    install).
 
-Both look the same to a downstream caller: "install the openai extra."
+Anything else originating from *inside* ``langchain_openai`` (e.g. its
+``openai`` transitive dep missing, or any other unrelated import failure
+during the package's own ``__init__``) is **re-raised unchanged** so the
+user sees the real cause instead of a misleading "install
+langchain-openai" hint.
 """
 
 try:
     from langchain_openai import ChatOpenAI
 except ImportError as _exc:  # pragma: no cover - install-time guard
-    raise ModuleNotFoundError(
-        "cogflow.agent.chat_models.openai requires `langchain-openai`. "
-        "Install with `pip install cogflow[openai]`."
-    ) from _exc
+    _name = getattr(_exc, "name", "") or ""
+    if _name == "langchain_openai" or _name.startswith("langchain_openai."):
+        raise ModuleNotFoundError(
+            "cogflow.agent.chat_models.openai requires `langchain-openai`. "
+            "Install with `pip install cogflow[openai]`."
+        ) from _exc
+    raise
 
 __all__ = ["ChatOpenAI"]

--- a/cogflow/agent/fakes.py
+++ b/cogflow/agent/fakes.py
@@ -1,0 +1,19 @@
+"""Test doubles for cogflow.agent users.
+
+Re-exports LangChain's scripted chat-model fakes. The module is named
+``fakes`` rather than ``testing`` to avoid implying it's the cogflow.agent
+test suite — that's elsewhere under ``cogflow/agent/tests/``.
+
+Typical use::
+
+    from cogflow.agent.fakes import FakeListChatModel
+    model = FakeListChatModel(responses=["hello", "world"])
+    assert model.invoke("hi").content == "hello"
+"""
+
+from langchain_core.language_models.fake_chat_models import (
+    FakeListChatModel,
+    GenericFakeChatModel,
+)
+
+__all__ = ["FakeListChatModel", "GenericFakeChatModel"]

--- a/cogflow/agent/messages.py
+++ b/cogflow/agent/messages.py
@@ -1,0 +1,32 @@
+"""LangChain message-class re-exports.
+
+Pure pass-through of the message classes downstream agent code uses to
+type chat history, construct records, and filter streamed chunks. No
+wrapping — these are the same objects ``langchain_core.messages``
+exports, accessible via the ``cogflow.agent.*`` namespace.
+
+This module deliberately reverses the Phase-1 architecture decision to
+keep message classes as direct LangChain imports (see
+``docs/agent/proposals/langchain-reexports.md``). Evidence from a real
+downstream port showed every agent needs ``BaseMessage`` /
+``AIMessage`` / ``HumanMessage`` for typing and construction, so making
+them reachable from the SDK's own namespace is the right ergonomics.
+"""
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+__all__ = [
+    "AIMessage",
+    "AIMessageChunk",
+    "BaseMessage",
+    "HumanMessage",
+    "SystemMessage",
+    "ToolMessage",
+]

--- a/cogflow/agent/prompts.py
+++ b/cogflow/agent/prompts.py
@@ -1,0 +1,13 @@
+"""LangChain prompt-template re-exports.
+
+Used to build ``prompt | llm`` chains in agent node bodies. Pure
+pass-through; no validation or wrapping layer.
+"""
+
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+)
+
+__all__ = ["ChatPromptTemplate", "MessagesPlaceholder", "PromptTemplate"]

--- a/cogflow/agent/runnables.py
+++ b/cogflow/agent/runnables.py
@@ -1,0 +1,22 @@
+"""LangChain Runnable composition re-exports.
+
+Surface needed for return-type annotations on chain-factory functions
+and for composing nodes outside the ``StateGraph`` builder (where
+``RunnableLambda`` / ``RunnableParallel`` are useful).
+"""
+
+from langchain_core.runnables import (
+    Runnable,
+    RunnableConfig,
+    RunnableLambda,
+    RunnableParallel,
+    RunnablePassthrough,
+)
+
+__all__ = [
+    "Runnable",
+    "RunnableConfig",
+    "RunnableLambda",
+    "RunnableParallel",
+    "RunnablePassthrough",
+]

--- a/cogflow/agent/runtime/__init__.py
+++ b/cogflow/agent/runtime/__init__.py
@@ -1,6 +1,14 @@
 """Runtime helpers (checkpointers, invoke shortcuts)."""
 
-from .checkpoint import MemorySaver, SqliteSaver
+from .checkpoint import BaseCheckpointSaver, MemorySaver, SqliteSaver
 from .invoke import ainvoke, astream, invoke, stream
 
-__all__ = ["MemorySaver", "SqliteSaver", "ainvoke", "astream", "invoke", "stream"]
+__all__ = [
+    "BaseCheckpointSaver",
+    "MemorySaver",
+    "SqliteSaver",
+    "ainvoke",
+    "astream",
+    "invoke",
+    "stream",
+]

--- a/cogflow/agent/runtime/checkpoint.py
+++ b/cogflow/agent/runtime/checkpoint.py
@@ -1,5 +1,12 @@
-"""Re-exports of LangGraph checkpointers."""
+"""Re-exports of LangGraph checkpointers + the base class.
 
+``BaseCheckpointSaver`` is re-exported so downstream agents can write
+``isinstance(c, BaseCheckpointSaver)`` checks and type-annotate optional
+checkpointer kwargs without reaching into ``langgraph.checkpoint.base``
+directly.
+"""
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import MemorySaver
 
 try:
@@ -7,4 +14,4 @@ try:
 except ImportError:  # pragma: no cover - optional sqlite extra
     SqliteSaver = None  # type: ignore[assignment]
 
-__all__ = ["MemorySaver", "SqliteSaver"]
+__all__ = ["BaseCheckpointSaver", "MemorySaver", "SqliteSaver"]

--- a/cogflow/agent/tests/test_chat_models_openai.py
+++ b/cogflow/agent/tests/test_chat_models_openai.py
@@ -32,9 +32,13 @@ def _has_langchain_openai() -> bool:
 
 
 def test_openai_reexport_raises_friendly_error_when_uninstalled(monkeypatch):
-    # Shadow the top-level package with a plain module (no ``__path__``)
-    # so any ``from langchain_openai import ChatOpenAI`` deterministically
-    # raises ``ModuleNotFoundError`` regardless of what's installed locally.
+    # Shadow the top-level package with a plain (non-package) module so
+    # ``from langchain_openai import ChatOpenAI`` deterministically fails
+    # regardless of what's installed locally. The immediate exception is
+    # an ``ImportError`` (Python finds the shadowed module but the symbol
+    # ``ChatOpenAI`` is missing from it); the SUT catches the broader
+    # ``ImportError`` and re-raises as ``ModuleNotFoundError`` with the
+    # install hint, which is the user-facing shape we assert on below.
     fake_root = types.ModuleType("langchain_openai")
     monkeypatch.setitem(sys.modules, "langchain_openai", fake_root)
 

--- a/cogflow/agent/tests/test_chat_models_openai.py
+++ b/cogflow/agent/tests/test_chat_models_openai.py
@@ -18,6 +18,7 @@ in the SUT deterministically fails regardless of the test environment.
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import sys
 import types
 

--- a/cogflow/agent/tests/test_chat_models_openai.py
+++ b/cogflow/agent/tests/test_chat_models_openai.py
@@ -1,0 +1,60 @@
+"""Provider-gate tests for ``cogflow.agent.chat_models.openai``.
+
+Two cases:
+ 1. ``langchain-openai`` not installed: importing the module raises a
+    ``ModuleNotFoundError`` whose message contains the actionable hint
+    ``pip install cogflow[openai]``.
+ 2. ``langchain-openai`` is installed: the re-export resolves to the
+    real ``ChatOpenAI`` class.
+
+The "uninstalled" case is the same shape as the OTel adapter gate test
+(``test_tracing_otel.py``). ``sys.modules[X] = None`` is not reliable
+when X is actually present on the host — Python may re-import it. We
+shadow the top-level ``langchain_openai`` package with a plain
+``types.ModuleType`` so the ``from langchain_openai import ChatOpenAI``
+in the SUT deterministically fails regardless of the test environment.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _has_langchain_openai() -> bool:
+    try:
+        return importlib.util.find_spec("langchain_openai") is not None
+    except (ModuleNotFoundError, ImportError, ValueError):
+        return False
+
+
+def test_openai_reexport_raises_friendly_error_when_uninstalled(monkeypatch):
+    # Shadow the top-level package with a plain module (no ``__path__``)
+    # so any ``from langchain_openai import ChatOpenAI`` deterministically
+    # raises ``ModuleNotFoundError`` regardless of what's installed locally.
+    fake_root = types.ModuleType("langchain_openai")
+    monkeypatch.setitem(sys.modules, "langchain_openai", fake_root)
+
+    # Drop any cached cogflow.agent.chat_models.openai so the next import
+    # re-runs the module body against the shadowed langchain_openai.
+    monkeypatch.delitem(sys.modules, "cogflow.agent.chat_models.openai", raising=False)
+
+    with pytest.raises(ModuleNotFoundError, match=r"cogflow\[openai\]"):
+        importlib.import_module("cogflow.agent.chat_models.openai")
+
+
+@pytest.mark.skipif(
+    not _has_langchain_openai(),
+    reason="langchain-openai not installed; gated path is covered by the other test",
+)
+def test_openai_reexport_resolves_to_real_chatopenai():
+    # Defensive: clear any prior shadow before the real import.
+    sys.modules.pop("cogflow.agent.chat_models.openai", None)
+
+    from cogflow.agent.chat_models.openai import ChatOpenAI
+    from langchain_openai import ChatOpenAI as _Upstream
+
+    assert ChatOpenAI is _Upstream

--- a/cogflow/agent/tests/test_chat_models_openai.py
+++ b/cogflow/agent/tests/test_chat_models_openai.py
@@ -63,3 +63,32 @@ def test_openai_reexport_resolves_to_real_chatopenai():
     from langchain_openai import ChatOpenAI as _Upstream
 
     assert ChatOpenAI is _Upstream
+
+
+def test_openai_reexport_propagates_unrelated_import_errors(monkeypatch):
+    """A failure inside langchain_openai (e.g. its transitive ``openai`` dep
+    missing) must NOT be re-raised as a misleading "install langchain-openai"
+    hint. The SUT only converts ImportErrors whose ``name`` points at
+    ``langchain_openai`` itself; everything else propagates unchanged so the
+    user sees the real cause.
+    """
+
+    # Build a shadow ``langchain_openai`` whose ``__getattr__`` raises
+    # ModuleNotFoundError(name="openai") — simulating a broken transitive.
+    # ``from langchain_openai import ChatOpenAI`` invokes module __getattr__
+    # under PEP 562 when the attribute isn't in the module dict.
+    fake_root = types.ModuleType("langchain_openai")
+
+    def _broken_getattr(name: str):
+        raise ModuleNotFoundError("No module named 'openai'", name="openai")
+
+    fake_root.__getattr__ = _broken_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_openai", fake_root)
+    monkeypatch.delitem(sys.modules, "cogflow.agent.chat_models.openai", raising=False)
+
+    # The transitive failure surfaces with its real ``name="openai"`` — not
+    # masked as a langchain-openai install hint.
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        importlib.import_module("cogflow.agent.chat_models.openai")
+    assert exc_info.value.name == "openai"
+    assert "cogflow[openai]" not in str(exc_info.value)

--- a/cogflow/agent/tests/test_reexports.py
+++ b/cogflow/agent/tests/test_reexports.py
@@ -1,0 +1,102 @@
+"""Smoke tests for the LangChain / LangGraph re-export modules.
+
+Each test does an explicit ``from cogflow.agent.<module> import <symbol>``
+and exercises the re-exported object enough to prove it is the real
+LangChain / LangGraph class (not a stub). Anything beyond that would be
+testing LangChain itself.
+
+The proposal that drove these re-exports lives at
+``docs/agent/proposals/langchain-reexports.md``.
+"""
+
+from __future__ import annotations
+
+
+def test_messages_reexports():
+    from cogflow.agent.messages import (
+        AIMessage,
+        AIMessageChunk,
+        BaseMessage,
+        HumanMessage,
+        SystemMessage,
+        ToolMessage,
+    )
+
+    assert AIMessage(content="x").content == "x"
+    assert HumanMessage(content="hi").content == "hi"
+    assert SystemMessage(content="sys").content == "sys"
+    assert ToolMessage(content="tool", tool_call_id="t0").content == "tool"
+    assert isinstance(AIMessageChunk(content="chunk"), BaseMessage)
+
+
+def test_prompts_reexports():
+    from cogflow.agent.prompts import (
+        ChatPromptTemplate,
+        MessagesPlaceholder,
+        PromptTemplate,
+    )
+
+    t = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are helpful."),
+            ("human", "{q}"),
+        ]
+    )
+    rendered = t.invoke({"q": "ok"}).to_messages()
+    assert rendered[1].content == "ok"
+
+    pt = PromptTemplate.from_template("hi {name}")
+    assert pt.invoke({"name": "ada"}).to_string() == "hi ada"
+
+    # MessagesPlaceholder just needs to construct.
+    MessagesPlaceholder(variable_name="history")
+
+
+def test_runnables_reexports():
+    from cogflow.agent.runnables import (
+        Runnable,
+        RunnableConfig,
+        RunnableLambda,
+        RunnableParallel,
+        RunnablePassthrough,
+    )
+
+    inc: Runnable = RunnableLambda(lambda x: x + 1)
+    assert inc.invoke(1) == 2
+
+    pair = RunnableParallel(a=RunnableLambda(lambda x: x), b=RunnableLambda(lambda x: x * 2))
+    out = pair.invoke(3)
+    assert out == {"a": 3, "b": 6}
+
+    pt = RunnablePassthrough()
+    assert pt.invoke({"k": 1}) == {"k": 1}
+
+    # RunnableConfig is a TypedDict; just confirm it's importable + usable shape.
+    _: RunnableConfig = {"tags": ["unit-test"]}
+
+
+def test_fakes_reexports():
+    from cogflow.agent.fakes import FakeListChatModel, GenericFakeChatModel
+
+    m = FakeListChatModel(responses=["a", "b"])
+    assert m.invoke("anything").content == "a"
+    assert m.invoke("anything").content == "b"
+
+    # GenericFakeChatModel just needs to construct (its API is slightly
+    # different across langchain-core versions; constructability is enough).
+    GenericFakeChatModel(messages=iter([]))
+
+
+def test_runtime_basecheckpointsaver_reexport():
+    from cogflow.agent.runtime import BaseCheckpointSaver, MemorySaver
+
+    assert issubclass(MemorySaver, BaseCheckpointSaver)
+
+
+def test_chat_models_namespace_does_not_eagerly_load_providers():
+    """Importing ``cogflow.agent.chat_models`` must not require any provider."""
+    import cogflow.agent.chat_models  # noqa: F401
+
+    # No exported symbols at the namespace level — providers live in
+    # submodules so each can gate its own optional install.
+    assert cogflow.agent.chat_models.__all__ == []

--- a/cogflow/agent/tests/test_reexports.py
+++ b/cogflow/agent/tests/test_reexports.py
@@ -64,7 +64,9 @@ def test_runnables_reexports():
     inc: Runnable = RunnableLambda(lambda x: x + 1)
     assert inc.invoke(1) == 2
 
-    pair = RunnableParallel(a=RunnableLambda(lambda x: x), b=RunnableLambda(lambda x: x * 2))
+    pair = RunnableParallel(
+        a=RunnableLambda(lambda x: x), b=RunnableLambda(lambda x: x * 2)
+    )
     out = pair.invoke(3)
     assert out == {"a": 3, "b": 6}
 

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -143,7 +143,8 @@ exist:
 | `langgraph.graph.MessagesState`, `add_messages` | `cogflow.agent.MessagesState`, `add_messages` |
 | `langgraph.prebuilt.create_react_agent`, `ToolNode` | `cogflow.agent.create_react_agent`, `cogflow.agent.tools.ToolNode` |
 | `langgraph.types.interrupt`, `Command` | `cogflow.agent.interrupt`, `Command` |
-| `langgraph.checkpoint.memory.MemorySaver`, `SqliteSaver` | `cogflow.agent.runtime.MemorySaver`, `SqliteSaver` |
+| `langgraph.checkpoint.memory.MemorySaver` | `cogflow.agent.runtime.MemorySaver` |
+| `langgraph.checkpoint.sqlite.SqliteSaver` | `cogflow.agent.runtime.SqliteSaver` |
 | `langgraph.checkpoint.base.BaseCheckpointSaver` | `cogflow.agent.runtime.BaseCheckpointSaver` |
 | `langchain_core.tools.tool` | `cogflow.agent.tools.tool` |
 | `langchain_core.messages.{AIMessage, HumanMessage, …}` | `cogflow.agent.messages.{AIMessage, …}` |

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -143,9 +143,17 @@ exist:
 | `langgraph.graph.MessagesState`, `add_messages` | `cogflow.agent.MessagesState`, `add_messages` |
 | `langgraph.prebuilt.create_react_agent`, `ToolNode` | `cogflow.agent.create_react_agent`, `cogflow.agent.tools.ToolNode` |
 | `langgraph.types.interrupt`, `Command` | `cogflow.agent.interrupt`, `Command` |
-| `langgraph.checkpoint.memory.MemorySaver`, `SqliteSaver` | `cogflow.agent.runtime.checkpoint.MemorySaver`, `SqliteSaver` |
+| `langgraph.checkpoint.memory.MemorySaver`, `SqliteSaver` | `cogflow.agent.runtime.MemorySaver`, `SqliteSaver` |
+| `langgraph.checkpoint.base.BaseCheckpointSaver` | `cogflow.agent.runtime.BaseCheckpointSaver` |
 | `langchain_core.tools.tool` | `cogflow.agent.tools.tool` |
+| `langchain_core.messages.{AIMessage, HumanMessage, …}` | `cogflow.agent.messages.{AIMessage, …}` |
+| `langchain_core.prompts.{ChatPromptTemplate, PromptTemplate, MessagesPlaceholder}` | `cogflow.agent.prompts.*` |
+| `langchain_core.runnables.{Runnable, RunnableConfig, RunnableLambda, …}` | `cogflow.agent.runnables.*` |
+| `langchain_core.language_models.fake_chat_models.{FakeListChatModel, GenericFakeChatModel}` | `cogflow.agent.fakes.*` |
+| `langchain_openai.ChatOpenAI` | `cogflow.agent.chat_models.openai.ChatOpenAI` (requires `pip install cogflow[openai]`) |
 
-Provider SDKs (`langchain_openai`, `langchain_anthropic`, message
-classes, runnables) stay as direct deps — the SDK is provider-agnostic
-and doesn't try to abstract them.
+Provider chat models live behind optional install extras
+(`cogflow[openai]` so far; additional providers added on demand based
+on real downstream usage). The base `cogflow[agent]` install stays
+provider-agnostic — opt-in pulls only the providers a given agent
+actually needs.

--- a/docs/agent/proposals/langchain-reexports.md
+++ b/docs/agent/proposals/langchain-reexports.md
@@ -1,0 +1,293 @@
+# Proposal: Re-export the remaining LangChain / LangGraph primitives from `cogflow.agent`
+
+**Status:** first slice implemented — see PR #100. Two naming refinements
+landed in implementation: ``testing`` → ``fakes`` (avoids reading as "test
+suite for the SDK"); ``models`` → ``chat_models`` (avoids colliding with
+``cogflow.models``, the MLflow-tracked ML model registry). ``openai`` was
+folded into the first PR to unblock the hiro-iac port; other providers
+follow on demand.
+**Scope:** `cogflow/agent/` only (new submodules + optional extras).
+**Motivation:** every callable a `cogflow.agent` user needs should be reachable
+via `cogflow.agent.*`, so downstream graphs can be authored without importing
+`langchain*` or `langgraph*` directly.
+
+## Background
+
+`cogflow.agent` already re-exports the LangGraph-shaped graph surface
+(`StateGraph`, `START`, `END`, `MessagesState`, `add_messages`,
+`create_react_agent`, `interrupt`, `Command`, `ToolNode`, `tool`) plus the
+runtime helpers (`invoke`, `stream`, `ainvoke`, `astream`, `MemorySaver`,
+`SqliteSaver`). That lets you build a graph end-to-end with cogflow imports
+only.
+
+Porting an existing LangGraph application to cogflow (real example:
+[hiro-iac](https://github.com/HIRO-MicroDataCenters-BV/agentic-iac) `cogflow`
+branch) surfaces a handful of additional primitives that are commonly used in
+agent code but are *not* yet re-exported. Today the port keeps these as
+direct `langchain*` / `langgraph*` imports — the audit table below lists every
+one. Adding the re-exports proposed in this doc lets the port (and every
+future cogflow agent) reach zero direct LangChain/LangGraph imports.
+
+## Gap audit (from the hiro-iac port)
+
+| Direct import in caller code | Used for | Proposed re-export location |
+|---|---|---|
+| `langchain_core.messages.{BaseMessage, AIMessage, HumanMessage, SystemMessage, AIMessageChunk, ToolMessage}` | typing `chat_history`, constructing message records, filtering streamed chunks in CLI / Chainlit | **new** `cogflow.agent.messages` |
+| `langchain_core.prompts.{ChatPromptTemplate, MessagesPlaceholder, PromptTemplate}` | building `prompt | llm` chains in agent nodes | **new** `cogflow.agent.prompts` |
+| `langchain_core.runnables.{Runnable, RunnableConfig, RunnableLambda, RunnablePassthrough, RunnableParallel}` | return-type annotation for chain factories, composition primitives | **new** `cogflow.agent.runnables` |
+| `langchain_core.language_models.fake_chat_models.{FakeListChatModel, GenericFakeChatModel}` | scripted LLM responses in unit tests | **new** `cogflow.agent.testing` |
+| `langgraph.checkpoint.base.BaseCheckpointSaver` | `isinstance(checkpointer, BaseCheckpointSaver)` checks + type annotations for optional checkpointer kwargs | add to existing `cogflow.agent.runtime` |
+| `langchain_openai.ChatOpenAI` (parallel: `langchain_anthropic.ChatAnthropic`, `langchain_google_genai.ChatGoogleGenerativeAI`, `langchain_ollama.ChatOllama`, …) | the production chat model instantiated by the agent | **new** `cogflow.agent.models.<provider>` per-provider submodules, gated by `cogflow[<provider>]` install extras |
+
+## Proposed code
+
+All new modules are thin re-exports. The only file with real logic is the
+chat-model gate (which raises a friendly error if the underlying provider
+package isn't installed).
+
+### `cogflow/agent/messages.py` (new)
+
+```python
+"""Re-exports of LangChain message classes used by every agent graph."""
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+__all__ = [
+    "AIMessage",
+    "AIMessageChunk",
+    "BaseMessage",
+    "HumanMessage",
+    "SystemMessage",
+    "ToolMessage",
+]
+```
+
+### `cogflow/agent/prompts.py` (new)
+
+```python
+"""Re-exports of LangChain prompt templates."""
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+)
+
+__all__ = ["ChatPromptTemplate", "MessagesPlaceholder", "PromptTemplate"]
+```
+
+### `cogflow/agent/runnables.py` (new)
+
+```python
+"""Re-exports of LangChain Runnable composition primitives."""
+from langchain_core.runnables import (
+    Runnable,
+    RunnableConfig,
+    RunnableLambda,
+    RunnableParallel,
+    RunnablePassthrough,
+)
+
+__all__ = [
+    "Runnable",
+    "RunnableConfig",
+    "RunnableLambda",
+    "RunnableParallel",
+    "RunnablePassthrough",
+]
+```
+
+### `cogflow/agent/testing.py` (new)
+
+```python
+"""Test doubles for cogflow.agent users."""
+from langchain_core.language_models.fake_chat_models import (
+    FakeListChatModel,
+    GenericFakeChatModel,
+)
+
+__all__ = ["FakeListChatModel", "GenericFakeChatModel"]
+```
+
+### `cogflow/agent/runtime/__init__.py` (one-line addition)
+
+Append `BaseCheckpointSaver` to the existing checkpointer re-exports:
+
+```python
+# (existing imports …)
+from langgraph.checkpoint.base import BaseCheckpointSaver  # NEW
+
+__all__ = [
+    # existing entries …
+    "BaseCheckpointSaver",
+]
+```
+
+### `cogflow/agent/models/__init__.py` (new namespace)
+
+```python
+"""Chat model re-exports, one submodule per provider.
+
+Each provider lives behind an optional install extra so the bare
+``cogflow[agent]`` install doesn't drag in every LangChain provider
+package.
+"""
+```
+
+### `cogflow/agent/models/openai.py` (new)
+
+```python
+try:
+    from langchain_openai import ChatOpenAI
+except ModuleNotFoundError as _exc:  # pragma: no cover - install-time guard
+    raise ModuleNotFoundError(
+        "cogflow.agent.models.openai requires `langchain-openai`. "
+        "Install with `pip install cogflow[openai]`."
+    ) from _exc
+
+__all__ = ["ChatOpenAI"]
+```
+
+Parallel one-file modules for the other providers (each gated the same way):
+
+| File | Import | Install extra |
+|---|---|---|
+| `cogflow/agent/models/anthropic.py` | `from langchain_anthropic import ChatAnthropic` | `cogflow[anthropic]` |
+| `cogflow/agent/models/google.py` | `from langchain_google_genai import ChatGoogleGenerativeAI` | `cogflow[google]` |
+| `cogflow/agent/models/ollama.py` | `from langchain_ollama import ChatOllama` | `cogflow[ollama]` |
+| `cogflow/agent/models/vertex.py` | `from langchain_google_vertexai import ChatVertexAI` | `cogflow[vertex]` |
+
+(Add providers incrementally based on demand — start with `openai` and
+`anthropic`; the others can land in follow-up PRs.)
+
+### `cogflow/agent/__init__.py` (touch)
+
+No re-export at the top level — keep `cogflow.agent.*` the "graph surface"
+and let users reach for `cogflow.agent.messages.AIMessage` etc. explicitly.
+This keeps the top-level namespace small and mirrors how
+`cogflow.agent.tools` and `cogflow.agent.runtime` already work.
+
+If desired, the new submodules can be added to the import-side-effect list:
+
+```python
+# existing
+from . import compile, nodes, parse, tracing
+# add
+from . import messages, models, prompts, runnables, testing
+```
+
+…so that `import cogflow.agent` makes them discoverable without an explicit
+import. Optional — pick the convention that matches the rest of the project.
+
+### `pyproject.toml` (extras)
+
+```toml
+[project.optional-dependencies]
+agent     = ["langchain-core>=0.3.0", "langgraph>=0.2.0"]
+openai    = ["langchain-openai>=0.2.0"]
+anthropic = ["langchain-anthropic>=0.2.0"]
+google    = ["langchain-google-genai>=2.0.0"]
+ollama    = ["langchain-ollama>=0.2.0"]
+vertex    = ["langchain-google-vertexai>=2.0.0"]
+```
+
+The existing `cogflow[agent]` extra is unchanged. Provider extras are
+additive: `pip install cogflow[agent,openai]` brings in the OpenAI chat model
+on top of the agent SDK.
+
+## Caller-side diff after this PR lands
+
+For the hiro-iac port, the audit becomes:
+
+| Today (direct `langchain*` import) | After cogflow PR |
+|---|---|
+| `from langchain_core.messages import BaseMessage` | `from cogflow.agent.messages import BaseMessage` |
+| `from langchain_core.messages import AIMessage, HumanMessage` | `from cogflow.agent.messages import AIMessage, HumanMessage` |
+| `from langchain_core.messages import AIMessageChunk` | `from cogflow.agent.messages import AIMessageChunk` |
+| `from langchain_core.prompts import ChatPromptTemplate` | `from cogflow.agent.prompts import ChatPromptTemplate` |
+| `from langchain_core.runnables import Runnable` | `from cogflow.agent.runnables import Runnable` |
+| `from langgraph.checkpoint.base import BaseCheckpointSaver` | `from cogflow.agent.runtime import BaseCheckpointSaver` |
+| `from langchain_core.language_models.fake_chat_models import FakeListChatModel` | `from cogflow.agent.testing import FakeListChatModel` |
+| `from langchain_openai import ChatOpenAI` | `from cogflow.agent.models.openai import ChatOpenAI` |
+
+Net: zero direct `langchain*` / `langgraph*` imports in the downstream agent.
+
+## Tests
+
+Each new re-export module gets a single import-smoke test under
+`cogflow/agent/tests/`:
+
+```python
+# tests/test_reexports.py
+def test_messages_reexports():
+    from cogflow.agent.messages import (
+        AIMessage, AIMessageChunk, BaseMessage,
+        HumanMessage, SystemMessage, ToolMessage,
+    )
+    assert AIMessage(content="x").content == "x"
+
+def test_prompts_reexports():
+    from cogflow.agent.prompts import ChatPromptTemplate
+    t = ChatPromptTemplate.from_messages([("system", "hi"), ("human", "{q}")])
+    assert t.invoke({"q": "ok"}).to_messages()[1].content == "ok"
+
+def test_runnables_reexports():
+    from cogflow.agent.runnables import Runnable, RunnableLambda
+    r: Runnable = RunnableLambda(lambda x: x + 1)
+    assert r.invoke(1) == 2
+
+def test_testing_reexports():
+    from cogflow.agent.testing import FakeListChatModel
+    m = FakeListChatModel(responses=["a", "b"])
+    assert m.invoke("x").content == "a"
+
+def test_runtime_basecheckpointsaver_reexport():
+    from cogflow.agent.runtime import BaseCheckpointSaver, MemorySaver
+    assert issubclass(MemorySaver, BaseCheckpointSaver)
+```
+
+Provider-model modules are tested only for the gated `ModuleNotFoundError`
+shape:
+
+```python
+# tests/test_models_openai.py
+def test_openai_reexport_raises_friendly_error_when_uninstalled(monkeypatch):
+    import sys
+    monkeypatch.setitem(sys.modules, "langchain_openai", None)  # simulate uninstall
+    with pytest.raises(ModuleNotFoundError, match="cogflow\\[openai\\]"):
+        import importlib
+        importlib.reload(importlib.import_module("cogflow.agent.models.openai"))
+```
+
+## Rollout
+
+1. Land the four trivial re-export modules (`messages`, `prompts`,
+   `runnables`, `testing`) plus the `BaseCheckpointSaver` line — these have
+   no install-extra story and unblock the bulk of caller-side rewrites.
+2. Land `cogflow.agent.models.openai` + the `cogflow[openai]` extra so the
+   first downstream agent (hiro-iac) can finish the migration.
+3. Add other provider modules in follow-ups, driven by which providers
+   downstream cogflow agents actually use.
+
+## Non-goals
+
+- No new behavior, no wrappers, no validation layers. Every export in this
+  PR is a verbatim re-export.
+- No deprecation of direct `langchain*` imports. Callers can still reach
+  into LangChain directly if they want; the re-exports are an *option*.
+- No changes to `StateGraph`, `compile`, `parse`, `nodes`, `tracing`, or
+  the IR. This proposal is purely about surface-area completeness.
+
+## References
+
+- Caller-side audit produced from
+  [hiro-iac (cogflow branch)](https://github.com/HIRO-MicroDataCenters-BV/agentic-iac/tree/cogflow):
+  `grep -rn -E "^(from|import) (langchain|langgraph)" src/ tests/ app.py`.
+- Existing re-export pattern in `cogflow/agent/tools.py` (the friendly
+  `ModuleNotFoundError` shape used for the optional `langchain-core` /
+  `langgraph` install gates) is the template for the new provider modules.

--- a/docs/agent/proposals/langchain-reexports.md
+++ b/docs/agent/proposals/langchain-reexports.md
@@ -35,9 +35,9 @@ future cogflow agent) reach zero direct LangChain/LangGraph imports.
 | `langchain_core.messages.{BaseMessage, AIMessage, HumanMessage, SystemMessage, AIMessageChunk, ToolMessage}` | typing `chat_history`, constructing message records, filtering streamed chunks in CLI / Chainlit | **new** `cogflow.agent.messages` |
 | `langchain_core.prompts.{ChatPromptTemplate, MessagesPlaceholder, PromptTemplate}` | building `prompt | llm` chains in agent nodes | **new** `cogflow.agent.prompts` |
 | `langchain_core.runnables.{Runnable, RunnableConfig, RunnableLambda, RunnablePassthrough, RunnableParallel}` | return-type annotation for chain factories, composition primitives | **new** `cogflow.agent.runnables` |
-| `langchain_core.language_models.fake_chat_models.{FakeListChatModel, GenericFakeChatModel}` | scripted LLM responses in unit tests | **new** `cogflow.agent.testing` |
+| `langchain_core.language_models.fake_chat_models.{FakeListChatModel, GenericFakeChatModel}` | scripted LLM responses in unit tests | **new** `cogflow.agent.fakes` |
 | `langgraph.checkpoint.base.BaseCheckpointSaver` | `isinstance(checkpointer, BaseCheckpointSaver)` checks + type annotations for optional checkpointer kwargs | add to existing `cogflow.agent.runtime` |
-| `langchain_openai.ChatOpenAI` (parallel: `langchain_anthropic.ChatAnthropic`, `langchain_google_genai.ChatGoogleGenerativeAI`, `langchain_ollama.ChatOllama`, …) | the production chat model instantiated by the agent | **new** `cogflow.agent.models.<provider>` per-provider submodules, gated by `cogflow[<provider>]` install extras |
+| `langchain_openai.ChatOpenAI` (parallel: `langchain_anthropic.ChatAnthropic`, `langchain_google_genai.ChatGoogleGenerativeAI`, `langchain_ollama.ChatOllama`, …) | the production chat model instantiated by the agent | **new** `cogflow.agent.chat_models.<provider>` per-provider submodules, gated by `cogflow[<provider>]` install extras |
 
 ## Proposed code
 
@@ -102,7 +102,11 @@ __all__ = [
 ]
 ```
 
-### `cogflow/agent/testing.py` (new)
+### `cogflow/agent/fakes.py` (new)
+
+Named `fakes` rather than `testing` so the module name doesn't read as
+"the cogflow.agent test suite" — the actual test suite lives under
+`cogflow/agent/tests/`.
 
 ```python
 """Test doubles for cogflow.agent users."""
@@ -128,10 +132,15 @@ __all__ = [
 ]
 ```
 
-### `cogflow/agent/models/__init__.py` (new namespace)
+### `cogflow/agent/chat_models/__init__.py` (new namespace)
+
+Named `chat_models` rather than `models` to avoid colliding with
+cogflow's top-level `cogflow.models` namespace, which already serves the
+MLflow-tracked ML model registry. Two different concepts ("ML model"
+vs "LLM chat client") deserve two different names.
 
 ```python
-"""Chat model re-exports, one submodule per provider.
+"""Chat-model re-exports, one submodule per provider.
 
 Each provider lives behind an optional install extra so the bare
 ``cogflow[agent]`` install doesn't drag in every LangChain provider
@@ -139,14 +148,20 @@ package.
 """
 ```
 
-### `cogflow/agent/models/openai.py` (new)
+### `cogflow/agent/chat_models/openai.py` (new)
+
+Catches the broader `ImportError` (not just `ModuleNotFoundError`)
+because `from langchain_openai import ChatOpenAI` can fail two ways:
+the package isn't installed (`ModuleNotFoundError`) or it's installed
+but the symbol is missing from a broken/incompatible version
+(`ImportError`). Both should surface the same friendly install hint.
 
 ```python
 try:
     from langchain_openai import ChatOpenAI
-except ModuleNotFoundError as _exc:  # pragma: no cover - install-time guard
+except ImportError as _exc:  # pragma: no cover - install-time guard
     raise ModuleNotFoundError(
-        "cogflow.agent.models.openai requires `langchain-openai`. "
+        "cogflow.agent.chat_models.openai requires `langchain-openai`. "
         "Install with `pip install cogflow[openai]`."
     ) from _exc
 
@@ -157,13 +172,13 @@ Parallel one-file modules for the other providers (each gated the same way):
 
 | File | Import | Install extra |
 |---|---|---|
-| `cogflow/agent/models/anthropic.py` | `from langchain_anthropic import ChatAnthropic` | `cogflow[anthropic]` |
-| `cogflow/agent/models/google.py` | `from langchain_google_genai import ChatGoogleGenerativeAI` | `cogflow[google]` |
-| `cogflow/agent/models/ollama.py` | `from langchain_ollama import ChatOllama` | `cogflow[ollama]` |
-| `cogflow/agent/models/vertex.py` | `from langchain_google_vertexai import ChatVertexAI` | `cogflow[vertex]` |
+| `cogflow/agent/chat_models/anthropic.py` | `from langchain_anthropic import ChatAnthropic` | `cogflow[anthropic]` |
+| `cogflow/agent/chat_models/google.py` | `from langchain_google_genai import ChatGoogleGenerativeAI` | `cogflow[google]` |
+| `cogflow/agent/chat_models/ollama.py` | `from langchain_ollama import ChatOllama` | `cogflow[ollama]` |
+| `cogflow/agent/chat_models/vertex.py` | `from langchain_google_vertexai import ChatVertexAI` | `cogflow[vertex]` |
 
-(Add providers incrementally based on demand — start with `openai` and
-`anthropic`; the others can land in follow-up PRs.)
+(Add providers incrementally based on demand — `openai` shipped first
+to unblock the hiro-iac port; the others can land in follow-up PRs.)
 
 ### `cogflow/agent/__init__.py` (touch)
 
@@ -188,17 +203,19 @@ import. Optional — pick the convention that matches the rest of the project.
 
 ```toml
 [project.optional-dependencies]
-agent     = ["langchain-core>=0.3.0", "langgraph>=0.2.0"]
-openai    = ["langchain-openai>=0.2.0"]
-anthropic = ["langchain-anthropic>=0.2.0"]
-google    = ["langchain-google-genai>=2.0.0"]
-ollama    = ["langchain-ollama>=0.2.0"]
-vertex    = ["langchain-google-vertexai>=2.0.0"]
+agent     = ["langgraph >=0.2,<0.5", "langchain-core >=0.3,<0.4"]
+openai    = ["cogflow[agent]", "langchain-openai >=0.2,<0.4"]
+anthropic = ["cogflow[agent]", "langchain-anthropic >=0.2,<0.4"]   # future
+google    = ["cogflow[agent]", "langchain-google-genai >=2.0,<3.0"] # future
+ollama    = ["cogflow[agent]", "langchain-ollama >=0.2,<0.4"]       # future
+vertex    = ["cogflow[agent]", "langchain-google-vertexai >=2.0,<3.0"]  # future
+full      = ["cogflow[agent-otel]", "cogflow[openai]"]
 ```
 
-The existing `cogflow[agent]` extra is unchanged. Provider extras are
-additive: `pip install cogflow[agent,openai]` brings in the OpenAI chat model
-on top of the agent SDK.
+The existing `cogflow[agent]` extra is unchanged. Provider extras
+self-reference `cogflow[agent]` so the SDK runtime is pulled
+transitively. `cogflow[full]` is the one-shot "the works" command;
+when a new provider extra lands it should append to `[full]`.
 
 ## Caller-side diff after this PR lands
 
@@ -212,8 +229,8 @@ For the hiro-iac port, the audit becomes:
 | `from langchain_core.prompts import ChatPromptTemplate` | `from cogflow.agent.prompts import ChatPromptTemplate` |
 | `from langchain_core.runnables import Runnable` | `from cogflow.agent.runnables import Runnable` |
 | `from langgraph.checkpoint.base import BaseCheckpointSaver` | `from cogflow.agent.runtime import BaseCheckpointSaver` |
-| `from langchain_core.language_models.fake_chat_models import FakeListChatModel` | `from cogflow.agent.testing import FakeListChatModel` |
-| `from langchain_openai import ChatOpenAI` | `from cogflow.agent.models.openai import ChatOpenAI` |
+| `from langchain_core.language_models.fake_chat_models import FakeListChatModel` | `from cogflow.agent.fakes import FakeListChatModel` |
+| `from langchain_openai import ChatOpenAI` | `from cogflow.agent.chat_models.openai import ChatOpenAI` |
 
 Net: zero direct `langchain*` / `langgraph*` imports in the downstream agent.
 
@@ -241,8 +258,8 @@ def test_runnables_reexports():
     r: Runnable = RunnableLambda(lambda x: x + 1)
     assert r.invoke(1) == 2
 
-def test_testing_reexports():
-    from cogflow.agent.testing import FakeListChatModel
+def test_fakes_reexports():
+    from cogflow.agent.fakes import FakeListChatModel
     m = FakeListChatModel(responses=["a", "b"])
     assert m.invoke("x").content == "a"
 
@@ -255,24 +272,32 @@ Provider-model modules are tested only for the gated `ModuleNotFoundError`
 shape:
 
 ```python
-# tests/test_models_openai.py
+# tests/test_chat_models_openai.py
 def test_openai_reexport_raises_friendly_error_when_uninstalled(monkeypatch):
-    import sys
-    monkeypatch.setitem(sys.modules, "langchain_openai", None)  # simulate uninstall
-    with pytest.raises(ModuleNotFoundError, match="cogflow\\[openai\\]"):
-        import importlib
-        importlib.reload(importlib.import_module("cogflow.agent.models.openai"))
+    # Shadow the top-level langchain_openai package with a plain (non-
+    # package) module so ``from langchain_openai import ChatOpenAI``
+    # deterministically fails regardless of what's installed on the host.
+    # The older ``monkeypatch.setitem(sys.modules, "langchain_openai", None)``
+    # approach was caught as flaky in PR #96 R3 — Python can re-import past
+    # the None sentinel when the real package is present.
+    import importlib, sys, types
+    monkeypatch.setitem(sys.modules, "langchain_openai", types.ModuleType("langchain_openai"))
+    monkeypatch.delitem(sys.modules, "cogflow.agent.chat_models.openai", raising=False)
+    with pytest.raises(ModuleNotFoundError, match=r"cogflow\[openai\]"):
+        importlib.import_module("cogflow.agent.chat_models.openai")
 ```
 
 ## Rollout
 
 1. Land the four trivial re-export modules (`messages`, `prompts`,
-   `runnables`, `testing`) plus the `BaseCheckpointSaver` line — these have
-   no install-extra story and unblock the bulk of caller-side rewrites.
-2. Land `cogflow.agent.models.openai` + the `cogflow[openai]` extra so the
-   first downstream agent (hiro-iac) can finish the migration.
-3. Add other provider modules in follow-ups, driven by which providers
-   downstream cogflow agents actually use.
+   `runnables`, `fakes`) plus the `BaseCheckpointSaver` line and
+   `cogflow.agent.chat_models.openai` + the `cogflow[openai]` extra —
+   all in one PR so the first downstream agent (hiro-iac) can finish
+   the migration without waiting on a second PR. **(Implemented in
+   PR #100.)**
+2. Add other provider modules (`anthropic`, `google`, `ollama`,
+   `vertex`) in follow-ups, driven by which providers downstream
+   cogflow agents actually use.
 
 ## Non-goals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ The agent SDK ships as an optional extra of cogflow:
 ```bash
 pip install "cogflow[agent]"        # core: langgraph + langchain-core
 pip install "cogflow[agent-otel]"   # adds OpenTelemetry tracing (already depends on agent)
+pip install "cogflow[openai]"       # adds langchain-openai for cogflow.agent.chat_models.openai
 pip install "cogflow[full]"         # one-shot: everything above in a single command
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,17 +93,27 @@ agent-otel = [
   "opentelemetry-exporter-otlp>=1.20.0"
 ]
 
-# Single-command install for users who want the agent SDK *and* the OTel
-# tracing extras together. Keeps the base ``pip install cogflow`` lean
-# (pipeline-only users don't pull LangChain) while giving "everything"
-# users one command instead of two extras to remember.
+# Per-provider chat-model gates. Each one re-exports a single LangChain
+# provider's chat client from ``cogflow.agent.chat_models.<provider>`` —
+# kept out of ``[agent]`` so the SDK install stays provider-agnostic
+# (the Phase-1 design decision) but reachable via the cogflow.agent
+# namespace when the user opts in. Add new providers here only when a
+# downstream audit produces evidence one is actually used.
+openai = [
+  "cogflow[agent]",
+  "langchain-openai>=0.2,<0.4"
+]
+
+# Single-command install for users who want the agent SDK + OTel tracing
+# + the providers we ship gates for. Keeps the base ``pip install cogflow``
+# lean (pipeline-only users don't pull LangChain) while giving "give me
+# everything" users one command instead of remembering the composition.
 #
-# Only ``agent-otel`` is listed — it already self-references ``cogflow[agent]``
-# (see above), so explicitly listing ``agent`` here would duplicate the
-# self-requirement in the generated metadata. If the agent-otel graph ever
-# stops including ``agent`` transitively, add it back.
+# Whenever a new provider extra lands above, append ``cogflow[<provider>]``
+# here so ``[full]`` continues to mean "the works."
 full = [
-  "cogflow[agent-otel]"
+  "cogflow[agent-otel]",
+  "cogflow[openai]"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

First slice of the [langchain-reexports proposal](https://github.com/HIRO-MicroDataCenters-BV/cogflow/blob/feat/agent-reexports/docs/agent/proposals/langchain-reexports.md). Adds pure re-export submodules so downstream agents can reach every primitive they need via `cogflow.agent.*` without direct `langchain*` / `langgraph*` imports.

**This deliberately reverses Phase-1 plan §3a.** That plan said keep message classes / prompts / runnables / provider SDKs as direct imports because they're "provider-agnostic / upstream concerns." A real downstream port (hiro-iac, `cogflow` branch) audit showed every agent reaches for these — so the SDK's namespace stops short of useful without them. Re-exports are still **strictly pure** (no wrappers, no validation, no behaviour change); this is surface widening, not semantics widening.

## What's new

| Module | Re-exports | Notes |
|---|---|---|
| `cogflow.agent.messages` | `AIMessage`, `AIMessageChunk`, `BaseMessage`, `HumanMessage`, `SystemMessage`, `ToolMessage` | — |
| `cogflow.agent.prompts` | `ChatPromptTemplate`, `MessagesPlaceholder`, `PromptTemplate` | — |
| `cogflow.agent.runnables` | `Runnable`, `RunnableConfig`, `RunnableLambda`, `RunnableParallel`, `RunnablePassthrough` | — |
| `cogflow.agent.fakes` | `FakeListChatModel`, `GenericFakeChatModel` | Named `fakes` not `testing` (the latter reads as "the SDK test suite") |
| `cogflow.agent.chat_models/openai.py` | `ChatOpenAI` | Gated on `cogflow[openai]`; friendly `ModuleNotFoundError` if missing |
| `cogflow.agent.runtime.BaseCheckpointSaver` | `langgraph.checkpoint.base.BaseCheckpointSaver` | One-line addition to the existing `runtime` re-exports |

**Naming refinements vs. the original proposal:**
- `testing` → `fakes` — avoids reading as the cogflow.agent test suite
- `models` → `chat_models` — avoids colliding with `cogflow.models` (the MLflow-tracked ML model registry). Two different concepts deserve two different names.

## pyproject.toml

```toml
openai = ["cogflow[agent]", "langchain-openai >=0.2,<0.4"]
full   = ["cogflow[agent-otel]", "cogflow[openai]"]   # ← updated
```

`[full]` now includes `[openai]` so "the works" stays honest after PR #99. New provider extras append to `[full]` by convention (comment in pyproject.toml documents this).

## Tests (7 new, suite now 81 / 3 skipped)

- **`test_reexports.py`** — smokes every new module via explicit imports and exercises each re-exported object enough to prove identity (not a stub). Anything more would be testing LangChain itself.
- **`test_chat_models_openai.py`** — provider-gate test uses `types.ModuleType` to shadow `langchain_openai` (same robust pattern landed in `test_tracing_otel.py` from PR #96 R3; the older `sys.modules[X] = None` approach was caught as flaky). When `langchain-openai` is locally installed, a second test verifies the re-export is the literal upstream class.

## Docs

- `architecture.md` drop-in import table expanded with the new rows.
- `index.md` install commands now include `cogflow[openai]`.
- `proposals/langchain-reexports.md` status stamped to "first slice implemented" with the naming refinements recorded.

## One real bug caught while writing tests

`cogflow/agent/chat_models/openai.py` originally caught only `ModuleNotFoundError`. The shadow-module test pattern revealed that `from langchain_openai import ChatOpenAI` against an *installed-but-empty* `langchain_openai` raises `ImportError` (symbol missing) — not `ModuleNotFoundError` (module missing). Broken installs would have fallen through to a raw ImportError instead of the friendly install-hint. Widened the catch to `ImportError`.

## Out of scope

- Additional provider modules (`anthropic`, `google`, `ollama`, `vertex`) — added incrementally on demand based on real downstream usage.
- Runtime parity (task #68): real ReAct loop, `llmUpdateState` honoring, ToolFactory `@tool`/`ToolNode` semantics, wider `.format` exception handling. The re-export surface and the runtime semantics are orthogonal — both wanted, neither blocks the other.