### PR TITLE
Shared fine-tuned-adapter catalog handshake + NTK serving hybrid

### DIFF
--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -623,6 +623,7 @@ class AsyncServingManager:
         predictor_spec, effective_annotations = sync_manager_cls._apply_raw_deployment_defaults(
             predictor_spec, annotations
         )
+        sync_manager_cls._assert_controller_compatible_mode(controller_storage_uri, effective_annotations)
 
         metadata = async_client.V1ObjectMeta(
             name=isvc_name,

--- a/cogflow/core/async_serving.py
+++ b/cogflow/core/async_serving.py
@@ -563,6 +563,8 @@ class AsyncServingManager:
         max_num_seqs: int | None = None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
+        controller_storage_uri: str | None = None,
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
         node_selector: dict[str, str] | None = None,
@@ -615,6 +617,8 @@ class AsyncServingManager:
             hf_secret_name=hf_secret_name,
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
+            hf_overrides=hf_overrides,
+            controller_storage_uri=controller_storage_uri,
         )
         predictor_spec, effective_annotations = sync_manager_cls._apply_raw_deployment_defaults(
             predictor_spec, annotations
@@ -684,6 +688,8 @@ class AsyncServingManager:
         max_num_seqs: int | None = None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
+        controller_storage_uri: str | None = None,
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
         node_selector: dict[str, str] | None = None,
@@ -695,6 +701,10 @@ class AsyncServingManager:
         extra_tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Async variant of :meth:`ServingManager.serve_llm`.
+
+        ``hf_overrides`` and ``controller_storage_uri`` carry through to
+        :meth:`deploy_llm` — see its docstring; they enable serving an
+        adapter (e.g. an ntkmirror controller) on an HF base.
 
         Catalog registration uses
         :meth:`ModelManager.async_register_llm_catalog_entry`, so the
@@ -798,6 +808,8 @@ class AsyncServingManager:
             max_num_seqs=max_num_seqs,
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
+            hf_overrides=hf_overrides,
+            controller_storage_uri=controller_storage_uri,
             resources=resources,
             tolerations=tolerations,
             node_selector=node_selector,

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -1087,10 +1087,13 @@ class ModelManager:
             "type": adapter_type,
             "description": description,
             "user_id": resolved_user,
-            # The self-FK to the base. The catalog service requires this
-            # for adapter rows (an adapter is meaningless without the
-            # base it modifies) and rejects the row otherwise.
-            "base_model_id": base_model_id,
+            # The self-FK to the base. Normalized to the canonical
+            # hyphenated UUID form (same as ``model_id`` above) so the FK
+            # lookup doesn't depend on whether the caller passed a compact
+            # or hyphenated id. The catalog service requires this for
+            # adapter rows (an adapter is meaningless without the base it
+            # modifies) and rejects the row otherwise.
+            "base_model_id": common.normalize_uuid(base_model_id),
         }
         if base_model_hf_id:
             # Carries the base's HuggingFace id onto the adapter row so

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -1121,8 +1121,7 @@ class ModelManager:
         """
         if adapter_type not in self.FINETUNED_ADAPTER_TYPES:
             raise ValueError(
-                f"adapter_type must be one of "
-                f"{sorted(self.FINETUNED_ADAPTER_TYPES)}; got {adapter_type!r}."
+                f"adapter_type must be one of {sorted(self.FINETUNED_ADAPTER_TYPES)}; got {adapter_type!r}."
             )
         if not base_model_id:
             raise ValueError(
@@ -1227,8 +1226,7 @@ class ModelManager:
             )
         except Exception as post_err:
             logger.warning(
-                "Failed to post %s adapter catalog entry to CogFlow backend "
-                "(caller proceeds regardless): %s",
+                "Failed to post %s adapter catalog entry to CogFlow backend (caller proceeds regardless): %s",
                 adapter_type,
                 str(post_err),
             )
@@ -1284,8 +1282,7 @@ class ModelManager:
             )
         except Exception as post_err:
             logger.warning(
-                "Failed to post %s adapter catalog entry to CogFlow backend "
-                "(caller proceeds regardless): %s",
+                "Failed to post %s adapter catalog entry to CogFlow backend (caller proceeds regardless): %s",
                 adapter_type,
                 str(post_err),
             )

--- a/cogflow/core/models.py
+++ b/cogflow/core/models.py
@@ -1044,6 +1044,254 @@ class ModelManager:
 
         return run_id
 
+    # Fine-tuned adapter rows (LoRA, NTK controller, …) all share one
+    # catalog shape: a child row in the model registry that points at
+    # the base it was trained against (``base_model_id``) and carries
+    # the base's HuggingFace id so the serving runtime can load the
+    # base. The accepted adapter ``type`` strings are kept here as the
+    # single source of truth so notebook callers and the platform's
+    # fine-tune pipeline agree on the vocabulary.
+    FINETUNED_ADAPTER_TYPES = frozenset({"lora", "ntk_controller"})
+
+    def _build_finetuned_catalog_payload(
+        self,
+        *,
+        run_id: str,
+        register_date_ms: int,
+        served_model_name: str,
+        adapter_type: str,
+        base_model_id: str,
+        base_model_hf_id: str | None,
+        description: str,
+        user_id: str | None,
+    ):
+        """Shape the catalog-service payload for a fine-tuned adapter.
+
+        Returns ``(url, model_dict, headers, resolved_user)`` so both
+        the sync and async registration methods reuse one body. The
+        catalog row's id is the tracking ``run_id`` that already holds
+        the adapter artifact — the same identity invariant every other
+        registration path respects — so the serving side can resolve
+        the artifact location straight from the row id.
+        """
+        resolved_user = user_id or common.get_current_user()
+        model_dict: dict[str, Any] = {
+            "model_id": common.normalize_uuid(run_id),
+            "model_name": served_model_name,
+            # The adapter artifact is logged to the run, not registered
+            # as a versioned registry entry, so there is no version
+            # number to report. 0 is the established "unknown version"
+            # sentinel (see the LLM-catalog and classical log paths).
+            "model_version": 0,
+            "register_date": datetime.fromtimestamp(register_date_ms / 1000).isoformat(),
+            "type": adapter_type,
+            "description": description,
+            "user_id": resolved_user,
+            # The self-FK to the base. The catalog service requires this
+            # for adapter rows (an adapter is meaningless without the
+            # base it modifies) and rejects the row otherwise.
+            "base_model_id": base_model_id,
+        }
+        if base_model_hf_id:
+            # Carries the base's HuggingFace id onto the adapter row so
+            # the serving runtime can pull the base weights without a
+            # second lookup. Older catalog schemas ignore unknown keys.
+            model_dict["hf_model_id"] = base_model_hf_id
+
+        url = f"{config.API_PATH}{config.LOG_MODEL}"
+        headers = {"kubeflow-userid": resolved_user}
+        return url, model_dict, headers, resolved_user
+
+    def _resolve_finetuned_catalog_run(
+        self,
+        *,
+        run_id: str,
+        adapter_type: str,
+        base_model_id: str,
+        register_date_ms: int | None,
+    ):
+        """Validate inputs + resolve the row's register date.
+
+        Shared front half of the sync/async fine-tuned registration
+        methods. ``adapter_type`` is checked against
+        :data:`FINETUNED_ADAPTER_TYPES` and ``base_model_id`` is
+        required up-front so a bad call fails before the catalog POST.
+        When ``register_date_ms`` is not supplied it is read from the
+        tracking run that holds the artifact.
+        """
+        if adapter_type not in self.FINETUNED_ADAPTER_TYPES:
+            raise ValueError(
+                f"adapter_type must be one of "
+                f"{sorted(self.FINETUNED_ADAPTER_TYPES)}; got {adapter_type!r}."
+            )
+        if not base_model_id:
+            raise ValueError(
+                "base_model_id is required for a fine-tuned adapter — the "
+                "row points at the base it was trained against."
+            )
+        if register_date_ms is None:
+            # The run already exists (the caller logged the adapter
+            # artifact into it); read its start time so the catalog
+            # row's register_date matches the run that produced it.
+            register_date_ms = self.client.get_run(run_id).info.start_time
+        return register_date_ms
+
+    def register_finetuned_catalog_entry(
+        self,
+        *,
+        run_id: str,
+        served_model_name: str,
+        adapter_type: str,
+        base_model_id: str,
+        base_model_hf_id: str | None = None,
+        register_date_ms: int | None = None,
+        description: str | None = None,
+        user_id: str | None = None,
+    ) -> str:
+        """Register a fine-tuned adapter (LoRA, NTK controller, …) in the catalog.
+
+        Use this after logging the adapter artifact to a tracking run:
+        the run's id becomes the catalog row's id, and this call adds
+        the catalog metadata that links the adapter to its base
+        (``base_model_id`` + the base's HuggingFace id). It is the
+        shared registration entry-point for every fine-tuned export
+        format, so notebook users and the platform fine-tune pipeline
+        produce identical rows.
+
+        Steps:
+
+        - Validate ``adapter_type`` and ``base_model_id``.
+        - Resolve the row's register date from the run (unless given).
+        - Best-effort POST to the catalog service: failures are logged
+          as warnings and do **not** raise, matching the LLM-catalog
+          and classical log paths — a transient backend outage should
+          not abort a pipeline that otherwise succeeded.
+
+        For callers already inside an async coroutine, prefer
+        :meth:`async_register_finetuned_catalog_entry` — the backend
+        POST here is synchronous and would deadlock the event loop if
+        the target URL resolves back to the same process.
+
+        Args:
+            run_id: Tracking run that holds the adapter artifact. Also
+                becomes the catalog row's primary key.
+            served_model_name: Logical name for the catalog row.
+            adapter_type: One of :data:`FINETUNED_ADAPTER_TYPES`
+                (``"lora"`` or ``"ntk_controller"``).
+            base_model_id: Catalog id of the base the adapter was
+                trained against. Required.
+            base_model_hf_id: HuggingFace Hub id of the base, so the
+                serving runtime can load the base weights. Optional for
+                checkpoint-backed bases.
+            register_date_ms: Override for the row's register date in
+                epoch milliseconds. Defaults to the run's start time.
+            description: Human-readable description; a sensible default
+                is generated from the adapter type and base when omitted.
+            user_id: Override for the row owner. Falls back to
+                :func:`common.get_current_user`.
+
+        Returns:
+            The ``run_id`` — which is also the catalog row's id.
+
+        Raises:
+            ValueError: If ``adapter_type`` is unknown or
+                ``base_model_id`` is empty. Backend POST failures are
+                *not* raised (warn-only).
+        """
+        register_date_ms = self._resolve_finetuned_catalog_run(
+            run_id=run_id,
+            adapter_type=adapter_type,
+            base_model_id=base_model_id,
+            register_date_ms=register_date_ms,
+        )
+        description = description or f"{adapter_type} adapter fine-tuned from base {base_model_id}"
+
+        url, model_dict, headers, _ = self._build_finetuned_catalog_payload(
+            run_id=run_id,
+            register_date_ms=register_date_ms,
+            served_model_name=served_model_name,
+            adapter_type=adapter_type,
+            base_model_id=base_model_id,
+            base_model_hf_id=base_model_hf_id,
+            description=description,
+            user_id=user_id,
+        )
+
+        try:
+            network.make_post_request(url=url, data=model_dict, headers=headers)
+            logger.info(
+                "Registered %s adapter catalog entry via CogFlow backend: %s (run_id=%s)",
+                adapter_type,
+                url,
+                run_id,
+            )
+        except Exception as post_err:
+            logger.warning(
+                "Failed to post %s adapter catalog entry to CogFlow backend "
+                "(caller proceeds regardless): %s",
+                adapter_type,
+                str(post_err),
+            )
+
+        return run_id
+
+    async def async_register_finetuned_catalog_entry(
+        self,
+        *,
+        run_id: str,
+        served_model_name: str,
+        adapter_type: str,
+        base_model_id: str,
+        base_model_hf_id: str | None = None,
+        register_date_ms: int | None = None,
+        description: str | None = None,
+        user_id: str | None = None,
+    ) -> str:
+        """Async variant of :meth:`register_finetuned_catalog_entry`.
+
+        Identical semantics; the backend POST uses an async HTTP client
+        so the event loop stays free during the call (which is what
+        lets a self-call from the service that also hosts the catalog
+        endpoint terminate instead of deadlocking). Return value and
+        exception semantics match the sync variant.
+        """
+        register_date_ms = self._resolve_finetuned_catalog_run(
+            run_id=run_id,
+            adapter_type=adapter_type,
+            base_model_id=base_model_id,
+            register_date_ms=register_date_ms,
+        )
+        description = description or f"{adapter_type} adapter fine-tuned from base {base_model_id}"
+
+        url, model_dict, headers, _ = self._build_finetuned_catalog_payload(
+            run_id=run_id,
+            register_date_ms=register_date_ms,
+            served_model_name=served_model_name,
+            adapter_type=adapter_type,
+            base_model_id=base_model_id,
+            base_model_hf_id=base_model_hf_id,
+            description=description,
+            user_id=user_id,
+        )
+
+        try:
+            await network.make_async_post_request(url=url, data=model_dict, headers=headers)
+            logger.info(
+                "Registered %s adapter catalog entry via CogFlow backend: %s (run_id=%s)",
+                adapter_type,
+                url,
+                run_id,
+            )
+        except Exception as post_err:
+            logger.warning(
+                "Failed to post %s adapter catalog entry to CogFlow backend "
+                "(caller proceeds regardless): %s",
+                adapter_type,
+                str(post_err),
+            )
+
+        return run_id
+
     def search_model_versions(self, filter_string: str | None = None):
         """
         Search for model versions in the MLflow Model Registry.

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -844,6 +844,20 @@ class ServingManager:
         # SDK users) still get the same validation.
         hf_id = ServingManager._extract_hf_model_id(storage_uri)
         is_hf_source = hf_id is not None
+
+        # A predictor has exactly one ``storageUri`` — one storage-initializer
+        # download into ``/mnt/models``. The HF-base hybrid only works because
+        # the base loads from the Hub via ``--model_id`` (the HF runtime's
+        # ``get_model_id_or_path`` prefers it), leaving that single slot free
+        # to stage the controller. With a non-HF base the base already claims
+        # the slot, so a ``controller_storage_uri`` would be silently dropped.
+        # Fail fast instead.
+        if controller_storage_uri and not is_hf_source:
+            raise CogflowValidationError(
+                "controller_storage_uri is only supported with an hf:// base "
+                f"(the base loads via --model_id, freeing the single storageUri "
+                f"slot for the controller); got base storage_uri={storage_uri!r}."
+            )
         runtime_args = ServingManager._build_llm_args(
             served_model_name,
             max_model_len=max_model_len,
@@ -1107,6 +1121,8 @@ class ServingManager:
         max_num_seqs: int | None = None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
+        controller_storage_uri: str | None = None,
         # scheduling / scaling
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
@@ -1122,6 +1138,10 @@ class ServingManager:
     ) -> dict[str, Any]:
         """High-level LLM serving: MLflow-backed catalog registration
         **plus** KServe InferenceService create, in one call.
+
+        ``hf_overrides`` and ``controller_storage_uri`` carry through to
+        :meth:`deploy_llm` — see its docstring; they enable serving a
+        native adapter (e.g. an ntkmirror controller) on an HF base.
 
         This is the entry point notebook users should reach for — analogous
         to ``cogflow.log_model`` for classical artifacts. It:
@@ -1256,6 +1276,8 @@ class ServingManager:
             max_num_seqs=max_num_seqs,
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
+            hf_overrides=hf_overrides,
+            controller_storage_uri=controller_storage_uri,
             resources=resources,
             tolerations=tolerations,
             node_selector=node_selector,

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -973,6 +973,32 @@ class ServingManager:
             predictor = {**predictor, "deploymentStrategy": {"type": "Recreate"}}
         return predictor, effective_annotations
 
+    @staticmethod
+    def _assert_controller_compatible_mode(
+        controller_storage_uri: str | None,
+        effective_annotations: dict[str, str],
+    ) -> None:
+        """Reject the controller hybrid in non-RawDeployment mode.
+
+        The hybrid stages the controller via ``model.storageUri``, whose
+        storage-initializer injects ``POD_NAME``/``POD_NAMESPACE`` env via
+        ``fieldRef`` — shapes the Knative admission webhook rejects in
+        Serverless mode. The LLM default is RawDeployment, but a caller
+        can override via the ``deploymentMode`` annotation, so fail fast
+        with a clear error here instead of leaking a late, opaque Knative
+        admission rejection.
+        """
+        if not controller_storage_uri:
+            return
+        mode = effective_annotations.get(ServingManager._DEPLOYMENT_MODE_ANNOTATION)
+        if mode != "RawDeployment":
+            raise CogflowValidationError(
+                "controller_storage_uri requires RawDeployment mode — the "
+                "controller is staged via storageUri, whose fieldRef env "
+                "the Knative webhook rejects in Serverless mode; got "
+                f"deploymentMode={mode!r}."
+            )
+
     def deploy_llm(
         self,
         *,
@@ -1071,6 +1097,7 @@ class ServingManager:
         predictor_spec, effective_annotations = ServingManager._apply_raw_deployment_defaults(
             predictor_spec, annotations
         )
+        ServingManager._assert_controller_compatible_mode(controller_storage_uri, effective_annotations)
 
         try:
             metadata = client.V1ObjectMeta(

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -900,8 +900,7 @@ class ServingManager:
         # side controller artifact (``controller_storage_uri``) is also
         # S3-staged, so an HF base + S3 controller still needs the SA.
         if storage_uri.startswith("s3://") or (
-            controller_storage_uri is not None
-            and controller_storage_uri.startswith("s3://")
+            controller_storage_uri is not None and controller_storage_uri.startswith("s3://")
         ):
             predictor["serviceAccountName"] = "kserve-controller-s3"
 

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -780,8 +780,19 @@ class ServingManager:
         # subclass (e.g. an adapter-aware ``NTK<Arch>ForCausalLM``)
         # without re-uploading the base weights. ``sort_keys`` keeps the
         # emitted JSON byte-stable so reruns produce a diff-clean ISVC.
+        # vLLM requires a JSON *object*, so reject non-dicts and
+        # non-serializable values up-front with a clear error rather than
+        # emitting a bad flag or leaking a raw TypeError.
         if hf_overrides:
-            args.append(f"--hf-overrides={json.dumps(hf_overrides, sort_keys=True)}")
+            if not isinstance(hf_overrides, dict):
+                raise CogflowValidationError(
+                    f"hf_overrides must be a JSON object (dict), got {type(hf_overrides).__name__}"
+                )
+            try:
+                rendered = json.dumps(hf_overrides, sort_keys=True)
+            except (TypeError, ValueError) as exc:
+                raise CogflowValidationError(f"hf_overrides must be JSON-serializable: {exc}") from exc
+            args.append(f"--hf-overrides={rendered}")
         return args
 
     @staticmethod

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -782,17 +782,22 @@ class ServingManager:
         # emitted JSON byte-stable so reruns produce a diff-clean ISVC.
         # vLLM requires a JSON *object*, so reject non-dicts and
         # non-serializable values up-front with a clear error rather than
-        # emitting a bad flag or leaking a raw TypeError.
-        if hf_overrides:
+        # emitting a bad flag or leaking a raw TypeError. ``is not None``
+        # (not truthiness) so a supplied-but-falsey value (``[]``, ``""``,
+        # ``0``) still gets type-checked instead of being silently ignored.
+        if hf_overrides is not None:
             if not isinstance(hf_overrides, dict):
                 raise CogflowValidationError(
                     f"hf_overrides must be a JSON object (dict), got {type(hf_overrides).__name__}"
                 )
-            try:
-                rendered = json.dumps(hf_overrides, sort_keys=True)
-            except (TypeError, ValueError) as exc:
-                raise CogflowValidationError(f"hf_overrides must be JSON-serializable: {exc}") from exc
-            args.append(f"--hf-overrides={rendered}")
+            # An empty object is a valid "no overrides" value — accept it
+            # but don't emit a pointless ``--hf-overrides={}`` flag.
+            if hf_overrides:
+                try:
+                    rendered = json.dumps(hf_overrides, sort_keys=True)
+                except (TypeError, ValueError) as exc:
+                    raise CogflowValidationError(f"hf_overrides must be JSON-serializable: {exc}") from exc
+                args.append(f"--hf-overrides={rendered}")
         return args
 
     @staticmethod

--- a/cogflow/core/serving.py
+++ b/cogflow/core/serving.py
@@ -14,6 +14,7 @@ No circular imports occur because we load them lazily.
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from datetime import datetime
@@ -722,6 +723,7 @@ class ServingManager:
         max_num_seqs: int | None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
     ) -> list[str]:
         """Whitelisted runtime args passed into the HF runtime container.
 
@@ -772,6 +774,14 @@ class ServingManager:
         normalized_kv_cache_dtype = kv_cache_dtype.strip() if kv_cache_dtype is not None else None
         if not _is_unset_sentinel(normalized_kv_cache_dtype):
             args.append(f"--kv-cache-dtype={normalized_kv_cache_dtype}")
+        # ``--hf-overrides`` is a vLLM hyphen-style flag taking a JSON
+        # object that patches the loaded model's HF config. The platform
+        # uses it to redirect the architecture to a runtime-registered
+        # subclass (e.g. an adapter-aware ``NTK<Arch>ForCausalLM``)
+        # without re-uploading the base weights. ``sort_keys`` keeps the
+        # emitted JSON byte-stable so reruns produce a diff-clean ISVC.
+        if hf_overrides:
+            args.append(f"--hf-overrides={json.dumps(hf_overrides, sort_keys=True)}")
         return args
 
     @staticmethod
@@ -793,6 +803,8 @@ class ServingManager:
         hf_secret_name: str | None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
+        controller_storage_uri: str | None = None,
     ) -> dict[str, Any]:
         # Replica bounds must be internally consistent before we hand the
         # ISVC to KServe — otherwise the CRD is rejected at admission (or
