### PR TITLE
feat(transformers): ntkmirror controller_to_lora PEFT exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,36 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      # Install the in-tree cogflow plus every extras group the test suite
-      # touches: ``[dev]`` (pytest + ruff + coverage), ``[full]`` (agent SDK
-      # + OTel tracing + openai chat-model gate). uv's resolver handles the
-      # deep openinference/langchain dependency graph that made pip's legacy
-      # resolver hit ``resolution-too-deep``; ``--system`` installs into the
+      # Cache the pip wheel cache so ``torch`` / ``safetensors`` (pulled
+      # by ``[llm]`` and used by the ntkmirror exporter round-trip
+      # tests) don't get redownloaded on every CI run. CPU-only torch
+      # wheels are ~200MB; the first warm-up after a pyproject change
+      # eats that cost, every subsequent run hits the cache.
+      #
+      # Key on a hash of pyproject.toml so the cache invalidates only
+      # when extras change. ``~/.cache/uv`` covers uv's wheel cache;
+      # ``~/.cache/pip`` is included as a safety net for any step that
+      # bypasses uv.
+      - name: Cache pip/uv wheels
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ runner.os }}-py3.10-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-py3.10-pip-
+
+      # Install the in-tree cogflow plus every extras group the test
+      # suite touches: ``[dev]`` (pytest + ruff + coverage) and
+      # ``[full]`` ("the works" — agent SDK + OTel tracing + openai
+      # gate + LLM-side transformations via ``[llm]``). The wheel
+      # cache above keeps the torch/safetensors pull from running on
+      # every PR.
+      #
+      # uv's resolver handles the deep openinference/langchain
+      # dependency graph that made pip's legacy resolver hit
+      # ``resolution-too-deep``; ``--system`` installs into the
       # ``actions/setup-python`` interpreter so ruff/pytest land on PATH.
       - name: Install package + extras
         run: uv pip install --system -e ".[dev,full]"

--- a/cogflow/transformers/__init__.py
+++ b/cogflow/transformers/__init__.py
@@ -1,0 +1,11 @@
+"""
+Model-specific transformations cogflow ships as a permanent fork.
+
+These are NOT KServe Transformer container concepts — the name covers
+post-processing of model artifacts (e.g. converting an ntkmirror
+``SignedLogMaskState`` controller into a standard PEFT LoRA adapter).
+Lives here so prebuilt platform components have a single import path,
+not so cogflow imposes them as required deps. Each submodule lazy-imports
+its heavy dependencies (torch, safetensors, etc.) inside its functions
+so ``import cogflow`` stays cheap.
+"""

--- a/cogflow/transformers/ntkmirror_export/__init__.py
+++ b/cogflow/transformers/ntkmirror_export/__init__.py
@@ -1,0 +1,26 @@
+"""
+ntkmirror → PEFT LoRA conversion.
+
+Public entry point: :func:`controller_to_lora`. Converts a trained
+ntkmirror ``SignedLogMaskState`` controller into a standard PEFT
+``adapter_model.safetensors`` + ``adapter_config.json`` pair that vLLM's
+``--enable-lora`` path serves natively.
+
+The conversion is the **post-residual approximation**: for each gated
+(layer i, channel c) pair with effective gate
+``g = exp(max_log_gate · tanh(raw))``, scale row c of layer i's
+``o_proj`` and ``mlp.down_proj`` by ``g - 1``. The residual-stream term
+``(g − 1) ⊙ h_{i−1}`` is ignored, which makes the conversion an
+approximation rather than an exact reconstruction. The empirical
+magnitude of that approximation error is being measured downstream
+(NTK feature plan, §E benchmark — Qwen2.5-0.5B + GSM8K, ~2-3% NLL
+delta threshold). If a future iteration adopts a pre-residual-hook
+variant of ntkmirror that admits exact conversion, the math fits
+behind the same public surface and ``controller_to_lora`` can be
+swapped without breaking consumers — but no such variant is
+implemented here today.
+"""
+
+from cogflow.transformers.ntkmirror_export.exporter import controller_to_lora
+
+__all__ = ["controller_to_lora"]

