### PR TITLE
Fix refactor CI: ruff lint + langchain 1.0 migration

### DIFF
--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -604,9 +604,7 @@ def _normalize_data_products(data_input) -> list[dict]:
     if isinstance(data, Mapping):
         data = [data]
     elif not isinstance(data, (list, tuple)):
-        raise ValueError(
-            "Data products must be a mapping, a list/tuple of mappings, or a JSON string of the same."
-        )
+        raise ValueError("Data products must be a mapping, a list/tuple of mappings, or a JSON string of the same.")
     normalized: list[dict] = []
     for item in data:
         if not isinstance(item, Mapping):

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -766,14 +766,10 @@ class ServingManager:
         # unset field. Applied symmetrically to both flags so the
         # diff-clean guarantee holds regardless of which sentinel the
         # caller picks.
-        normalized_quantization = (
-            quantization.strip() if quantization is not None else None
-        )
+        normalized_quantization = quantization.strip() if quantization is not None else None
         if not _is_unset_sentinel(normalized_quantization):
             args.append(f"--quantization={normalized_quantization}")
-        normalized_kv_cache_dtype = (
-            kv_cache_dtype.strip() if kv_cache_dtype is not None else None
-        )
+        normalized_kv_cache_dtype = kv_cache_dtype.strip() if kv_cache_dtype is not None else None
         if not _is_unset_sentinel(normalized_kv_cache_dtype):
             args.append(f"--kv-cache-dtype={normalized_kv_cache_dtype}")
         return args