@@ -842,6 +854,7 @@ class ServingManager:
             max_num_seqs=max_num_seqs,
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
+            hf_overrides=hf_overrides,
         )
         if is_hf_source:
             # --model_id comes first for readability in the emitted YAML
@@ -854,6 +867,19 @@ class ServingManager:
         }
         if not is_hf_source:
             model_block["storageUri"] = storage_uri
+        elif controller_storage_uri:
+            # Adapter-on-HF-base hybrid: the base weights load from the
+            # HF Hub via ``--model_id`` (above), while a small side
+            # artifact — e.g. an ntkmirror controller — is staged by
+            # KServe's storage-initializer to the predictor's model
+            # mount (``/mnt/models``). The runtime ignores the mount for
+            # the base (``--model_id`` wins in the HF server's
+            # ``get_model_id_or_path``), and the adapter-aware model
+            # subclass reads its artifact from there. Only valid in
+            # RawDeployment mode (the LLM default) — the storage-
+            # initializer's fieldRef env is rejected by the Knative
+            # webhook in Serverless mode.
+            model_block["storageUri"] = controller_storage_uri
 
         if hf_secret_name:
             model_block["env"] = [
@@ -869,9 +895,14 @@ class ServingManager:
             "model": model_block,
         }
 
-        # S3-backed artifacts need the cluster-provisioned S3 SA.
-        # HF Hub pulls do not — omitting the SA keeps the pod token-free.
-        if storage_uri.startswith("s3://"):
+        # S3-backed artifacts need the cluster-provisioned S3 SA. HF Hub
+        # pulls do not — omitting the SA keeps the pod token-free. The
+        # side controller artifact (``controller_storage_uri``) is also
+        # S3-staged, so an HF base + S3 controller still needs the SA.
+        if storage_uri.startswith("s3://") or (
+            controller_storage_uri is not None
+            and controller_storage_uri.startswith("s3://")
+        ):
             predictor["serviceAccountName"] = "kserve-controller-s3"
 
         if tolerations:
@@ -929,6 +960,8 @@ class ServingManager:
         max_num_seqs: int | None = None,
         quantization: str | None = None,
         kv_cache_dtype: str | None = None,
+        hf_overrides: dict[str, Any] | None = None,
+        controller_storage_uri: str | None = None,
         # scheduling / scaling
         resources: dict[str, dict[str, str]] | None = None,
         tolerations: list[dict[str, Any]] | None = None,
@@ -941,6 +974,13 @@ class ServingManager:
     ) -> dict:
         """Create a KServe InferenceService backed by the built-in
         ``huggingface`` ClusterServingRuntime (KServe 0.15+).
+
+        ``hf_overrides`` patches the loaded model's HF config (emitted as
+        the vLLM ``--hf-overrides`` flag) — used to redirect the
+        architecture to a runtime-registered adapter-aware subclass.
+        ``controller_storage_uri``, when set alongside an ``hf://`` base,
+        stages a side artifact (e.g. an ntkmirror controller) to the
+        predictor's model mount while the base still loads from the Hub.
 
         The ``storage_uri`` is used verbatim — pass ``hf://<org>/<model>``
         for a direct HF Hub pull or ``s3://mlflow/...`` for an MLflow-stored
@@ -996,6 +1036,8 @@ class ServingManager:
             hf_secret_name=hf_secret_name,
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
+            hf_overrides=hf_overrides,
+            controller_storage_uri=controller_storage_uri,
         )
         predictor_spec, effective_annotations = ServingManager._apply_raw_deployment_defaults(
             predictor_spec, annotations

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -341,12 +341,8 @@ async def test_async_register_finetuned_catalog_entry_posts_adapter_row(monkeypa
     run_id = "abcdef000000abcdef000000abcdef00"
     base_id = "22222222222222222222222222222222"
     post_mock = AsyncMock()
-    monkeypatch.setattr(
-        core_models_module.network, "make_async_post_request", post_mock, raising=True
-    )
-    monkeypatch.setattr(
-        core_models_module.common, "get_current_user", lambda: "u@example.com", raising=True
-    )
+    monkeypatch.setattr(core_models_module.network, "make_async_post_request", post_mock, raising=True)
+    monkeypatch.setattr(core_models_module.common, "get_current_user", lambda: "u@example.com", raising=True)
 
     returned = await core_models_module.async_register_finetuned_catalog_entry(
         run_id=run_id,

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -358,5 +358,5 @@ async def test_async_register_finetuned_catalog_entry_posts_adapter_row(monkeypa
     payload = post_mock.call_args.kwargs["data"]
     assert payload["model_id"] == common.normalize_uuid(run_id)
     assert payload["type"] == "lora"
-    assert payload["base_model_id"] == base_id
+    assert payload["base_model_id"] == common.normalize_uuid(base_id)
     assert payload["hf_model_id"] == "Qwen/Qwen2.5-0.5B-Instruct"

--- a/tests/test_async_serving.py
+++ b/tests/test_async_serving.py
@@ -328,3 +328,39 @@ async def test_async_serve_llm_registers_and_deploys(async_serving, fake_async_a
     assert annotations["model_id"] == common.normalize_uuid(fake_run_id)
     assert annotations["model_type"] == "llm"
     assert annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+
+
+@pytest.mark.asyncio
+async def test_async_register_finetuned_catalog_entry_posts_adapter_row(monkeypatch):
+    """async_register_finetuned_catalog_entry POSTs the adapter row via
+    the async HTTP client (the sync POST would deadlock when caller and
+    /models/log share a worker). Shares the validation + payload shape
+    with the sync variant."""
+    import cogflow.core.models as core_models_module
+
+    run_id = "abcdef000000abcdef000000abcdef00"
+    base_id = "22222222222222222222222222222222"
+    post_mock = AsyncMock()
+    monkeypatch.setattr(
+        core_models_module.network, "make_async_post_request", post_mock, raising=True
+    )
+    monkeypatch.setattr(
+        core_models_module.common, "get_current_user", lambda: "u@example.com", raising=True
+    )
+
+    returned = await core_models_module.async_register_finetuned_catalog_entry(
+        run_id=run_id,
+        served_model_name="my-lora",
+        adapter_type="lora",
+        base_model_id=base_id,
+        base_model_hf_id="Qwen/Qwen2.5-0.5B-Instruct",
+        register_date_ms=1_700_000_000_000,
+    )
+
+    assert returned == run_id
+    post_mock.assert_awaited_once()
+    payload = post_mock.call_args.kwargs["data"]
+    assert payload["model_id"] == common.normalize_uuid(run_id)
+    assert payload["type"] == "lora"
+    assert payload["base_model_id"] == base_id
+    assert payload["hf_model_id"] == "Qwen/Qwen2.5-0.5B-Instruct"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -605,6 +605,23 @@ def test_deploy_llm_rejects_non_object_hf_overrides(serving, serving_module):
         )
 
 
+def test_deploy_llm_controller_uri_rejects_serverless_mode(serving, serving_module):
+    """The controller hybrid stages via storageUri, whose fieldRef env
+    Knative rejects in Serverless mode. A caller-forced Serverless
+    deploymentMode must fail fast rather than reconcile-fail later."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="RawDeployment"):
+        serving.deploy_llm(
+            storage_uri="hf://Qwen/Qwen2.5-0.5B-Instruct",
+            isvc_name="ntk-serverless",
+            served_model_name="ntk-serverless",
+            hf_overrides={"architectures": ["NTKQwen2ForCausalLM"]},
+            controller_storage_uri="s3://mlflow/0/abc/artifacts/controller/controller.pt",
+            annotations={"serving.kserve.io/deploymentMode": "Serverless"},
+        )
+
+
 def test_deploy_llm_controller_uri_rejects_non_hf_base(serving, serving_module):
     """controller_storage_uri needs an hf:// base — with an s3 base the
     base already claims the single storageUri slot, so fail fast rather

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -591,6 +591,21 @@ def test_deploy_llm_hf_base_with_controller_storage_uri(serving, serving_module)
     assert '--hf-overrides={"architectures": ["NTKQwen2ForCausalLM"]}' in model["args"]
 
 
+def test_deploy_llm_controller_uri_rejects_non_hf_base(serving, serving_module):
+    """controller_storage_uri needs an hf:// base — with an s3 base the
+    base already claims the single storageUri slot, so fail fast rather
+    than silently dropping the controller."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="controller_storage_uri"):
+        serving.deploy_llm(
+            storage_uri="s3://mlflow/0/abc/artifacts/model",
+            isvc_name="bad-hybrid",
+            served_model_name="bad-hybrid",
+            controller_storage_uri="s3://mlflow/0/abc/artifacts/controller/controller.pt",
+        )
+
+
 def test_deploy_llm_default_resources(serving, serving_module):
     """No resources override → defaults: 4/7Gi/1gpu requests, 8/8Gi/1gpu limits."""
     _, fake_api, _ = serving_module