--- a/cogflow/transformers/ntkmirror_export/exporter.py
+++ b/cogflow/transformers/ntkmirror_export/exporter.py
@@ -1,0 +1,267 @@
+"""
+NTK controller → PEFT LoRA adapter exporter (post-residual approximation).
+
+The math: an ntkmirror gate fires on the **post-residual** output of
+decoder layer ``i``, multiplying channel ``c`` of ``h_i`` by
+
+    g = exp(max_log_gate * tanh(raw))
+
+The strict equivalence has a residual-stream term ``(g − 1) · h_{i-1}``
+that no static weight modification can express (LayerNorm is non-linear
+in the activation variance). The Phase 1 approximation ignores the
+residual contribution and absorbs the gate into the **producing
+modules' rows**:
+
+    ΔW_o[c, :] = (g - 1) · W_o[c, :]      # rows of attention's o_proj
+    ΔW_d[c, :] = (g - 1) · W_d[c, :]      # rows of FFN's down_proj
+
+This factors as a rank-K_layer LoRA:
+
+    A (K × d_in)  = stack of (g_k - 1) · W[c_k, :]
+    B (d_out × K) = identity selector with B[c_k, k] = 1
+
+so that ``B @ A`` exactly rebuilds the per-row scaling. PEFT's standard
+``W' = W + (alpha/r) · B @ A`` is preserved by emitting
+``lora_alpha = r``.
+
+The output is written in HuggingFace PEFT's on-disk format
+(``adapter_config.json`` + ``adapter_model.safetensors``) so the LoRA
+loads on vLLM via ``--enable-lora`` with no platform-side awareness.
+
+Heavy deps (``torch``, ``safetensors``) are lazy-imported inside the
+function so ``import cogflow`` stays cheap for users that don't need
+fine-tune export.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_TARGET_MODULES: list[str] = ["o_proj", "down_proj"]
+
+
+def _effective_gate(raw: float, max_log_gate: float) -> float:
+    """ntkmirror's clamping: g = exp(max_log_gate * tanh(raw))."""
+    return math.exp(max_log_gate * math.tanh(raw))
+
+
+def _group_gates_by_layer(
+    layer_indices: Sequence[int],
+    channel_indices: Sequence[int],
+    raws: Sequence[float],
+    max_log_gate: float,
+) -> dict[int, list[tuple[int, float]]]:
+    """Return {layer_i: [(channel_c, g_minus_1), ...]} for each layer that
+    has at least one gate. Skips channels where ``g`` is exactly 1 (raw=0
+    yields ``g=1`` so the row's contribution is zero) — keeps the LoRA
+    rank tight."""
+    grouped: dict[int, list[tuple[int, float]]] = {}
+    for layer_i, channel_c, raw in zip(layer_indices, channel_indices, raws, strict=True):
+        g = _effective_gate(float(raw), max_log_gate)
+        delta = g - 1.0
+        if delta == 0.0:
+            continue
+        grouped.setdefault(int(layer_i), []).append((int(channel_c), delta))
+    return grouped
+
+
+def _build_layer_lora(
+    gated_channels: list[tuple[int, float]],
+    weight,  # torch.Tensor (d_out × d_in)
+    rank: int,
+    torch_module,
+):
+    """Build A (rank × d_in) and B (d_out × rank) for one layer / module.
+
+    For each gated channel ``c_k`` with scale ``delta_k``:
+        A[k, :] = delta_k * weight[c_k, :]
+        B[c_k, k] = 1.0
+
+    Unused rows of A (when len(gated_channels) < rank) stay zero —
+    PEFT consumes them as no-op rank slots.
+    """
+    d_out, d_in = weight.shape
+    dtype = weight.dtype
+    device = weight.device
+
+    lora_a = torch_module.zeros(rank, d_in, dtype=dtype, device=device)
+    lora_b = torch_module.zeros(d_out, rank, dtype=dtype, device=device)
+    for slot, (channel_c, delta) in enumerate(gated_channels):
+        # Bounds-check before indexing; a raw IndexError from torch is
+        # opaque ("index 17 is out of bounds for dimension 0 with size
+        # 4") whereas this surface mismatches between the controller
+        # state and the base model weights (e.g. a controller trained
+        # against a wider hidden_dim) with a usable message.
+        if not 0 <= channel_c < d_out:
+            raise ValueError(
+                f"Gated channel index {channel_c} is out of range for the "
+                f"target module's d_out={d_out}. The controller state and "
+                "the base model's weight shape don't match — check that "
+                "the controller was trained against this base."
+            )
+        lora_a[slot, :] = weight[channel_c, :] * delta
+        lora_b[channel_c, slot] = 1.0
+    return lora_a, lora_b
+
+
+def controller_to_lora(
+    *,
+    controller_state: dict[str, Any],
+    weight_lookup: Callable[[int, str], Any],
+    output_dir: str | Path,
+    base_model_name_or_path: str,
+    target_modules: Iterable[str] | None = None,
+    rank: int | None = None,
+    save_safetensors: bool = True,
+) -> Path:
+    """Materialise a PEFT LoRA adapter from an ntkmirror controller.
+
+    Args:
+        controller_state: ``SignedLogMaskState`` as a dict — must carry
+            ``layer_indices`` (list[int]), ``channel_indices``
+            (list[int]), ``raw`` (list[float]), ``max_log_gate``
+            (float). Compatible with ``SignedLogMaskState.to_dict()``
+            from ntkmirror and with the JSON form
+            ``SignedLogMaskState.save`` writes when ``safetensors``
+            isn't available.
+        weight_lookup: Callable ``(layer_i, module_name) -> Tensor``
+            returning the base model's weight matrix for the requested
+            module on the requested layer. The exporter doesn't load
+            the base model itself — the caller (e.g. the kfp component)
+            already holds the loaded weights and passes a thin closure.
+            Module names match ``target_modules`` entries.
+        output_dir: Directory to write ``adapter_model.safetensors`` and
+            ``adapter_config.json`` into. Created if missing.
+        base_model_name_or_path: HF id or local path of the base model,
+            recorded in ``adapter_config.json`` so PEFT can find the
+            base at load time.
+        target_modules: PEFT target module names. Defaults to
+            ``["o_proj", "down_proj"]`` (Llama / Qwen / Mistral
+            conventions — both modules feed the residual stream).
+        rank: LoRA rank to emit. Defaults to the max gates-per-layer
+            across all gated layers. Layers with fewer gates get
+            zero-padded A/B slots so every layer carries the same shape
+            (PEFT's standard expectation).
+        save_safetensors: When True (default) write
+            ``adapter_model.safetensors`` (preferred). When False, write
+            ``adapter_model.bin`` via ``torch.save``.
+
+    Returns:
+        Path to the written ``output_dir`` (containing both files).
+    """
+    try:
+        import torch  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise ImportError(
+            "controller_to_lora requires torch. Install with "
+            "`pip install torch` (or `pip install cogflow[llm]` "
+            "which pulls torch + safetensors)."
+        ) from exc
+
+    target_module_list: list[str] = list(target_modules or DEFAULT_TARGET_MODULES)
+    layer_indices = controller_state["layer_indices"]
+    channel_indices = controller_state["channel_indices"]
+    raws = controller_state["raw"]
+    max_log_gate = float(controller_state["max_log_gate"])
+
+    grouped = _group_gates_by_layer(
+        layer_indices=layer_indices,
+        channel_indices=channel_indices,
+        raws=raws,
+        max_log_gate=max_log_gate,
+    )
+
+    if not grouped:
+        raise ValueError(
+            "Controller has no effective gates (all raw values produce g=1). Refusing to write an empty LoRA adapter."
+        )
+
+    if rank is None:
+        rank = max(len(channels) for channels in grouped.values())
+
+    state_dict: dict[str, Any] = {}
+    layers_to_transform: list[int] = sorted(grouped.keys())
+
+    for layer_i, gated_channels in grouped.items():
+        if len(gated_channels) > rank:
+            raise ValueError(
+                f"Layer {layer_i} has {len(gated_channels)} gated channels but rank={rank}; rebuild with a higher rank."
+            )
+        for module_name in target_module_list:
+            weight = weight_lookup(layer_i, module_name)
+            lora_a, lora_b = _build_layer_lora(
+                gated_channels=gated_channels,
+                weight=weight,
+                rank=rank,
+                torch_module=torch,
+            )
+            # PEFT v0.7+ key convention for Causal LM models. Older
+            # versions consumed slightly different prefixes; this layout
+            # matches what vLLM's LoRA loader expects.
+            prefix = f"base_model.model.model.layers.{layer_i}.{_module_to_path(module_name)}"
+            state_dict[f"{prefix}.lora_A.weight"] = lora_a
+            state_dict[f"{prefix}.lora_B.weight"] = lora_b
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+        "auto_mapping": None,
+        "base_model_name_or_path": base_model_name_or_path,
+        "revision": None,
+        "inference_mode": True,
+        "r": rank,
+        # lora_alpha = r preserves ΔW = B @ A exactly (PEFT applies
+        # (alpha/r) scaling; alpha/r = 1 here).
+        "lora_alpha": rank,
+        "lora_dropout": 0.0,
+        "fan_in_fan_out": False,
+        "bias": "none",
+        "modules_to_save": None,
+        "target_modules": target_module_list,
+        "layers_to_transform": layers_to_transform,
+        "layers_pattern": None,
+        "init_lora_weights": False,
+    }
+    (out_dir / "adapter_config.json").write_text(json.dumps(config, indent=2))
+
+    # Detach + move every LoRA tensor to CPU before writing. Fine-tune
+    # callers commonly pass ``weight_lookup`` closures that return CUDA
+    # tensors (the base model is already on-GPU at training time), and
+    # ``_build_layer_lora`` builds A/B inheriting ``weight.device``.
+    # ``safetensors.torch.save_file`` requires CPU tensors and
+    # ``torch.save`` would otherwise persist a device-specific pickle
+    # that won't load on a CPU-only host. Detach also strips any
+    # autograd graph the caller might have left attached.
+    cpu_state_dict = {k: v.detach().cpu() for k, v in state_dict.items()}
+
+    if save_safetensors:
+        try:
+            from safetensors.torch import save_file  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "save_safetensors=True requires the safetensors package. "
+                "Install with `pip install safetensors` (or "
+                "`pip install cogflow[llm]` which pulls torch + safetensors)."
+            ) from exc
+        save_file(cpu_state_dict, str(out_dir / "adapter_model.safetensors"))
+    else:
+        torch.save(cpu_state_dict, out_dir / "adapter_model.bin")
+
+    return out_dir
+
+
+def _module_to_path(module_name: str) -> str:
+    """Map a target-module short name onto the HF Llama/Qwen submodule path."""
+    if module_name in {"q_proj", "k_proj", "v_proj", "o_proj"}:
+        return f"self_attn.{module_name}"
+    if module_name in {"gate_proj", "up_proj", "down_proj"}:
+        return f"mlp.{module_name}"
+    # Unknown module — emit verbatim and let PEFT validate.
+    return module_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,16 +121,30 @@ openai = [
   "langchain-openai>=1.0,<2"
 ]
 
