### PR TITLE
fix(serving): restore async re-export block on cogflow.core.serving

### DIFF
--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1826,4 +1826,23 @@ for attr_name in dir(ServingManager):
         # Bind the method to the singleton instance
         globals()[attr_name] = getattr(_serving, attr_name)
 
-# Expose async methods from AsyncServingManager
+# Expose async methods from AsyncServingManager so consumers reaching
+# ``cogflow.serving`` (via the package-level _LazyLoader, which maps
+# ``cogflow.serving`` → ``cogflow.core.serving``) get the full async
+# surface alongside the sync one — without this block, ``from cogflow
+# import serving as cogflow_serving; cogflow_serving.async_deploy_llm``
+# returns AttributeError. Test
+# ``test_serving_module_reexports_async_deploy_llm`` defends this
+# contract by running an import in a fresh subprocess.
+from .async_serving import (  # noqa: E402
+    async_deploy_model,
+    async_deploy_llm,
+    async_serve_llm,
+    async_update_model,
+    async_delete_isvc,
+    async_list_models,
+    async_get_isvc,
+    async_update_isvc,
+    async_restart_isvc,
+    async_create_isvc,
+)

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1834,7 +1834,7 @@ for attr_name in dir(ServingManager):
 # raises AttributeError. Test
 # ``test_serving_module_reexports_async_deploy_llm`` defends this
 # contract by running an import in a fresh subprocess.
-from .async_serving import (  # noqa: E402
+from .async_serving import (  # noqa: E402, F401
     async_deploy_model,
     async_deploy_llm,
     async_serve_llm,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -1831,7 +1831,7 @@ for attr_name in dir(ServingManager):
 # ``cogflow.serving`` → ``cogflow.core.serving``) get the full async
 # surface alongside the sync one — without this block, ``from cogflow
 # import serving as cogflow_serving; cogflow_serving.async_deploy_llm``
-# returns AttributeError. Test
+# raises AttributeError. Test
 # ``test_serving_module_reexports_async_deploy_llm`` defends this
 # contract by running an import in a fresh subprocess.
 from .async_serving import (  # noqa: E402


### PR DESCRIPTION
## Summary

Restore the explicit ``async_*`` re-exports at the bottom of ``cogflow/core/serving.py`` so consumers reaching the async surface via ``from cogflow import serving as cogflow_serving; cogflow_serving.async_deploy_llm`` (the public path through the package-level ``_LazyLoader``) get the helpers back. Without this block ``hasattr(cogflow_serving, \"async_deploy_llm\")`` returns False and any caller of the async LLM API breaks.

## Why

The block was unintentionally dropped during the ruff migration in #101 (commit ``8b0e984``) — the explicit ``# noqa: E402`` (intentional, since the import is below module-level code) didn't survive the auto-rewrite. The regression test ``test_serving_module_reexports_async_deploy_llm`` blocked the v3.0.0b2 release until I restored the block on the release branch (``9c21923``). This PR cherry-picks that restore onto ``refactor`` so the next release cut from refactor doesn't re-fail.

## Test plan

- [x] Restored block matches v3.0.0b1 verbatim — same import set, same order.
- [x] ``test_serving_module_reexports_async_deploy_llm`` passes locally in the subprocess path (would fail before this).
- [x] Full cogflow suite: 297 passed, 1 skipped, 0 failures.
- [ ] CI on this PR will exercise the same gate that caught it on v3.0.0b2.