@@ -1039,6 +1054,27 @@ def test_serve_llm_end_to_end_happy_path(serving, serving_module, monkeypatch):
     assert meta_annotations["model_id"] == common.normalize_uuid(fake_run_id)
     assert meta_annotations["model_type"] == "llm"
     assert meta_annotations["hf_model_id"] == "Qwen/Qwen2.5-Coder-7B-Instruct"
+
+
+def test_serve_llm_threads_hf_overrides_and_controller(serving, serving_module, monkeypatch):
+    """The high-level sync serve_llm forwards hf_overrides +
+    controller_storage_uri down to the emitted ISVC (the HF-base + native
+    adapter hybrid is reachable from the notebook entry point, not just
+    the lower-level deploy_llm / async path)."""
+    fake_run_id = "abcdef01234567890123456789abcde0"
+    _patch_llm_catalog(monkeypatch, run_id=fake_run_id)
+    _, fake_api, _ = serving_module
+
+    serving.serve_llm(
+        hf_model_id="Qwen/Qwen2.5-0.5B-Instruct",
+        hf_overrides={"architectures": ["NTKQwen2ForCausalLM"]},
+        controller_storage_uri="s3://mlflow/0/abc/artifacts/controller/controller.pt",
+    )
+
+    model = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]
+    assert "--model_id=Qwen/Qwen2.5-0.5B-Instruct" in model["args"]
+    assert '--hf-overrides={"architectures": ["NTKQwen2ForCausalLM"]}' in model["args"]
+    assert model["storageUri"] == "s3://mlflow/0/abc/artifacts/controller/controller.pt"
 
 
 def test_serve_llm_storage_uri_hf_shorthand_populates_hf_model_id(serving, serving_module, monkeypatch):

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -591,6 +591,20 @@ def test_deploy_llm_hf_base_with_controller_storage_uri(serving, serving_module)
     assert '--hf-overrides={"architectures": ["NTKQwen2ForCausalLM"]}' in model["args"]
 
 
