### PR TITLE
fix(deps): pin kubernetes<35 to restore in-cluster sync auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,11 @@ dependencies = [
     "pydantic-settings >=2.0.0",
     "scikit-learn (==1.7.0)",
     "tenacity",
-    "kubernetes",
+    # kubernetes>=35 breaks in-cluster auth on the sync client:
+    # Configuration.auth_settings() now requires api_key["BearerToken"]
+    # while incluster_config still writes api_key["authorization"], so
+    # every in-cluster sync request 401s. kubernetes_asyncio is unaffected.
+    "kubernetes<35",
     "kubernetes_asyncio",
     "minio>=7.2.0",
     "httpx >=0.25,<1"


### PR DESCRIPTION
## Summary

The synchronous ``cogflow.serving`` API 401s on every in-cluster call when running against ``kubernetes`` Python client ``>=35``:

- ``kubernetes==34.1.0`` → ``list_namespaced_custom_object(...)`` returns ISVCs
- ``kubernetes==36.0.0`` → ``UnauthorizedException 401`` on the very first request from a fresh subprocess

Upstream split-brain across two files of the sync client:

| File | v34 and earlier | v35+ |
| --- | --- | --- |
| ``incluster_config._set_config`` | writes ``api_key['authorization']`` | **unchanged** — still writes ``api_key['authorization']`` |
| ``Configuration.auth_settings`` | ``if 'authorization' in self.api_key`` ✅ | ``if 'BearerToken' in self.api_key`` ❌ |

``auth_settings()`` returns ``{}``, ``ApiClient.update_params_for_auth(['BearerToken'])`` adds no Authorization header, k8s API returns 401. ``kubernetes_asyncio``'s in-cluster loader writes the new key directly and is unaffected (which is why ``cogflow.serving.async_list_models`` / ``async_delete_isvc`` keep working).

## Change

Pin ``kubernetes<35`` in ``pyproject.toml`` with a comment explaining why. ``uv pip compile`` resolves cleanly to ``kubernetes==33.1.0`` — no other cogflow dep pulls ``kubernetes`` directly, no conflicts.

## Verification

Repro on the live ``cog-api-dev`` pod:

```
kubectl exec -n kubeflow cog-api-dev-0 -c cogapi-app -- bash -c "
  pip install -q --target=/tmp/k8s34 'kubernetes<35'
  PYTHONPATH=/tmp/k8s34 python3 -c '
import kubernetes
from kubernetes import config, client
config.load_incluster_config()
r = client.CustomObjectsApi().list_namespaced_custom_object(
    group=\"serving.kserve.io\", version=\"v1beta1\",
    namespace=\"admin\", plural=\"inferenceservices\")
print(\"items:\", len(r[\"items\"]))
'"
```

Returns `items: 6` on v34, raises `UnauthorizedException 401` on v36.

A companion Cog-Engine PR (HIRO-MicroDataCenters-BV/Cog-Engine#304) migrates that app's read/delete sites to the existing ``async_*`` twins so its user-visible 500 is fixed independently. The two fixes are independent.

## Follow-up (not in this PR)

Open an issue at ``kubernetes-client/python`` describing the v35 incluster_config / auth_settings mismatch. Once upstream releases a fix, drop the pin.