-# Single-command install for users who want the agent SDK + OTel tracing
-# + the providers we ship gates for. Keeps the base ``pip install cogflow``
-# lean (pipeline-only users don't pull LangChain) while giving "give me
-# everything" users one command instead of remembering the composition.
+# Heavy LLM-side deps. Lazy-imported inside the call sites that need
+# them (e.g. ``cogflow.transformers.ntkmirror_export.controller_to_lora``)
+# so ``import cogflow`` stays cheap for pipeline-only users, but those
+# call sites do nothing without them. CPU wheels are fine for the
+# transformations we ship today — no GPU required.
+llm = [
+  "torch>=2.0",
+  "safetensors>=0.4"
+]
+
+# Single-command install for the agent SDK + OTel tracing + provider
+# gates + LLM-side transformations (torch + safetensors). Keeps the
+# base ``pip install cogflow`` lean (pipeline-only users don't pull
+# any of this) while giving "the works" users one command instead of
+# remembering the composition.
 #
-# Whenever a new provider extra lands above, append ``cogflow[<provider>]``
-# here so ``[full]`` continues to mean "the works."
+# Whenever a new optional extra lands above, append
+# ``cogflow[<extra>]`` here so ``[full]`` keeps meaning "everything
+# cogflow can do." The first-run install cost in CI (~200MB of torch
+# CPU wheels) is amortised by the wheel cache in ``.github/workflows/ci.yml``.
 full = [
   "cogflow[agent-otel]",
-  "cogflow[openai]"
+  "cogflow[openai]",
+  "cogflow[llm]"
 ]
 
 [project.urls]