+def test_deploy_llm_rejects_non_object_hf_overrides(serving, serving_module):
+    """hf_overrides must be a JSON object — a non-dict fails fast with a
+    clear CogflowValidationError, not a bad flag or a raw TypeError."""
+    from cogflow.utils.exceptions import CogflowValidationError
+
+    with pytest.raises(CogflowValidationError, match="hf_overrides must be a JSON object"):
+        serving.deploy_llm(
+            storage_uri="hf://Qwen/Qwen2.5-0.5B-Instruct",
+            isvc_name="bad-overrides",
+            served_model_name="bad-overrides",
+            hf_overrides=["NTKQwen2ForCausalLM"],  # list, not an object
+        )
+
+
 def test_deploy_llm_controller_uri_rejects_non_hf_base(serving, serving_module):
     """controller_storage_uri needs an hf:// base — with an s3 base the
     base already claims the single storageUri slot, so fail fast rather
@@ -1494,7 +1508,7 @@ def test_register_finetuned_catalog_entry_posts_adapter_row(serving_module, monk
     assert payload["model_id"] == common.normalize_uuid(run_id)
     assert payload["type"] == "ntk_controller"
     assert payload["model_name"] == "my-ntk-controller"
-    assert payload["base_model_id"] == base_id
+    assert payload["base_model_id"] == common.normalize_uuid(base_id)
     assert payload["hf_model_id"] == "Qwen/Qwen2.5-0.5B-Instruct"
     assert payload["user_id"] == "user@example.com"
     assert payload["register_date"]  # populated from register_date_ms

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -550,6 +550,47 @@ def test_deploy_llm_s3_uri_sets_service_account(serving, serving_module):
     assert not any(a.startswith("--model_id=") for a in model["args"])
 
 
+def test_deploy_llm_hf_overrides_emits_flag(serving, serving_module):
+    """``hf_overrides`` is emitted as a single JSON --hf-overrides arg
+    (sorted keys, diff-stable)."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-0.5B-Instruct",
+        isvc_name="q",
+        served_model_name="q",
+        hf_overrides={"architectures": ["NTKQwen2ForCausalLM"]},
+    )
+
+    args = _deploy_llm_create_call(fake_api)["spec"]["predictor"]["model"]["args"]
+    assert '--hf-overrides={"architectures": ["NTKQwen2ForCausalLM"]}' in args
+
+
+def test_deploy_llm_hf_base_with_controller_storage_uri(serving, serving_module):
+    """Adapter-on-HF-base hybrid: base via --model_id (HF), controller via
+    storageUri (S3-staged to /mnt/models), S3 SA present."""
+    _, fake_api, _ = serving_module
+
+    serving.deploy_llm(
+        storage_uri="hf://Qwen/Qwen2.5-0.5B-Instruct",
+        isvc_name="ntk-q",
+        served_model_name="ntk-q",
+        hf_overrides={"architectures": ["NTKQwen2ForCausalLM"]},
+        controller_storage_uri="s3://mlflow/0/abc/artifacts/controller/controller.pt",
+    )
+
+    body = _deploy_llm_create_call(fake_api)
+    predictor = body["spec"]["predictor"]
+    model = predictor["model"]
+    # Base still loads from the Hub via --model_id …
+    assert "--model_id=Qwen/Qwen2.5-0.5B-Instruct" in model["args"]
+    # … while the controller is staged via storageUri to /mnt/models.
+    assert model["storageUri"] == "s3://mlflow/0/abc/artifacts/controller/controller.pt"
+    # S3-staged controller needs the cluster S3 SA even on an HF base.
+    assert predictor["serviceAccountName"] == "kserve-controller-s3"
+    assert '--hf-overrides={"architectures": ["NTKQwen2ForCausalLM"]}' in model["args"]
+
+
 def test_deploy_llm_default_resources(serving, serving_module):
     """No resources override → defaults: 4/7Gi/1gpu requests, 8/8Gi/1gpu limits."""
     _, fake_api, _ = serving_module
