### PR TITLE
feat(serving): pass --quantization and --kv-cache-dtype to vLLM

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -561,6 +561,8 @@ class AsyncServingManager:
         trust_remote_code: bool = False,
         gpu_memory_utilization: float | None = None,
         max_num_seqs: int | None = None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
         node_selector: dict[str, str] | None = None,
@@ -611,6 +613,8 @@ class AsyncServingManager:
             min_replicas=min_replicas,
             max_replicas=max_replicas,
             hf_secret_name=hf_secret_name,
+            quantization=quantization,
+            kv_cache_dtype=kv_cache_dtype,
         )
         predictor_spec, effective_annotations = sync_manager_cls._apply_raw_deployment_defaults(
             predictor_spec, annotations
@@ -678,6 +682,8 @@ class AsyncServingManager:
         trust_remote_code: bool = False,
         gpu_memory_utilization: float | None = None,
         max_num_seqs: int | None = None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
         node_selector: dict[str, str] | None = None,
@@ -790,6 +796,8 @@ class AsyncServingManager:
             trust_remote_code=trust_remote_code,
             gpu_memory_utilization=gpu_memory_utilization,
             max_num_seqs=max_num_seqs,
+            quantization=quantization,
+            kv_cache_dtype=kv_cache_dtype,
             resources=resources,
             tolerations=tolerations,
             node_selector=node_selector,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -734,7 +734,12 @@ class ServingManager:
             args.append(f"--gpu-memory-utilization={gpu_memory_utilization}")
         if max_num_seqs is not None:
             args.append(f"--max-num-seqs={max_num_seqs}")
-        if quantization is not None and quantization != "none":
+        # ``"none"`` and ``"auto"`` are recommender-side sentinels for
+        # "vLLM should decide" — they aren't real vLLM CLI values, so
+        # treat them like an unset kwarg and emit nothing. Keeps the
+        # diff-clean guarantee when callers normalise their config layer
+        # to those defaults instead of leaving the field unset.
+        if quantization is not None and quantization not in {"none", "auto"}:
             args.append(f"--quantization={quantization}")
         if kv_cache_dtype is not None and kv_cache_dtype != "auto":
             args.append(f"--kv-cache-dtype={kv_cache_dtype}")

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -766,10 +766,16 @@ class ServingManager:
         # unset field. Applied symmetrically to both flags so the
         # diff-clean guarantee holds regardless of which sentinel the
         # caller picks.
-        if not _is_unset_sentinel(quantization):
-            args.append(f"--quantization={quantization}")
-        if not _is_unset_sentinel(kv_cache_dtype):
-            args.append(f"--kv-cache-dtype={kv_cache_dtype}")
+        normalized_quantization = (
+            quantization.strip() if quantization is not None else None
+        )
+        if not _is_unset_sentinel(normalized_quantization):
+            args.append(f"--quantization={normalized_quantization}")
+        normalized_kv_cache_dtype = (
+            kv_cache_dtype.strip() if kv_cache_dtype is not None else None
+        )
+        if not _is_unset_sentinel(normalized_kv_cache_dtype):
+            args.append(f"--kv-cache-dtype={normalized_kv_cache_dtype}")
         return args
 
     @staticmethod

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -54,6 +54,29 @@ def _ensure_k8s_config_loaded():
     common._k8s_loaded_flag = True
 
 
+# Sentinel values that mean "no flag emitted" for quantization /
+# kv_cache_dtype runtime args. ``"none"`` and ``"auto"`` aren't real
+# vLLM CLI values — they're recommender-side labels for the absence of
+# a runtime cast — so emitting them would either no-op (best case) or
+# break model load (vLLM rejects ``--quantization=auto``). The empty
+# string is included because a stringly-typed config layer can
+# substitute it for unset.
+_LLM_ARG_SENTINELS = frozenset({"", "none", "auto"})
+
+
+def _is_unset_sentinel(value: str | None) -> bool:
+    """Return True when ``value`` should suppress the corresponding flag.
+
+    Matches case-insensitively and ignores surrounding whitespace so the
+    diff-clean guarantee holds when callers normalise to ``"AUTO"`` or
+    ``" none "``. Real CLI values (e.g. ``"fp8"``, ``"fp8_e4m3"``) are
+    preserved untouched and emitted verbatim.
+    """
+    if value is None:
+        return True
+    return value.strip().lower() in _LLM_ARG_SENTINELS
+
+
 # =====================================================================
 #   Serving Manager (Kubernetes-native)
 # =====================================================================
@@ -734,14 +757,18 @@ class ServingManager:
             args.append(f"--gpu-memory-utilization={gpu_memory_utilization}")
         if max_num_seqs is not None:
             args.append(f"--max-num-seqs={max_num_seqs}")
-        # ``"none"`` and ``"auto"`` are recommender-side sentinels for
-        # "vLLM should decide" — they aren't real vLLM CLI values, so
-        # treat them like an unset kwarg and emit nothing. Keeps the
-        # diff-clean guarantee when callers normalise their config layer
-        # to those defaults instead of leaving the field unset.
-        if quantization is not None and quantization not in {"none", "auto"}:
+        # ``"none"`` / ``"auto"`` (and the empty string) are recommender-
+        # side sentinels for "vLLM should decide" — they aren't real
+        # vLLM CLI values, so treat them like an unset kwarg and emit
+        # nothing. Matched case-insensitively and after stripping
+        # surrounding whitespace so a slightly noisy config layer
+        # (``"AUTO"``, ``" none "``) still produces the same ISVC as an
+        # unset field. Applied symmetrically to both flags so the
+        # diff-clean guarantee holds regardless of which sentinel the
+        # caller picks.
+        if not _is_unset_sentinel(quantization):
             args.append(f"--quantization={quantization}")
-        if kv_cache_dtype is not None and kv_cache_dtype != "auto":
+        if not _is_unset_sentinel(kv_cache_dtype):
             args.append(f"--kv-cache-dtype={kv_cache_dtype}")
         return args
 

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -697,6 +697,8 @@ class ServingManager:
         trust_remote_code: bool,
         gpu_memory_utilization: float | None,
         max_num_seqs: int | None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
     ) -> list[str]:
         """Whitelisted runtime args passed into the HF runtime container.
 
@@ -712,7 +714,12 @@ class ServingManager:
           ``--max_model_len``, ``--dtype``, ``--trust_remote_code``.
         - Hyphen flags fall through to vLLM's CLI
           (``--tensor-parallel-size``, ``--gpu-memory-utilization``,
-          ``--max-num-seqs``).
+          ``--max-num-seqs``, ``--quantization``, ``--kv-cache-dtype``).
+
+        ``quantization`` and ``kv_cache_dtype`` are the runtime-cast knobs
+        the recommender's fallback ladder relies on (fp8/AWQ weights and
+        fp8 KV cache). Emitted only when set so unrelated callers keep
+        emitting diff-clean ISVCs.
         """
         args: list[str] = [f"--model_name={served_model_name}"]
         if max_model_len is not None:
