### PR TITLE
Fix load_component wrapped() to return op

### DIFF
--- a/cogflow/core/pipelines/__init__.py
+++ b/cogflow/core/pipelines/__init__.py
@@ -81,6 +81,7 @@ def load_component(
         # Inject env only if this is a real container-backed op
         if hasattr(op, "add_env_variable"):
             orchestration._inject_env_into_container_op(op)
+        return op
 
     wrapped.__signature__ = getattr(base, "__signature__", None)
     wrapped.component_spec = getattr(base, "component_spec", None)


### PR DESCRIPTION
Forward-port of the one-line fix shipped in `release/v3.0.0b7`.

`cogflow.pipelines.load_component(id=...)` returned a `wrapped()` closure that created and registered the KFP op but never returned it — callers got `None`. Pipelines built from id-loaded components (Cog-Engine training-builder) then crashed (e.g. `None.set_display_name`), so no run was submitted. Adds the missing `return op`, matching `create_component_from_func`'s wrapper.

Without this on develop, the next beta cut from develop reintroduces the bug.