### PR TITLE
Declare boto3 dependency for MLflow's S3 artifact store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,15 @@ dependencies = [
     "kubernetes<35",
     "kubernetes_asyncio",
     "minio>=7.2.0",
+    # mlflow's S3 artifact store imports boto3 lazily inside
+    # log_artifact / log_artifacts when the artifact backend is an
+    # S3-compatible store — which is the platform default (MinIO).
+    # Without boto3 in the dependency tree, every kfp / notebook /
+    # service that calls ``cogflow.core.models.log_artifact`` (or
+    # any path that uploads run artifacts through MLflow) fails
+    # with ``ModuleNotFoundError: No module named 'boto3'``.
+    # See ``mlflow/store/artifact/s3_artifact_repo.py:59``.
+    "boto3 >=1.34",
     "httpx >=0.25,<1"
 ]
 


### PR DESCRIPTION
## Summary

mlflow's S3 artifact store imports \`boto3\` lazily inside
\`log_artifact\` / \`log_artifacts\` whenever the artifact backend is an
S3-compatible store (\`mlflow/store/artifact/s3_artifact_repo.py:59\`).
Every cogflow-deployed cluster uses MinIO as the artifact backend, so
every cogflow user calling \`cogflow.core.models.log_artifact\` —
directly or via \`register_model\`'s internal upload — hits this code
path.

Today \`boto3\` isn't in cogflow's declared deps (neither direct nor
transitive), so the call fails with \`ModuleNotFoundError: No module
named 'boto3'\` unless the consumer has installed boto3 themselves.

## Where it surfaced

Filed when the Cog-Engine \`ntk_fine_tune\` kfp component (running on
\`hiroregistry/cogflow:latest-beta\`) ran end-to-end through model
load + ntkmirror fit + LoRA export and only died at \`log_artifact\`:

\`\`\`
INFO:ntk_fine_tune:controller saved to /tmp/ntk-…/controller.pt
INFO:ntk_fine_tune:ntk fit complete: 5000 gates trained
INFO:ntk_fine_tune:LoRA exported to /tmp/ntk-…/adapter
ERROR:cogflow:❌ Exception occurred in Log artifact …:
  No module named 'boto3'
cogflow.utils.exceptions.CogflowArtifactError: [CogFlowError]
  No module named 'boto3'
\`\`\`

The Cog-Engine fine-tune fix that goes with this is
\`HIRO-MicroDataCenters-BV/Cog-Engine#312\` — it drops the manual
\`packages_to_install=[..., "boto3"]\` band-aid once this lands so
the base image carries boto3 itself.

## Fix

Add \`boto3 >=1.34\` to the project's runtime dependencies. >=1.34
is well within mlflow 2.22's tested matrix and matches the version
range Cog-Engine already uses in its own \`requirements.txt\`.

## Test plan

- [x] \`pyproject.toml\` diff is a single new line.
- [ ] Once merged + a new beta is published, downstream Cog-Engine
      kfp run that died at \`log_artifact\` succeeds end-to-end on the
      same image (verified by re-submitting the §E benchmark).