@@ -727,6 +734,10 @@ class ServingManager:
             args.append(f"--gpu-memory-utilization={gpu_memory_utilization}")
         if max_num_seqs is not None:
             args.append(f"--max-num-seqs={max_num_seqs}")
+        if quantization is not None and quantization != "none":
+            args.append(f"--quantization={quantization}")
+        if kv_cache_dtype is not None and kv_cache_dtype != "auto":
+            args.append(f"--kv-cache-dtype={kv_cache_dtype}")
         return args
 
     @staticmethod
@@ -746,6 +757,8 @@ class ServingManager:
         min_replicas: int,
         max_replicas: int,
         hf_secret_name: str | None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
     ) -> dict[str, Any]:
         # Replica bounds must be internally consistent before we hand the
         # ISVC to KServe — otherwise the CRD is rejected at admission (or
@@ -793,6 +806,8 @@ class ServingManager:
             trust_remote_code=trust_remote_code,
             gpu_memory_utilization=gpu_memory_utilization,
             max_num_seqs=max_num_seqs,
+            quantization=quantization,
+            kv_cache_dtype=kv_cache_dtype,
         )
         if is_hf_source:
             # --model_id comes first for readability in the emitted YAML
@@ -878,6 +893,8 @@ class ServingManager:
         trust_remote_code: bool = False,
         gpu_memory_utilization: float | None = None,
         max_num_seqs: int | None = None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
         # scheduling / scaling
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
@@ -943,6 +960,8 @@ class ServingManager:
             min_replicas=min_replicas,
             max_replicas=max_replicas,
             hf_secret_name=hf_secret_name,