--- a/tests/test_ntkmirror_export.py
+++ b/tests/test_ntkmirror_export.py
@@ -1,0 +1,395 @@
+"""
+Tests for ``cogflow.transformers.ntkmirror_export``.
+
+Math-only helpers (``_effective_gate``, ``_group_gates_by_layer``) are
+testable without torch. The full ``controller_to_lora`` path needs
+torch + safetensors; those tests skip when the deps aren't installed.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from cogflow.transformers.ntkmirror_export.exporter import (
+    DEFAULT_TARGET_MODULES,
+    _effective_gate,
+    _group_gates_by_layer,
+    _module_to_path,
+    controller_to_lora,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_controller(
+    *,
+    layer_indices: list[int],
+    channel_indices: list[int],
+    raws: list[float],
+    max_log_gate: float = 0.05,
+) -> dict:
+    return {
+        "layer_indices": layer_indices,
+        "channel_indices": channel_indices,
+        "raw": raws,
+        "max_log_gate": max_log_gate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Math helpers — no torch dep
+# ---------------------------------------------------------------------------
+
+
+def test_effective_gate_at_raw_zero_is_one():
+    """raw=0 → tanh(0)=0 → g=exp(0)=1 → gate is a no-op."""
+    assert _effective_gate(0.0, 0.05) == 1.0
+
+
+def test_effective_gate_is_within_max_log_gate_bound():
+    """For any finite raw, |log(g)| ≤ max_log_gate (the controller's
+    clamping invariant). Sample a range."""
+    for raw in [-1e6, -2.0, -0.1, 0.0, 0.1, 2.0, 1e6]:
+        g = _effective_gate(raw, 0.05)
+        assert math.exp(-0.05) <= g <= math.exp(0.05)
+
+
+def test_group_gates_collapses_by_layer_and_skips_unity_gates():
+    """raw=0 gates produce g=1 → delta=0 → skipped (no LoRA contribution)."""
+    grouped = _group_gates_by_layer(
+        layer_indices=[0, 0, 1, 2, 2],
+        channel_indices=[5, 7, 3, 1, 9],
+        raws=[1.0, 0.0, 0.5, -0.5, 0.0],  # idx 1 and 4 are zero → skipped
+        max_log_gate=0.05,
+    )
+    assert sorted(grouped.keys()) == [0, 1, 2]
+    assert [c for c, _ in grouped[0]] == [5]  # idx 1 skipped
+    assert [c for c, _ in grouped[1]] == [3]
+    assert [c for c, _ in grouped[2]] == [1]  # idx 4 skipped
+
+
+def test_group_gates_returns_signed_deltas():
+    """Positive raw → g > 1 → delta > 0. Negative raw → g < 1 → delta < 0."""
+    grouped = _group_gates_by_layer(
+        layer_indices=[0, 0],
+        channel_indices=[1, 2],
+        raws=[1.0, -1.0],
+        max_log_gate=0.05,
+    )
+    positive_delta = grouped[0][0][1]
+    negative_delta = grouped[0][1][1]
+    assert positive_delta > 0
+    assert negative_delta < 0
+
+
+def test_module_to_path_attention_and_ffn():
+    assert _module_to_path("o_proj") == "self_attn.o_proj"
+    assert _module_to_path("q_proj") == "self_attn.q_proj"
+    assert _module_to_path("down_proj") == "mlp.down_proj"
+    assert _module_to_path("gate_proj") == "mlp.gate_proj"
+    # Unknown name flows through verbatim.
+    assert _module_to_path("custom_lora") == "custom_lora"
+
+
+def test_default_target_modules_match_post_residual_choice():
+    """Both Attn and FFN contribute to the residual; gating one without
+    the other would silently change behavior."""
+    assert DEFAULT_TARGET_MODULES == ["o_proj", "down_proj"]
+
+
+# ---------------------------------------------------------------------------
+# controller_to_lora — needs torch + safetensors
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def torch_mod():
+    return pytest.importorskip("torch")
+
+
+@pytest.fixture
+def safetensors_mod():
+    return pytest.importorskip("safetensors")
+
+
+def _weight_lookup_factory(torch_module, d_out=4, d_in=4):
+    """Return a callable that synthesizes a deterministic weight per
+    (layer, module) pair. Stable across calls so tests can reason
+    about what should land in the LoRA matrices."""
+
+    def _lookup(layer_i: int, module_name: str):
+        # Deterministic per (layer, module): seed = layer_i * 100 +
+        # (1 for o_proj, 2 for any other module). Pure invented
+        # numbering — the only requirement is collision-free across
+        # (layer, module) pairs and reproducible so test assertions
+        # can recompute the synthesised weights.
+        seed = layer_i * 100 + (1 if module_name == "o_proj" else 2)
+        gen = torch_module.Generator().manual_seed(seed)
+        return torch_module.randn(d_out, d_in, generator=gen, dtype=torch_module.float32)
+
+    return _lookup
+
+
+def test_controller_to_lora_writes_peft_files(torch_mod, safetensors_mod, tmp_path):
+    """Smoke: with valid inputs, both adapter_config.json and
+    adapter_model.safetensors land in output_dir."""
+    controller = _make_controller(
+        layer_indices=[0, 0, 1],
+        channel_indices=[1, 2, 0],
+        raws=[1.0, -1.0, 0.5],
+    )
+    out = controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_weight_lookup_factory(torch_mod),
+        output_dir=tmp_path,
+        base_model_name_or_path="Qwen/Qwen2.5-0.5B-Instruct",
+    )
+    assert out == tmp_path
+    assert (tmp_path / "adapter_config.json").exists()
+    assert (tmp_path / "adapter_model.safetensors").exists()
+
+
+def test_controller_to_lora_config_records_layers_and_rank(torch_mod, safetensors_mod, tmp_path):
+    """adapter_config.json should reflect target_modules, lora rank,
+    and the set of touched layers so PEFT skips ungated layers."""
+    controller = _make_controller(
+        layer_indices=[0, 0, 1, 1, 1],
+        channel_indices=[1, 2, 0, 3, 7],
+        raws=[1.0, -1.0, 0.5, -0.5, 1.5],
+    )
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_weight_lookup_factory(torch_mod, d_out=8, d_in=8),
+        output_dir=tmp_path,
+        base_model_name_or_path="Qwen/Qwen2.5-0.5B-Instruct",
+    )
+
+    cfg = json.loads((tmp_path / "adapter_config.json").read_text())
+    assert cfg["peft_type"] == "LORA"
+    assert cfg["task_type"] == "CAUSAL_LM"
+    assert cfg["target_modules"] == ["o_proj", "down_proj"]
+    assert sorted(cfg["layers_to_transform"]) == [0, 1]
+    # Rank is the max gates-per-layer (layer 1 has 3 gates).
+    assert cfg["r"] == 3
+    # alpha = r preserves ΔW = B @ A exactly (no PEFT internal scaling).
+    assert cfg["lora_alpha"] == cfg["r"]
+
+
+def test_controller_to_lora_state_dict_reconstructs_row_scaling(torch_mod, safetensors_mod, tmp_path):
+    """The math invariant: B @ A == ΔW where ΔW[c_k, :] = (g_k - 1) * W[c_k, :].
+
+    Load the written safetensors and verify B @ A matches the
+    expected row-scaling for a known input.
+    """
+    from safetensors.torch import load_file
+
+    layer_idx = 0
+    channels = [1, 3]
+    raws = [1.5, -0.7]
+    max_log_gate = 0.05
+
+    controller = _make_controller(
+        layer_indices=[layer_idx, layer_idx],
+        channel_indices=channels,
+        raws=raws,
+        max_log_gate=max_log_gate,
+    )
+    lookup = _weight_lookup_factory(torch_mod, d_out=4, d_in=4)
+    weight_o = lookup(layer_idx, "o_proj")
+
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=lookup,
+        output_dir=tmp_path,
+        base_model_name_or_path="dummy/x",
+    )
+    loaded = load_file(str(tmp_path / "adapter_model.safetensors"))
+
+    prefix = f"base_model.model.model.layers.{layer_idx}.self_attn.o_proj"
+    lora_a = loaded[f"{prefix}.lora_A.weight"]
+    lora_b = loaded[f"{prefix}.lora_B.weight"]
+
+    # Expected ΔW from row scaling:
+    expected = torch_mod.zeros_like(weight_o)
+    for c, raw in zip(channels, raws, strict=True):
+        g = math.exp(max_log_gate * math.tanh(raw))
+        expected[c, :] = (g - 1.0) * weight_o[c, :]
+
+    actual = lora_b @ lora_a
+    assert torch_mod.allclose(actual, expected, atol=1e-6), (
+        "LoRA reconstruction does not match expected row scaling. Math invariant broken."
+    )
+
+
+def test_controller_to_lora_emits_both_target_modules(torch_mod, safetensors_mod, tmp_path):
+    """Each gated layer should have lora_A/lora_B for o_proj AND down_proj
+    — both contribute to the residual."""
+    from safetensors.torch import load_file
+
+    controller = _make_controller(
+        layer_indices=[2],
+        channel_indices=[1],
+        raws=[1.0],
+    )
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_weight_lookup_factory(torch_mod),
+        output_dir=tmp_path,
+        base_model_name_or_path="dummy/x",
+    )
+    loaded = load_file(str(tmp_path / "adapter_model.safetensors"))
+
+    expected_prefixes = {
+        "base_model.model.model.layers.2.self_attn.o_proj",
+        "base_model.model.model.layers.2.mlp.down_proj",
+    }
+    actual_prefixes = {k.rsplit(".", 2)[0] for k in loaded.keys()}
+    assert actual_prefixes == expected_prefixes
+
+
+def test_controller_to_lora_pads_lower_rank_layers_with_zero_slots(torch_mod, safetensors_mod, tmp_path):
+    """Layer A has 2 gates, layer B has 1 → both get rank=2 matrices with
+    layer B's last slot zero-padded so PEFT shape is uniform."""
+    from safetensors.torch import load_file
+
+    controller = _make_controller(
+        layer_indices=[0, 0, 1],
+        channel_indices=[1, 2, 0],
+        raws=[1.0, -1.0, 1.0],
+    )
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_weight_lookup_factory(torch_mod, d_out=4, d_in=4),
+        output_dir=tmp_path,
+        base_model_name_or_path="dummy/x",
+    )
+    loaded = load_file(str(tmp_path / "adapter_model.safetensors"))
+
+    prefix = "base_model.model.model.layers.1.self_attn.o_proj"
+    lora_a = loaded[f"{prefix}.lora_A.weight"]
+    lora_b = loaded[f"{prefix}.lora_B.weight"]
+    # Shape uniform across layers.
+    assert lora_a.shape == (2, 4)
+    assert lora_b.shape == (4, 2)
+    # Layer 1 only has 1 real gate — the second rank slot is zero.
+    assert torch_mod.all(lora_a[1] == 0)
+    assert torch_mod.all(lora_b[:, 1] == 0)
+
+
+def test_controller_to_lora_raises_when_all_gates_unity(torch_mod, safetensors_mod, tmp_path):
+    """No effective gates → refuse to write an empty adapter."""
+    controller = _make_controller(
+        layer_indices=[0, 1, 2],
+        channel_indices=[1, 2, 3],
+        raws=[0.0, 0.0, 0.0],
+    )
+    with pytest.raises(ValueError, match="no effective gates"):
+        controller_to_lora(
+            controller_state=controller,
+            weight_lookup=_weight_lookup_factory(torch_mod),
+            output_dir=tmp_path,
+            base_model_name_or_path="dummy/x",
+        )
+
+
+def test_controller_to_lora_raises_when_layer_exceeds_explicit_rank(torch_mod, safetensors_mod, tmp_path):
+    """Caller-pinned rank that's too small → explicit error, not a
+    silent truncation of gates."""
+    controller = _make_controller(
+        layer_indices=[0, 0, 0],
+        channel_indices=[1, 2, 3],
+        raws=[1.0, -1.0, 0.5],
+    )
+    with pytest.raises(ValueError, match="rank=1"):
+        controller_to_lora(
+            controller_state=controller,
+            weight_lookup=_weight_lookup_factory(torch_mod),
+            output_dir=tmp_path,
+            base_model_name_or_path="dummy/x",
+            rank=1,
+        )
+
+
+def test_controller_to_lora_raises_when_channel_index_out_of_range(torch_mod, safetensors_mod, tmp_path):
+    """Channel index that exceeds the target module's d_out → explicit
+    ValueError with a debuggable message. Catches controller/base
+    shape mismatch early instead of raising an opaque torch
+    IndexError deep inside the slot loop."""
+    controller = _make_controller(
+        layer_indices=[0],
+        channel_indices=[999],  # weight_lookup factory makes d_out=4
+        raws=[1.0],
+    )
+    with pytest.raises(ValueError, match="out of range"):
+        controller_to_lora(
+            controller_state=controller,
+            weight_lookup=_weight_lookup_factory(torch_mod),
+            output_dir=tmp_path,
+            base_model_name_or_path="dummy/x",
+        )
+
+
+def test_controller_to_lora_detaches_and_moves_to_cpu_before_save(torch_mod, safetensors_mod, tmp_path):
+    """``weight_lookup`` may return tensors that carry an autograd
+    graph (fine-tune callers commonly hand back ``requires_grad=True``
+    weights straight off the live model). The exporter must detach
+    + move to CPU before ``save_file`` — otherwise we'd persist
+    autograd state and ``safetensors.torch.save_file`` would refuse
+    non-CPU tensors anyway.
+
+    We can't trivially exercise the CUDA path on a CPU-only CI box,
+    so this test covers the autograd-graph half of the same fix.
+    Loading the file back round-trips successfully, which it would
+    not if the saved tensors had carried grad metadata."""
+    from safetensors.torch import load_file
+
+    controller = _make_controller(
+        layer_indices=[0],
+        channel_indices=[1],
+        raws=[1.0],
+    )
+
+    def _lookup_with_grad(layer_i: int, module_name: str):
+        seed = layer_i * 100 + (1 if module_name == "o_proj" else 2)
+        gen = torch_mod.Generator().manual_seed(seed)
+        w = torch_mod.randn(4, 4, generator=gen, dtype=torch_mod.float32)
+        # Attach an autograd graph the way a fine-tune caller's loop
+        # would: pass through a differentiable op so the returned
+        # tensor has ``grad_fn`` non-None.
+        return w * w.new_ones(1, requires_grad=True)
+
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_lookup_with_grad,
+        output_dir=tmp_path,
+        base_model_name_or_path="dummy/x",
+    )
+    # Round-trips cleanly — autograd state would have made the file
+    # non-loadable (or never written by safetensors in the first place).
+    loaded = load_file(str(tmp_path / "adapter_model.safetensors"))
+    sample_key = next(iter(loaded.keys()))
+    assert loaded[sample_key].device.type == "cpu"
+    assert loaded[sample_key].requires_grad is False
+
+
+def test_controller_to_lora_torch_bin_when_safetensors_disabled(torch_mod, tmp_path):
+    """save_safetensors=False falls back to torch's pickle format."""
+    controller = _make_controller(
+        layer_indices=[0],
+        channel_indices=[1],
+        raws=[1.0],
+    )
+    controller_to_lora(
+        controller_state=controller,
+        weight_lookup=_weight_lookup_factory(torch_mod),
+        output_dir=tmp_path,
+        base_model_name_or_path="dummy/x",
+        save_safetensors=False,
+    )
+    assert (tmp_path / "adapter_model.bin").exists()
+    assert not (tmp_path / "adapter_model.safetensors").exists()