@@ -1378,6 +1419,148 @@ def test_register_llm_catalog_entry_swallows_post_failure(serving_module, monkey
     )
 
     assert run_id == fake_run_id
+
+
+def test_register_finetuned_catalog_entry_posts_adapter_row(serving_module, monkeypatch):
+    """Exercises ``ModelManager.register_finetuned_catalog_entry``: POSTs
+    an adapter row to {API_PATH}/models/log with the run_id as model_id,
+    the adapter type, the base self-FK, and the base's HuggingFace id.
+    ``register_date_ms`` is passed explicitly so no run lookup happens."""
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module
+    import cogflow.core.models as core_models_module
+
+    run_id = "cafebabecafebabecafebabecafebabe"
+    base_id = "11111111111111111111111111111111"
+    post_mock = MagicMock()
+    monkeypatch.setattr(core_models_module.network, "make_post_request", post_mock, raising=True)
+    monkeypatch.setattr(
+        core_models_module.common,
+        "get_current_user",
+        lambda: "user@example.com",
+        raising=True,
+    )
+
+    returned = cogflow_models_module.register_finetuned_catalog_entry(
+        run_id=run_id,
+        served_model_name="my-ntk-controller",
+        adapter_type="ntk_controller",
+        base_model_id=base_id,
+        base_model_hf_id="Qwen/Qwen2.5-0.5B-Instruct",
+        register_date_ms=1_700_000_000_000,
+    )
+
+    assert returned == run_id
+    post_mock.assert_called_once()
+    post_kwargs = post_mock.call_args.kwargs
+    payload = post_kwargs["data"]
+    assert payload["model_id"] == common.normalize_uuid(run_id)
+    assert payload["type"] == "ntk_controller"
+    assert payload["model_name"] == "my-ntk-controller"
+    assert payload["base_model_id"] == base_id
+    assert payload["hf_model_id"] == "Qwen/Qwen2.5-0.5B-Instruct"
+    assert payload["user_id"] == "user@example.com"
+    assert payload["register_date"]  # populated from register_date_ms
+    assert post_kwargs["headers"]["kubeflow-userid"] == "user@example.com"
+
+
+def test_register_finetuned_catalog_entry_rejects_unknown_type(serving_module):
+    """An unrecognised adapter type fails before any catalog POST."""
+    import cogflow.core.models as cogflow_models_module
+
+    with pytest.raises(ValueError, match="adapter_type"):
+        cogflow_models_module.register_finetuned_catalog_entry(
+            run_id="a" * 32,
+            served_model_name="x",
+            adapter_type="bogus",
+            base_model_id="b" * 32,
+            register_date_ms=1,
+        )
+
+
+def test_register_finetuned_catalog_entry_requires_base_model_id(serving_module):
+    """An adapter with no base self-FK is rejected up-front (a fine-tuned
+    adapter is meaningless without the base it modifies)."""
+    import cogflow.core.models as cogflow_models_module
+
+    with pytest.raises(ValueError, match="base_model_id"):
+        cogflow_models_module.register_finetuned_catalog_entry(
+            run_id="a" * 32,
+            served_model_name="x",
+            adapter_type="lora",
+            base_model_id="",
+            register_date_ms=1,
+        )
+
+
+def test_register_finetuned_catalog_entry_reads_run_start_time(serving_module, monkeypatch):
+    """When ``register_date_ms`` is omitted, the row's register date is
+    read from the tracking run that holds the artifact."""
+    from unittest.mock import MagicMock
+
+    import cogflow.core.models as cogflow_models_module
+    import cogflow.core.models as core_models_module
+
+    run_id = "0123456789abcdef0123456789abcdef"
+    fake_run = MagicMock()
+    fake_run.info.start_time = 1_700_000_000_000
+    get_run_mock = MagicMock(return_value=fake_run)
+    post_mock = MagicMock()
+    monkeypatch.setattr(
+        core_models_module._models,
+        "client",
+        MagicMock(get_run=get_run_mock),
+        raising=False,
+    )
+    monkeypatch.setattr(core_models_module.network, "make_post_request", post_mock, raising=True)
+    monkeypatch.setattr(
+        core_models_module.common,
+        "get_current_user",
+        lambda: "u@example.com",
+        raising=True,
+    )
+
+    cogflow_models_module.register_finetuned_catalog_entry(
+        run_id=run_id,
+        served_model_name="x",
+        adapter_type="lora",
+        base_model_id="b" * 32,
+    )
+
+    get_run_mock.assert_called_once_with(run_id)
+    assert post_mock.call_args.kwargs["data"]["register_date"]
+
+
+def test_register_finetuned_catalog_entry_swallows_post_failure(serving_module, monkeypatch):
+    """A catalog-backend POST failure must NOT abort registration —
+    matches the LLM-catalog / log_model pattern. Returns the run_id
+    regardless."""
+    import cogflow.core.models as cogflow_models_module
+    import cogflow.core.models as core_models_module
+
+    run_id = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+    def failing_post(**_kwargs):
+        raise RuntimeError("cogapi unreachable")
+
+    monkeypatch.setattr(core_models_module.network, "make_post_request", failing_post, raising=True)
+    monkeypatch.setattr(
+        core_models_module.common,
+        "get_current_user",
+        lambda: "user@example.com",
+        raising=True,
+    )
+
+    returned = cogflow_models_module.register_finetuned_catalog_entry(
+        run_id=run_id,
+        served_model_name="x",
+        adapter_type="lora",
+        base_model_id="b" * 32,
+        register_date_ms=1,
+    )
+
+    assert returned == run_id
 
 
 def test_serving_module_reexports_async_deploy_llm():