+            quantization=quantization,
+            kv_cache_dtype=kv_cache_dtype,
         )
         predictor_spec, effective_annotations = ServingManager._apply_raw_deployment_defaults(
             predictor_spec, annotations
@@ -1011,6 +1030,8 @@ class ServingManager:
         trust_remote_code: bool = False,
         gpu_memory_utilization: float | None = None,
         max_num_seqs: int | None = None,
+        quantization: str | None = None,
+        kv_cache_dtype: str | None = None,
         # scheduling / scaling
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
@@ -1158,6 +1179,8 @@ class ServingManager:
             trust_remote_code=trust_remote_code,
             gpu_memory_utilization=gpu_memory_utilization,
             max_num_seqs=max_num_seqs,
+            quantization=quantization,
+            kv_cache_dtype=kv_cache_dtype,
             resources=resources,
             tolerations=tolerations,
             node_selector=node_selector,

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -737,14 +737,32 @@ def test_deploy_llm_quantization_and_kv_cache_dtype_appear_at_tail(serving, serv
     ]
 
 
-@pytest.mark.parametrize("quant_sentinel", [None, "none", "auto"])
+# Sentinel values that mean "don't emit the flag" — applied symmetrically
+# to both ``quantization`` and ``kv_cache_dtype``. Case + whitespace
+# variants prove the normaliser handles noisy config layers.
+_LLM_ARG_UNSET_SENTINELS = [
+    None,
+    "",
+    "none",
+    "None",
+    "NONE",
+    " none ",
+    "auto",
+    "Auto",
+    "AUTO",
+    " auto ",
+]
+
+
+@pytest.mark.parametrize("quant_sentinel", _LLM_ARG_UNSET_SENTINELS)
 def test_deploy_llm_quantization_sentinels_emit_no_flag(
     serving, serving_module, quant_sentinel
 ):
     """``None`` (unset), ``"none"`` (recommender's "unquantized" label),
-    and ``"auto"`` (vLLM-decides) all mean "don't emit ``--quantization``"
-    so callers can normalise to whichever default fits their config
-    layer without changing the rendered ISVC."""
+    and ``"auto"`` (vLLM-decides) — plus their case/whitespace variants
+    and the empty string — all mean "don't emit ``--quantization``" so
+    callers can normalise to whichever default fits their config layer
+    without changing the rendered ISVC."""
     _, fake_api, _ = serving_module
 
     serving.deploy_llm(
@@ -759,12 +777,15 @@ def test_deploy_llm_quantization_sentinels_emit_no_flag(
     assert not any(a.startswith("--quantization") for a in args), args
 
 
-@pytest.mark.parametrize("kv_sentinel", [None, "auto"])
+@pytest.mark.parametrize("kv_sentinel", _LLM_ARG_UNSET_SENTINELS)
 def test_deploy_llm_kv_cache_dtype_sentinels_emit_no_flag(
     serving, serving_module, kv_sentinel
 ):
-    """``None`` and ``"auto"`` both leave KV at the compute dtype, so no
-    ``--kv-cache-dtype`` should appear."""
+    """Same sentinel handling as ``quantization`` — applied symmetrically
+    so the diff-clean guarantee is field-agnostic. ``"none"`` was added
+    in response to Copilot review #2 on PR #103: a stringly-typed
+    config layer that uses ``"none"`` as the off-state for both flags
+    should produce identical ISVCs regardless of which field is set."""
     _, fake_api, _ = serving_module
 
     serving.deploy_llm(
@@ -777,6 +798,26 @@ def test_deploy_llm_kv_cache_dtype_sentinels_emit_no_flag(
 
     args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
     assert not any(a.startswith("--kv-cache-dtype") for a in args), args
+
+
+def test_deploy_llm_real_quantization_values_preserved_verbatim(serving, serving_module):
+    """A non-sentinel value passes through to the emitted arg unchanged
+    (no lowercasing of real vLLM CLI values like ``"fp8"`` — guards
+    against the normaliser accidentally munging legitimate inputs)."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        max_model_len=4096,
+        quantization="fp8",
+        kv_cache_dtype="fp8_e4m3",
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert "--quantization=fp8" in args
+    assert "--kv-cache-dtype=fp8_e4m3" in args
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -701,6 +701,84 @@ def test_deploy_llm_whitelisted_args_order_and_flags(serving, serving_module):
     ]
 
 