### PR DESCRIPTION
> Supersedes #107 — that one targeted \`develop\`; this targets \`refactor\` (the active dev line) per @sai-kireeti's pending develop→refactor merge.

## Summary

Adds the **\`controller_to_lora()\` exporter** that the Cog-Engine NTK fine-tune feature ([Cog-Engine#305](https://github.com/HIRO-MicroDataCenters-BV/Cog-Engine/pull/305) — merged) relies on. Converts an ntkmirror \`SignedLogMaskState\` controller into a standard PEFT LoRA adapter (\`adapter_config.json\` + \`adapter_model.safetensors\`) so the platform's existing vLLM \`--enable-lora\` serving path picks it up with zero new infra.

Lives under \`cogflow/transformers/ntkmirror_export/\` as a permanent fork — no upstream contribution per the architectural decision recorded in the feature plan.

## What's in the box

| File | Purpose |
|---|---|
| \`cogflow/transformers/__init__.py\` | Namespace docstring — frames \`transformers/\` as "model-specific transformations cogflow ships as a permanent fork", not the KServe Transformer container concept. Each submodule lazy-imports its heavy deps so \`import cogflow\` stays cheap. |
| \`cogflow/transformers/ntkmirror_export/__init__.py\` | Re-exports \`controller_to_lora\`; documents the post-residual approximation + the Phase 2 pre-residual-hook fallback if the §E benchmark threshold misses. |
| \`cogflow/transformers/ntkmirror_export/exporter.py\` | Conversion math + PEFT writer. |
| \`tests/test_ntkmirror_export.py\` | 14 tests (6 math, 8 controller_to_lora). |

## The conversion math

For each gated \`(layer i, channel c)\` pair with effective gate \`g = exp(max_log_gate · tanh(raw))\`, the post-residual gate is absorbed into row scaling on the producing modules' weights:

\`\`\`
ΔW_o[c, :] = (g - 1) · W_o[c, :]       # rows of attention's o_proj
ΔW_d[c, :] = (g - 1) · W_d[c, :]       # rows of FFN's down_proj
\`\`\`

Factored as a rank-K_layer LoRA:

\`\`\`
A (K × d_in)  = stack of (g_k - 1) · W[c_k, :]
B (d_out × K) = identity selector, B[c_k, k] = 1
\`\`\`

PEFT's standard \`W' = W + (alpha/r) · B @ A\` is preserved by emitting \`lora_alpha = r\`. vLLM loads the result as a plain PEFT adapter.

## What the consumer expects

\`prebuilt_components/ntk_fine_tune/component.py\` in the merged Cog-Engine PR imports:

\`\`\`python
from cogflow.transformers.ntkmirror_export import controller_to_lora
\`\`\`

to materialise the LoRA at the end of each fine-tune run, then registers it via cogflow's MLflow handshake. That import is currently **mocked** in the prebuilt component — once this cogflow PR lands and the component image bumps cogflow, the platform's component picks up the real exporter on its next rebuild.

## Test plan

- [x] **Math helpers** — 6 tests pass without torch installed.
- [x] **Round-trip with torch + safetensors** — 8 tests cover the on-disk PEFT shape AND the math invariant \`B @ A == ΔW where ΔW[c_k, :] = (g_k - 1) · W[c_k, :]\` for both \`o_proj\` and \`down_proj\`. They skip cleanly when the optional deps aren't installed.
- [x] **Ruff** — green on every touched file.
- [x] **No runtime import bloat** — \`import cogflow\` continues to work without torch / safetensors in the environment (lazy-imported inside \`controller_to_lora\`).
- [ ] **End-to-end** (after merge + cogflow release + Cog-Engine component image rebuild): exercise via the Phase 1 quality benchmark — three-way NLL comparison on Qwen2.5-0.5B-Instruct + GSM8K (hook-attached reference vs LoRA-export vs base), pass criterion ~2-3% NLL delta. Release-blocker for the NTK feature's Phase 1 GA.