### PR DESCRIPTION
## What

Two coordinated cogflow additions that let the platform serve ntkmirror-tuned LLMs natively (no LoRA conversion), reused by notebook callers too.

### `register_finetuned_catalog_entry` (+ async)
One catalog handshake for **any** fine-tuned adapter row (`lora` or `ntk_controller`). POSTs `/models/log` with the adapter `type`, the `base_model_id` self-FK, and the base's HuggingFace id. The catalog row's id is the tracking run id that already holds the artifact. Warn-only on POST failure (matches the LLM-catalog / `log_model` paths). `FINETUNED_ADAPTER_TYPES` is the single source of truth for the accepted vocabulary.

### Serving hybrid (`serve_llm` / `async_serve_llm` / `_build_llm_predictor`)
- `_build_llm_args` emits `--hf-overrides` (JSON, sorted keys) so the architecture can be redirected to a runtime-registered subclass (e.g. `NTKQwen2ForCausalLM`).
- New `hf_overrides` + `controller_storage_uri` params: HF base loaded via `--model_id` **plus** a side artifact (the controller) staged via `storageUri` to the predictor's `/mnt/models`. The KServe runtime's `get_model_id_or_path` lets `--model_id` win for the base while the storage-initializer stages the controller. S3 service account attached when the controller is S3-backed even on an HF base.

## Why
Consumed by Cog-Engine's `ntk_model` fine-tune + serving wiring (separate PR). Single helper so notebook and platform fine-tunes produce identical catalog rows.

## Tests
Sync + async catalog-entry coverage; `--hf-overrides` emission; HF-base-plus-controller hybrid spec. Full serving/models/async suites green, ruff clean.

## Follow-up (not in this PR)
Release as the next `release/v3.0.0bN` (PyPI + `cogflow:latest-beta`) so the Cog-Engine ISVC builder + kfp component pick it up.