+def test_deploy_llm_quantization_and_kv_cache_dtype_appear_at_tail(serving, serving_module):
+    """When the recommender supplies ``quantization`` / ``kv_cache_dtype``,
+    they land at the tail of the args list so the prefix order stays
+    diff-stable with calls that omit them."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen3.6-35B-A3B",
+        isvc_name="q",
+        served_model_name="q",
+        max_model_len=32768,
+        dtype="bfloat16",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.92,
+        quantization="fp8",
+        kv_cache_dtype="fp8_e4m3",
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    # The two new flags must be at the end; everything before them must
+    # match the existing stable ordering. This mirrors the user's live
+    # qwen3-6-35b-a3b ISVC shape — that's the recommender's target.
+    assert args[-2:] == [
+        "--quantization=fp8",
+        "--kv-cache-dtype=fp8_e4m3",
+    ]
+    assert args[:-2] == [
+        "--model_id=Qwen/Qwen3.6-35B-A3B",
+        "--model_name=q",
+        "--max_model_len=32768",
+        "--dtype=bfloat16",
+        "--tensor-parallel-size=1",
+        "--gpu-memory-utilization=0.92",
+    ]
+
+
+@pytest.mark.parametrize("quant_sentinel", [None, "none", "auto"])
+def test_deploy_llm_quantization_sentinels_emit_no_flag(
+    serving, serving_module, quant_sentinel
+):
+    """``None`` (unset), ``"none"`` (recommender's "unquantized" label),
+    and ``"auto"`` (vLLM-decides) all mean "don't emit ``--quantization``"
+    so callers can normalise to whichever default fits their config
+    layer without changing the rendered ISVC."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        max_model_len=4096,
+        quantization=quant_sentinel,
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert not any(a.startswith("--quantization") for a in args), args
+
+
+@pytest.mark.parametrize("kv_sentinel", [None, "auto"])
+def test_deploy_llm_kv_cache_dtype_sentinels_emit_no_flag(
+    serving, serving_module, kv_sentinel
+):
+    """``None`` and ``"auto"`` both leave KV at the compute dtype, so no
+    ``--kv-cache-dtype`` should appear."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-7B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        max_model_len=4096,
+        kv_cache_dtype=kv_sentinel,
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert not any(a.startswith("--kv-cache-dtype") for a in args), args
+
+
 # ---------------------------------------------------------------------
 # LLM name derivation (derive_llm_names + deploy_llm with omitted names)
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add optional ``quantization`` and ``kv_cache_dtype`` kwargs to ``_build_llm_args``, ``_build_llm_predictor``, ``deploy_llm``, ``serve_llm`` and their async counterparts.
- When set, emit ``--quantization=<value>`` and ``--kv-cache-dtype=<value>`` at the tail of the predictor args list. When unset (or ``"none"`` / ``"auto"``), no args are added — existing ISVCs stay diff-clean.
- Backward-compatible additive change: all existing call sites work unchanged, and ``_build_llm_args`` output is byte-identical for any call that doesn't pass the new kwargs.

## Why

KServe's HF runtime + vLLM accept these flags but the whitelisted runtime args didn't forward them. Cog-Engine's LLM config recommender produces ``quantization=fp8`` and ``kv_cache_dtype=fp8_e4m3`` as the unlock when an fp16 model won't fit the GPU budget — but without this change, deployers calling ``serve_llm`` could not pass those knobs through, so the recommender's fallback was useless end-to-end.

Pairs with Cog-Engine PR ``feat/llm-recommender-fallback-ladder`` which is the consumer.

## Test plan

- [x] Spot-checked ``_build_llm_args`` output with the new kwargs unset — identical to before.
- [x] Confirmed downstream Cog-Engine threads the new kwargs through ``cogflow_serving.async_serve_llm`` and the resulting predictor args match the shape of a real cluster ISVC (``--quantization=fp8 --kv-cache-dtype=fp8_e4m3``).
- [ ] Run cogflow's full test suite in CI.