### PR TITLE
Cog 402 fed pipeline fix

### DIFF
--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -10,7 +10,7 @@ import sys
 
 from ._lazy import _LazyLoader
 
-__version__ = "2.0.1b10"
+__version__ = "3.0.0b8"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -399,6 +399,7 @@ def delete_service(name: str):
 def _create_service_component(name: str) -> str:
     from kubernetes import client as k8s_client
     from kubernetes import config as k8s_config
+
     try:
         k8s_config.load_incluster_config()
     except Exception:  # pylint: disable=broad-except
@@ -433,6 +434,7 @@ def _create_service_component(name: str) -> str:
 def _delete_service_component(name: str) -> str:
     from kubernetes import client as k8s_client
     from kubernetes import config as k8s_config
+
     try:
         k8s_config.load_incluster_config()
     except Exception:  # pylint: disable=broad-except

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -437,7 +437,7 @@ def _delete_service_component(name: str) -> str:
 
     try:
         k8s_config.load_incluster_config()
-    except Exception:  # pylint: disable=broad-except
+    except k8s_config.config_exception.ConfigException:
         k8s_config.load_kube_config()
     try:
         with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -397,13 +397,62 @@ def delete_service(name: str):
 
 
 def _create_service_component(name: str) -> str:
-    create_service(name)
+    from kubernetes import client as k8s_client
+    from kubernetes import config as k8s_config
+    try:
+        k8s_config.load_incluster_config()
+    except Exception:  # pylint: disable=broad-except
+        k8s_config.load_kube_config()
+    try:
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:
+            namespace = f.read().strip()
+    except FileNotFoundError:
+        namespace = "default"
+    svc = k8s_client.V1Service(
+        api_version="v1",
+        kind="Service",
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            annotations={"service.alpha.kubernetes.io/app-protocols": '{"grpc":"HTTP2"}'},
+        ),
+        spec=k8s_client.V1ServiceSpec(
+            selector={"app": name},
+            ports=[k8s_client.V1ServicePort(protocol="TCP", port=8080, target_port=8080)],
+            type="ClusterIP",
+        ),
+    )
+    api = k8s_client.CoreV1Api()
+    try:
+        api.create_namespaced_service(namespace=namespace, body=svc)
+    except k8s_client.exceptions.ApiException as exc:
+        if exc.status != 409:
+            raise
     return name
 
 
 def _delete_service_component(name: str) -> str:
-    delete_service(name)
+    from kubernetes import client as k8s_client
+    from kubernetes import config as k8s_config
+    try:
+        k8s_config.load_incluster_config()
+    except Exception:  # pylint: disable=broad-except
+        k8s_config.load_kube_config()
+    try:
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:
+            namespace = f.read().strip()
+    except FileNotFoundError:
+        namespace = "default"
+    api = k8s_client.CoreV1Api()
+    try:
+        api.delete_namespaced_service(name=name, namespace=namespace)
+    except k8s_client.exceptions.ApiException as exc:
+        if exc.status != 404:
+            raise
     return name
+
+
+_create_service_component.__annotations__ = {"name": str, "return": str}
+_delete_service_component.__annotations__ = {"name": str, "return": str}
 
 
 # ================================================================

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -405,10 +405,17 @@ def _create_service_component(name: str) -> str:
     except k8s_config.config_exception.ConfigException:
         k8s_config.load_kube_config()
     try:
-        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:
+        with open(
+            "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+            encoding="utf-8",
+        ) as f:
             namespace = f.read().strip()
     except FileNotFoundError:
