### PR TITLE
fix(deps): pin kubernetes<35 (backport orphaned release hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ dependencies = [
     "pydantic-settings >=2.0.0",
     "scikit-learn (==1.7.0)",
     "tenacity",
-    "kubernetes",
+    # kubernetes>=35 breaks in-cluster auth on the sync client:
+    # every in-cluster sync request 401s. kubernetes_asyncio is unaffected.
+    "kubernetes<35",
     "kubernetes_asyncio",
     "minio>=7.2.0",
     "httpx >=0.25,<1"


### PR DESCRIPTION
develop ships `kubernetes` **unpinned** and so carries the kubernetes>=35 in-cluster-auth bug: `Configuration.auth_settings()` requires `api_key['BearerToken']` while `incluster_config._set_config` still writes `api_key['authorization']`, so the sync client sends no Authorization header and every in-cluster call 401s.

The fix (`kubernetes<35`) landed on `release/v3.0.0b3` as `eef7663` (PR #105) but was merged **only into the release branch** — never into `refactor`, so the refactor→develop merge (#72) never carried it. This backports it.

Found while auditing why `release/v3.0.0b3` had commits absent from develop. A `release/* → develop` drift guard is coming in a follow-up PR to stop this recurring.