@@ -1835,14 +1831,14 @@ for attr_name in dir(ServingManager):
 # ``test_serving_module_reexports_async_deploy_llm`` defends this
 # contract by running an import in a fresh subprocess.
 from .async_serving import (  # noqa: E402, F401
-    async_deploy_model,
-    async_deploy_llm,
-    async_serve_llm,
-    async_update_model,
-    async_delete_isvc,
-    async_list_models,
-    async_get_isvc,
-    async_update_isvc,
-    async_restart_isvc,
     async_create_isvc,
+    async_delete_isvc,
+    async_deploy_llm,
+    async_deploy_model,
+    async_get_isvc,
+    async_list_models,
+    async_restart_isvc,
+    async_serve_llm,
+    async_update_isvc,
+    async_update_model,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,14 @@ dependencies = [
     "google-cloud-storage >=2.2.1,<3",
     "jsonschema >=3.0.1,<5",
     "protobuf >=3.13.0,<4",
-    "requests-toolbelt >=0.8.0,<1",
+    # <2 (was <1): vendored kfp 1.8.24 copied kfp's `<1` cap, which existed
+    # only because requests-toolbelt 1.0 dropped the `adapters.appengine`
+    # module. cogflow's vendored kfp imports it solely in kfp/_auth.py behind
+    # an `isinstance(creds, app_engine.Credentials)` branch — a Google App
+    # Engine code path never reached in-cluster. Relaxing to <2 lets the
+    # agent SDK's langchain-core 1.x stack (langsmith -> requests-toolbelt>=1)
+    # resolve without affecting any live pipeline path.
+    "requests-toolbelt >=0.8.0,<2",
     "strip-hints >=0.1.8,<1",
     "tabulate >=0.8.6,<1",
     "typer >=0.3.2,<1.0",
@@ -83,8 +90,13 @@ docs = [
 ]
 
 agent = [
-  "langgraph >=0.2,<0.5",
-  "langchain-core >=0.3,<0.4"
+  # langchain 1.0 generation. langgraph >=0.4 (resolves to 1.x) pulls
+  # langgraph-checkpoint 4.x, whose serializer needs langchain-core's
+  # `Reviver(allowed_objects=...)` API — present only in langchain-core 1.x
+  # (the ecosystem jumped 0.3 -> 1.0, there is no 0.4/0.5). The agent SDK
+  # code is forward-compatible with 1.x as-is (full test suite passes).
+  "langgraph >=0.4,<2",
+  "langchain-core >=1.0,<2"
 ]
 
 # Note: a LangSmith adapter was intentionally NOT shipped. LangSmith is a
@@ -106,7 +118,7 @@ agent-otel = [
 # downstream audit produces evidence one is actually used.
 openai = [
   "cogflow[agent]",
-  "langchain-openai>=0.2,<0.4"
+  "langchain-openai>=1.0,<2"
 ]
 
 # Single-command install for users who want the agent SDK + OTel tracing

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -755,9 +755,7 @@ _LLM_ARG_UNSET_SENTINELS = [
 
 
 @pytest.mark.parametrize("quant_sentinel", _LLM_ARG_UNSET_SENTINELS)
-def test_deploy_llm_quantization_sentinels_emit_no_flag(
-    serving, serving_module, quant_sentinel
-):
+def test_deploy_llm_quantization_sentinels_emit_no_flag(serving, serving_module, quant_sentinel):
     """``None`` (unset), ``"none"`` (recommender's "unquantized" label),
     and ``"auto"`` (vLLM-decides) — plus their case/whitespace variants
     and the empty string — all mean "don't emit ``--quantization``" so
@@ -778,9 +776,7 @@ def test_deploy_llm_quantization_sentinels_emit_no_flag(
 
 
 @pytest.mark.parametrize("kv_sentinel", _LLM_ARG_UNSET_SENTINELS)
-def test_deploy_llm_kv_cache_dtype_sentinels_emit_no_flag(
-    serving, serving_module, kv_sentinel
-):
+def test_deploy_llm_kv_cache_dtype_sentinels_emit_no_flag(serving, serving_module, kv_sentinel):
     """Same sentinel handling as ``quantization`` — applied symmetrically
     so the diff-clean guarantee is field-agnostic. ``"none"`` was added
     in response to Copilot review #2 on PR #103: a stringly-typed


### PR DESCRIPTION
Makes the refactor branch's strict CI (ruff + full `[dev,full]` install + pytest) actually pass on PR #72. That CI had never run on refactor before — it only triggers on PRs to main/develop, and refactor's first such PR is #72 — so these are latent issues surfacing on first run, not regressions.

Two independent commits:

## 1. `lint:` ruff autofix
`ruff check` / `ruff format --check` flagged refactor code that predates the ruff migration:
- `serving.py`: I001 import-sort on the async re-export block (contract preserved — all names still exported) + collapse two short multi-line ternaries
- `orchestration.py`: collapse a multi-line `raise`
- `tests/test_serving.py`: formatting
All mechanical `ruff --fix` / `ruff format` output; both ruff steps pass after.

## 2. `deps:` langchain 1.0 migration
The pytest step couldn't even **collect** the agent suite: langgraph 0.4+ calls `Reviver(allowed_objects=...)`, an API only in **langchain-core 1.x**, but the extras capped `langchain-core <0.4`. There is no langchain-core 0.4/0.5 — the ecosystem jumped 0.3 → 1.0.

Bumped the agent extras to the 1.0 generation (`langchain-core>=1.0,<2`, `langgraph>=0.4,<2`, `langchain-openai>=1.0,<2`), which required relaxing `requests-toolbelt <1 → <2` (langchain-core 1.x → langsmith → requests-toolbelt>=1).

**Why relaxing requests-toolbelt is safe:** the `<1` cap came from vendored kfp 1.8.24, and existed only because requests-toolbelt 1.0 removed `adapters.appengine`. cogflow imports that module solely in `kfp/_auth.py`, behind an `isinstance(creds, google.auth.app_engine.Credentials)` branch — a Google App Engine auth path never reached when running in-cluster.

**No agent code changes were needed** — the SDK is forward-compatible with langchain-core 1.x.

### Verification (local, langchain-core 1.4.3 / langgraph 1.2.4 / langchain-openai 1.3.0)
- Full suite: **405 passed, 1 skipped**
- `ruff check .` + `ruff format --check .`: clean

Note: opentelemetry-instrumentation 0.48b0 declares a `setuptools` dep and imports `pkg_resources`; on a *fresh* venv that pulls setuptools 82 (no `pkg_resources`) and the 2 otel tests error. CI's `--system` install keeps setup-python's existing setuptools (which has `pkg_resources`), so this doesn't reproduce there — but flagging it as a separate, pre-existing OTel/setuptools fragility worth a follow-up.