-        namespace = "default"
+        try:
+            _, ctx = k8s_config.list_kube_config_contexts()
+            namespace = ctx["context"].get("namespace", "default")
+        except k8s_config.config_exception.ConfigException:
+            namespace = "default"
     svc = k8s_client.V1Service(
         api_version="v1",
         kind="Service",
@@ -440,10 +447,17 @@ def _delete_service_component(name: str) -> str:
     except k8s_config.config_exception.ConfigException:
         k8s_config.load_kube_config()
     try:
-        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:
+        with open(
+            "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+            encoding="utf-8",
+        ) as f:
             namespace = f.read().strip()
     except FileNotFoundError:
-        namespace = "default"
+        try:
+            _, ctx = k8s_config.list_kube_config_contexts()
+            namespace = ctx["context"].get("namespace", "default")
+        except k8s_config.config_exception.ConfigException:
+            namespace = "default"
     api = k8s_client.CoreV1Api()
     try:
         api.delete_namespaced_service(name=name, namespace=namespace)

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -402,7 +402,7 @@ def _create_service_component(name: str) -> str:
 
     try:
         k8s_config.load_incluster_config()
-    except Exception:  # pylint: disable=broad-except
+    except k8s_config.config_exception.ConfigException:
         k8s_config.load_kube_config()
     try:
         with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", encoding="utf-8") as f:

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -240,3 +240,84 @@ def test_valid_param_names():
     names = orchestration._valid_param_names(sig)
 
     assert names == ["a", "b", "c"]
+
+
+# ============================================================
+# _create_service_component / _delete_service_component
+# ============================================================
+
+
+class _MockApiException(Exception):
+    """Lightweight stand-in for kubernetes.client.exceptions.ApiException."""
+
+    def __init__(self, status):
+        self.status = status
+
+
+def _patch_k8s(mocker, *, api_mock):
+    """Patch kubernetes imports used by the self-contained KFP components."""
+    mocker.patch("kubernetes.config.load_incluster_config")
+    mocker.patch("kubernetes.client.CoreV1Api", return_value=api_mock)
+    mocker.patch("kubernetes.client.V1Service")
+    mocker.patch("kubernetes.client.V1ObjectMeta")
+    mocker.patch("kubernetes.client.V1ServiceSpec")
+    mocker.patch("kubernetes.client.V1ServicePort")
+    mocker.patch("kubernetes.client.exceptions.ApiException", _MockApiException)
+
+
+def test_create_service_component_success(mocker):
+    mock_api = mocker.Mock()
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    result = orchestration._create_service_component("flserver-abc")
+
+    assert result == "flserver-abc"
+    mock_api.create_namespaced_service.assert_called_once()
+
+
+def test_create_service_component_409_swallowed(mocker):
+    mock_api = mocker.Mock()
+    mock_api.create_namespaced_service.side_effect = _MockApiException(409)
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    result = orchestration._create_service_component("flserver-abc")
+
+    assert result == "flserver-abc"
+
+
+def test_create_service_component_non_409_raises(mocker):
+    mock_api = mocker.Mock()
+    mock_api.create_namespaced_service.side_effect = _MockApiException(403)
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    with pytest.raises(_MockApiException):
+        orchestration._create_service_component("flserver-abc")
+
+
+def test_delete_service_component_success(mocker):
+    mock_api = mocker.Mock()
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    result = orchestration._delete_service_component("flserver-abc")
+
+    assert result == "flserver-abc"
+    mock_api.delete_namespaced_service.assert_called_once()
+
+
+def test_delete_service_component_404_swallowed(mocker):
+    mock_api = mocker.Mock()
+    mock_api.delete_namespaced_service.side_effect = _MockApiException(404)
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    result = orchestration._delete_service_component("flserver-abc")
+
+    assert result == "flserver-abc"
+
+
+def test_delete_service_component_non_404_raises(mocker):
+    mock_api = mocker.Mock()
+    mock_api.delete_namespaced_service.side_effect = _MockApiException(403)
+    _patch_k8s(mocker, api_mock=mock_api)
+
+    with pytest.raises(_MockApiException):
+        orchestration._delete_service_component("flserver-abc")


### PR DESCRIPTION
Fix: Make _create_service_component and _delete_service_component self-contained KFP components

Problem

In release/v3.0.0b8 branch, both functions had the following:

def _create_service_component(name: str) -> str:
    create_service(name)
    return name

def _delete_service_component(name: str) -> str:
    delete_service(name)
    return name
KFP's create_component_from_func serializes only the function body into a standalone Python script that runs inside the container. Module-level helpers like create_service and delete_service are never part of that script, so the pod failed immediately with:

errors in logs :cog.log
NameError: name 'create_service' is not defined
exit code: 1
open /tmp/outputs/Output/data: no such file or directory
because the output file was never written.

Fix
Made both functions fully self-contained — all imports and logic live inside the function body so they survive being serialized into a blank script. Uses the kubernetes package directly with absolute imports (relative imports like from ...utils.common don't work outside the package context). Also handles idempotency: 409 (service already exists) is treated as success in create, 404 (not found) is treated as success in delete.

Added the __annotations__ patch to fix the type name str is different from expected: String KFP type-check warning caused by from __future__ import annotations stringizing the type annotations.