### PR TITLE
Release/v3.0.0b10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,9 @@ jobs:
           context: ./docker_image_variants/lite
           platforms: linux/amd64
           push: true
-          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          tags: |
+            hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}
+            hiroregistry/cogflow_lite:${{ steps.tags.outputs.channel == 'stable' && 'latest' || format('latest-{0}', steps.tags.outputs.channel) }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
           cache-from: type=gha,scope=lite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,11 +154,19 @@ jobs:
             # is the slow step) and matches the documented arch policy.
             PLATFORMS="linux/amd64"
           fi
+          LITE_REGISTRY="hiroregistry/cogflow_lite"
+          if [[ "$CHANNEL" == "stable" ]]; then
+            LITE_TAGS="$LITE_REGISTRY:$VERSION,$LITE_REGISTRY:latest"
+          else
+            LITE_TAGS="$LITE_REGISTRY:$VERSION,$LITE_REGISTRY:latest-$CHANNEL"
+          fi
           {
             echo "tags=$TAGS"
+            echo "lite_tags=$LITE_TAGS"
             echo "channel=$CHANNEL"
             echo "platforms=$PLATFORMS"
             echo "version_tag=$REGISTRY:$VERSION"
+            echo "lite_version_tag=$LITE_REGISTRY:$VERSION"
           } >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL"
           echo "Tags: $TAGS"
@@ -271,20 +279,13 @@ jobs:
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
 
-      - name: Prepare cogflow_lite wheel directory
-        run: mkdir -p docker_image_variants/lite/dist
-
-      - name: Copy cogflow wheel to cogflow_lite build context (tag-push path)
-        if: github.event_name == 'push'
-        run: cp docker_image_variants/latest/dist/*.whl docker_image_variants/lite/dist/
-
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/lite
-          platforms: linux/amd64
+          platforms: ${{ steps.tags.outputs.platforms }}
           push: true
-          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          tags: ${{ steps.tags.outputs.lite_tags }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
           cache-from: type=gha
@@ -292,6 +293,6 @@ jobs:
 
       - name: Smoke test cogflow_lite image
         run: |
-          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
-          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
+          docker pull "${{ steps.tags.outputs.lite_version_tag }}"
+          docker run --rm "${{ steps.tags.outputs.lite_version_tag }}" \
             python3 -c "import cogflow; print('cogflow', cogflow.__version__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,23 +189,18 @@ jobs:
           name: cogflow-${{ needs.build.outputs.version }}
           path: ./docker_image_variants/latest/dist/
 
-      - name: Set up Python (dispatch-only, for PyPI wait)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Set up Python (for PyPI wait)
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
-      - name: Wait for PyPI simple index (dispatch-only)
-        # Tag-push doesn't hit PyPI at all during the image build — the
-        # wheel comes from the artifact downloaded above — so the wait
-        # is only needed on workflow_dispatch, where we rebuild the
-        # image for a version that's already published on PyPI.
-        # ``workflow_dispatch`` targets stable/long-published versions,
-        # so propagation is usually a non-issue, but keep the poll as
-        # a safety net in case someone triggers it seconds after upload.
-        if: github.event_name == 'workflow_dispatch'
+      - name: Wait for PyPI simple index
+        # On workflow_dispatch the main image installs from PyPI (no local
+        # wheel artifact). On tag-push the main image uses the local wheel,
+        # but cogflow_lite always installs from PyPI, so both triggers need
+        # this wait. A single step covers both paths.
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
         run: |
           python3 - <<'PY'
           import os, sys, time
@@ -278,43 +273,6 @@ jobs:
           docker pull "${{ steps.tags.outputs.version_tag }}"
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
-
-      - name: Wait for PyPI simple index before cogflow_lite build (tag-push only)
-        # On tag-push the main image installs from a local wheel artifact so
-        # it never touches PyPI. The lite image has no local wheel and always
-        # runs pip install cogflow==$VERSION, so we must wait here too.
-        # On workflow_dispatch the version is already long-published; the
-        # existing wait above (dispatch-only) covers that path.
-        if: github.event_name == 'push'
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          python3 - <<'PY'
-          import os, sys, time
-          from urllib.request import urlopen
-          from urllib.error import URLError
-
-          version = os.environ["VERSION"]
-          url = "https://pypi.org/simple/cogflow/"
-          needles = (f"cogflow-{version}-", f"cogflow-{version}.")
-
-          attempts = 12  # ~4 minutes total
-          for attempt in range(1, attempts + 1):
-              try:
-                  with urlopen(url, timeout=10) as resp:
-                      html = resp.read().decode("utf-8", errors="replace")
-                  if any(n in html for n in needles):
-                      print(f"cogflow=={version} visible on simple index")
-                      sys.exit(0)
-              except URLError as exc:
-                  print(f"simple-index request failed ({attempt}/{attempts}): {exc}")
-              print(f"Waiting for simple index to list {version} ({attempt}/{attempts})...")
-              if attempt < attempts:
-                  time.sleep(20)
-
-          print(f"::error::cogflow=={version} not on simple index after ~4 min")
-          sys.exit(1)
-          PY
 
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,6 @@ jobs:
 
   docker-publish:
     needs: [build, publish-pypi]
-    # Two triggers, both land here:
-    #   1. Tag push  — `build` and `publish-pypi` ran; gate on pypi success.
-    #   2. workflow_dispatch (manual rebuild of an already-published version)
-    #      — `build` and `publish-pypi` were skipped because their `if` gates
-    #      require `event_name == 'push'`, so the default needs-success gate
-    #      would skip this job too. `always()` overrides that; the inner
-    #      condition then chooses the mode.
     if: >-
       always() && (
         github.event_name == 'workflow_dispatch'
@@ -142,43 +135,21 @@ jobs:
           fi
           if [[ "$CHANNEL" == "stable" ]]; then
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest"
-            # Stable channel is consumer-facing (main branch images,
-            # downstream charm releases, external users) and must work
-            # on arm64 too.
             PLATFORMS="linux/amd64,linux/arm64"
           else
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest-$CHANNEL"
-            # Pre-release channels (beta/rc/alpha) are consumed only by
-            # our own dev-cluster CD which runs on amd64 nodes. Skipping
-            # the arm64 build saves ~8–10 min per release (QEMU emulation
-            # is the slow step) and matches the documented arch policy.
             PLATFORMS="linux/amd64"
-          fi
-          LITE_REGISTRY="hiroregistry/cogflow_lite"
-          if [[ "$CHANNEL" == "stable" ]]; then
-            LITE_TAGS="$LITE_REGISTRY:$VERSION,$LITE_REGISTRY:latest"
-          else
-            LITE_TAGS="$LITE_REGISTRY:$VERSION,$LITE_REGISTRY:latest-$CHANNEL"
           fi
           {
             echo "tags=$TAGS"
-            echo "lite_tags=$LITE_TAGS"
             echo "channel=$CHANNEL"
             echo "platforms=$PLATFORMS"
             echo "version_tag=$REGISTRY:$VERSION"
-            echo "lite_version_tag=$LITE_REGISTRY:$VERSION"
           } >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL"
           echo "Tags: $TAGS"
           echo "Platforms: $PLATFORMS"
 
-      # Build context always has a ``dist/`` directory. On the tag-push
-      # path we populate it with the wheel that ``build`` already uploaded
-      # as an artifact — no PyPI round-trip, no CDN race. On the
-      # workflow_dispatch path the ``build`` job was skipped (different
-      # ``if`` gate) so no artifact exists; the Dockerfile falls back to
-      # ``pip install cogflow==$VERSION`` from PyPI and the wait step
-      # below handles any lingering propagation.
       - name: Prepare wheel directory in build context
         run: mkdir -p docker_image_variants/latest/dist
 
@@ -189,18 +160,16 @@ jobs:
           name: cogflow-${{ needs.build.outputs.version }}
           path: ./docker_image_variants/latest/dist/
 
-      - name: Set up Python (for PyPI wait)
+      - name: Set up Python (dispatch-only, for PyPI wait)
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
-      - name: Wait for PyPI simple index
-        # On workflow_dispatch the main image installs from PyPI (no local
-        # wheel artifact). On tag-push the main image uses the local wheel,
-        # but cogflow_lite always installs from PyPI, so both triggers need
-        # this wait. A single step covers both paths.
+      - name: Wait for PyPI simple index (dispatch-only)
+        if: github.event_name == 'workflow_dispatch'
         env:
-          VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           python3 - <<'PY'
           import os, sys, time
@@ -211,8 +180,7 @@ jobs:
           url = "https://pypi.org/simple/cogflow/"
           needles = (f"cogflow-{version}-", f"cogflow-{version}.")
 
-          attempts = 12  # ~4 minutes total
-          for attempt in range(1, attempts + 1):
+          for attempt in range(1, 13):
               try:
                   with urlopen(url, timeout=10) as resp:
                       html = resp.read().decode("utf-8", errors="replace")
@@ -220,20 +188,16 @@ jobs:
                       print(f"cogflow=={version} visible on simple index")
                       sys.exit(0)
               except URLError as exc:
-                  print(f"simple-index request failed ({attempt}/{attempts}): {exc}")
-              print(f"Waiting for simple index to list {version} ({attempt}/{attempts})...")
-              if attempt < attempts:
+                  print(f"simple-index request failed ({attempt}/12): {exc}")
+              print(f"Waiting for {version} on simple index ({attempt}/12)...")
+              if attempt < 12:
                   time.sleep(20)
 
-          print(f"::error::cogflow=={version} not on simple index after ~4 min")
+          print(f"::error::cogflow=={version} not found on simple index")
           sys.exit(1)
           PY
 
       - name: Set up QEMU
-        # Only needed when the platform list includes a non-native arch
-        # (runners are amd64, so arm64 is what actually needs emulation).
-        # Drive `with.platforms` from the same step so the QEMU and build
-        # platform lists can't drift if we later add/remove archs.
         if: contains(steps.tags.outputs.platforms, 'arm64')
         uses: docker/setup-qemu-action@v3
         with:
@@ -252,19 +216,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/latest
-          # Platforms come from the tags step so stable builds multi-arch
-          # and pre-release builds amd64-only. Even for amd64-only we keep
-          # the explicit platform list — build-push-action@v6 otherwise
-          # wraps the output in a manifest index that downstream
-          # `--platform linux/arm64` consumers reject outright.
           platforms: ${{ steps.tags.outputs.platforms }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
-          # Buildx GitHub-Actions cache: layer reuse across runs when
-          # only requirements.txt / cogflow version changes. `mode=max`
-          # includes intermediate layers so later runs benefit too.
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -274,13 +230,50 @@ jobs:
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
 
+      - name: Set up Python (tag-push, for cogflow_lite PyPI wait)
+        if: github.event_name == 'push'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Wait for PyPI simple index (tag-push, for cogflow_lite)
+        if: github.event_name == 'push'
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import os, sys, time
+          from urllib.request import urlopen
+          from urllib.error import URLError
+
+          version = os.environ["VERSION"]
+          url = "https://pypi.org/simple/cogflow/"
+          needles = (f"cogflow-{version}-", f"cogflow-{version}.")
+
+          for attempt in range(1, 19):
+              try:
+                  with urlopen(url, timeout=10) as resp:
+                      html = resp.read().decode("utf-8", errors="replace")
+                  if any(n in html for n in needles):
+                      print(f"cogflow=={version} visible on simple index")
+                      sys.exit(0)
+              except URLError as exc:
+                  print(f"simple-index request failed ({attempt}/18): {exc}")
+              print(f"Waiting for {version} on simple index ({attempt}/18)...")
+              if attempt < 18:
+                  time.sleep(20)
+
+          print(f"::error::cogflow=={version} not found on simple index")
+          sys.exit(1)
+          PY
+
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/lite
-          platforms: ${{ steps.tags.outputs.platforms }}
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.tags.outputs.lite_tags }}
+          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
           cache-from: type=gha
@@ -288,6 +281,6 @@ jobs:
 
       - name: Smoke test cogflow_lite image
         run: |
-          docker pull "${{ steps.tags.outputs.lite_version_tag }}"
-          docker run --rm "${{ steps.tags.outputs.lite_version_tag }}" \
+          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
+          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
             python3 -c "import cogflow; print('cogflow', cogflow.__version__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,43 @@ jobs:
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
 
+      - name: Wait for PyPI simple index before cogflow_lite build (tag-push only)
+        # On tag-push the main image installs from a local wheel artifact so
+        # it never touches PyPI. The lite image has no local wheel and always
+        # runs pip install cogflow==$VERSION, so we must wait here too.
+        # On workflow_dispatch the version is already long-published; the
+        # existing wait above (dispatch-only) covers that path.
+        if: github.event_name == 'push'
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import os, sys, time
+          from urllib.request import urlopen
+          from urllib.error import URLError
+
+          version = os.environ["VERSION"]
+          url = "https://pypi.org/simple/cogflow/"
+          needles = (f"cogflow-{version}-", f"cogflow-{version}.")
+
+          attempts = 12  # ~4 minutes total
+          for attempt in range(1, attempts + 1):
+              try:
+                  with urlopen(url, timeout=10) as resp:
+                      html = resp.read().decode("utf-8", errors="replace")
+                  if any(n in html for n in needles):
+                      print(f"cogflow=={version} visible on simple index")
+                      sys.exit(0)
+              except URLError as exc:
+                  print(f"simple-index request failed ({attempt}/{attempts}): {exc}")
+              print(f"Waiting for simple index to list {version} ({attempt}/{attempts})...")
+              if attempt < attempts:
+                  time.sleep(20)
+
+          print(f"::error::cogflow=={version} not on simple index after ~4 min")
+          sys.exit(1)
+          PY
+
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,10 +270,9 @@ jobs:
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:
-          context: ./docker_image_variants/lite
-          platforms: linux/amd64
-          push: true
-          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          tags: |
+            hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}
+            hiroregistry/cogflow_lite:${{ steps.tags.outputs.channel == 'stable' && 'latest' || format('latest-{0}', steps.tags.outputs.channel) }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,3 +270,53 @@ jobs:
           docker pull "${{ steps.tags.outputs.version_tag }}"
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
+
+      - name: Prepare cogflow_lite wheel directory
+        run: mkdir -p docker_image_variants/lite/dist
+
+      - name: Copy cogflow wheel to cogflow_lite build context (tag-push path)
+        if: github.event_name == 'push'
+        run: cp docker_image_variants/latest/dist/*.whl docker_image_variants/lite/dist/
+
+      - name: Build and push cogflow_lite image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker_image_variants/lite
+          platforms: linux/amd64
+          push: true
+          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          build-args: |
+            COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test cogflow_lite image
+        run: |
+          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
+          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
+            python3 -c "import cogflow; print('cogflow', cogflow.__version__)"
+
+      - name: Prepare cogflow_lite wheel directory
+        run: mkdir -p docker_image_variants/lite/dist
+
+      - name: Copy cogflow wheel to cogflow_lite build context (tag-push path)
+        if: github.event_name == 'push'
+        run: cp docker_image_variants/latest/dist/*.whl docker_image_variants/lite/dist/
+
+      - name: Build and push cogflow_lite image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker_image_variants/lite
+          platforms: linux/amd64
+          push: true
+          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          build-args: |
+            COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test cogflow_lite image
+        run: |
+          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
+          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
+            python3 -c "import cogflow; print('cogflow', cogflow.__version__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,13 @@ jobs:
 
   docker-publish:
     needs: [build, publish-pypi]
+    # Two triggers, both land here:
+    #   1. Tag push  — `build` and `publish-pypi` ran; gate on pypi success.
+    #   2. workflow_dispatch (manual rebuild of an already-published version)
+    #      — `build` and `publish-pypi` were skipped because their `if` gates
+    #      require `event_name == 'push'`, so the default needs-success gate
+    #      would skip this job too. `always()` overrides that; the inner
+    #      condition then chooses the mode.
     if: >-
       always() && (
         github.event_name == 'workflow_dispatch'
@@ -135,9 +142,16 @@ jobs:
           fi
           if [[ "$CHANNEL" == "stable" ]]; then
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest"
+            # Stable channel is consumer-facing (main branch images,
+            # downstream charm releases, external users) and must work
+            # on arm64 too.
             PLATFORMS="linux/amd64,linux/arm64"
           else
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest-$CHANNEL"
+            # Pre-release channels (beta/rc/alpha) are consumed only by
+            # our own dev-cluster CD which runs on amd64 nodes. Skipping
+            # the arm64 build saves ~8–10 min per release (QEMU emulation
+            # is the slow step) and matches the documented arch policy.
             PLATFORMS="linux/amd64"
           fi
           {
@@ -150,6 +164,13 @@ jobs:
           echo "Tags: $TAGS"
           echo "Platforms: $PLATFORMS"
 
+      # Build context always has a ``dist/`` directory. On the tag-push
+      # path we populate it with the wheel that ``build`` already uploaded
+      # as an artifact — no PyPI round-trip, no CDN race. On the
+      # workflow_dispatch path the ``build`` job was skipped (different
+      # ``if`` gate) so no artifact exists; the Dockerfile falls back to
+      # ``pip install cogflow==$VERSION`` from PyPI and the wait step
+      # below handles any lingering propagation.
       - name: Prepare wheel directory in build context
         run: mkdir -p docker_image_variants/latest/dist
 
@@ -160,12 +181,13 @@ jobs:
           name: cogflow-${{ needs.build.outputs.version }}
           path: ./docker_image_variants/latest/dist/
 
-      - name: Set up Python (dispatch-only, for PyPI wait)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-
+      # Tag-push doesn't hit PyPI during the main image build — the wheel
+      # comes from the artifact downloaded above — so this wait is only
+      # needed on workflow_dispatch, where we rebuild the image for a
+      # version installed from PyPI. Dispatch targets stable/long-published
+      # versions, so propagation is usually a non-issue, but keep the poll
+      # as a safety net in case someone triggers it seconds after upload.
+      # (Runs on the runner's system python3 — stdlib only, no setup-python.)
       - name: Wait for PyPI simple index (dispatch-only)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -198,6 +220,10 @@ jobs:
           PY
 
       - name: Set up QEMU
+        # Only needed when the platform list includes a non-native arch
+        # (runners are amd64, so arm64 is what actually needs emulation).
+        # Drive `with.platforms` from the same step so the QEMU and build
+        # platform lists can't drift if we later add/remove archs.
         if: contains(steps.tags.outputs.platforms, 'arm64')
         uses: docker/setup-qemu-action@v3
         with:
@@ -216,13 +242,21 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/latest
+          # Platforms come from the tags step so stable builds multi-arch
+          # and pre-release builds amd64-only. Even for amd64-only we keep
+          # the explicit platform list — build-push-action@v6 otherwise
+          # wraps the output in a manifest index that downstream
+          # `--platform linux/arm64` consumers reject outright.
           platforms: ${{ steps.tags.outputs.platforms }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Buildx GitHub-Actions cache: layer reuse across runs when
+          # only requirements.txt / cogflow version changes. `mode=max`
+          # includes intermediate layers so later runs benefit too.
+          cache-from: type=gha,scope=latest
+          cache-to: type=gha,mode=max,scope=latest
 
       - name: Smoke test pushed image
         run: |
@@ -230,12 +264,11 @@ jobs:
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
 
-      - name: Set up Python (tag-push, for cogflow_lite PyPI wait)
-        if: github.event_name == 'push'
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-
+      # On tag-push the main image installed from the wheel artifact, so
+      # this is the first PyPI round-trip of the run — cogflow_lite installs
+      # cogflow==$VERSION straight from PyPI. Wait longer than the dispatch
+      # path (18 × 20s ≈ 6 min) because the wheel was published seconds ago
+      # by publish-pypi and still needs to propagate to the simple index.
       - name: Wait for PyPI simple index (tag-push, for cogflow_lite)
         if: github.event_name == 'push'
         env:
@@ -267,17 +300,25 @@ jobs:
           sys.exit(1)
           PY
 
+      # cogflow_lite is built after the main image is already pushed and
+      # smoke-tested. A failure here (PyPI timeout, arm64 build) therefore
+      # leaves the main image published but lite un-pushed — re-run the job
+      # once the cause is resolved to reconcile. Platforms track the main
+      # image: amd64 for pre-release channels (dev-cluster CD is amd64) and
+      # amd64+arm64 for stable, so lite always runs on the dev cluster.
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/lite
-          platforms: linux/amd64
+          platforms: ${{ steps.tags.outputs.platforms }}
           push: true
-          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
+          tags: |
+            hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}
+            hiroregistry/cogflow_lite:${{ steps.tags.outputs.channel == 'stable' && 'latest' || format('latest-{0}', steps.tags.outputs.channel) }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=lite
+          cache-to: type=gha,mode=max,scope=lite
 
       - name: Smoke test cogflow_lite image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,28 +295,3 @@ jobs:
           docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
           docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
             python3 -c "import cogflow; print('cogflow', cogflow.__version__)"
-
-      - name: Prepare cogflow_lite wheel directory
-        run: mkdir -p docker_image_variants/lite/dist
-
-      - name: Copy cogflow wheel to cogflow_lite build context (tag-push path)
-        if: github.event_name == 'push'
-        run: cp docker_image_variants/latest/dist/*.whl docker_image_variants/lite/dist/
-
-      - name: Build and push cogflow_lite image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./docker_image_variants/lite
-          platforms: linux/amd64
-          push: true
-          tags: hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }},hiroregistry/cogflow_lite:latest
-          build-args: |
-            COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test cogflow_lite image
-        run: |
-          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
-          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
-            python3 -c "import cogflow; print('cogflow', cogflow.__version__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,11 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version || needs.build.outputs.version }}
         run: |
-          REGISTRY="hiroregistry/cogflow"
+          # Single source for the registry namespace so a rename touches
+          # one line and both images stay in sync.
+          REGISTRY_NS="hiroregistry"
+          REGISTRY="$REGISTRY_NS/cogflow"
+          LITE_REGISTRY="$REGISTRY_NS/cogflow_lite"
           if [[ "$VERSION" == *b* ]]; then
             CHANNEL="beta"
           elif [[ "$VERSION" == *rc* ]]; then
@@ -150,6 +154,7 @@ jobs:
             echo "channel=$CHANNEL"
             echo "platforms=$PLATFORMS"
             echo "version_tag=$REGISTRY:$VERSION"
+            echo "lite_registry=$LITE_REGISTRY"
           } >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL"
           echo "Tags: $TAGS"
@@ -284,8 +289,8 @@ jobs:
           platforms: ${{ steps.tags.outputs.platforms }}
           push: true
           tags: |
-            hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}
-            hiroregistry/cogflow_lite:${{ steps.tags.outputs.channel == 'stable' && 'latest' || format('latest-{0}', steps.tags.outputs.channel) }}
+            ${{ steps.tags.outputs.lite_registry }}:${{ github.event.inputs.version || needs.build.outputs.version }}
+            ${{ steps.tags.outputs.lite_registry }}:${{ steps.tags.outputs.channel == 'stable' && 'latest' || format('latest-{0}', steps.tags.outputs.channel) }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
           cache-from: type=gha,scope=lite
@@ -293,6 +298,6 @@ jobs:
 
       - name: Smoke test cogflow_lite image
         run: |
-          docker pull "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}"
-          docker run --rm "hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}" \
+          docker pull "${{ steps.tags.outputs.lite_registry }}:${{ github.event.inputs.version || needs.build.outputs.version }}"
+          docker run --rm "${{ steps.tags.outputs.lite_registry }}:${{ github.event.inputs.version || needs.build.outputs.version }}" \
             python3 -c "import cogflow; print('cogflow', cogflow.__version__)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/lite
-          platforms: linux/amd64
+          platforms: ${{ steps.tags.outputs.platforms }}
           push: true
           tags: |
             hiroregistry/cogflow_lite:${{ github.event.inputs.version || needs.build.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,9 @@ jobs:
 
   docker-publish:
     needs: [build, publish-pypi]
-    # Two triggers, both land here:
-    #   1. Tag push  — `build` and `publish-pypi` ran; gate on pypi success.
-    #   2. workflow_dispatch (manual rebuild of an already-published version)
-    #      — `build` and `publish-pypi` were skipped because their `if` gates
-    #      require `event_name == 'push'`, so the default needs-success gate
-    #      would skip this job too. `always()` overrides that; the inner
-    #      condition then chooses the mode.
+    # Runs on tag-push (gated on publish-pypi) and on workflow_dispatch (manual
+    # rebuild, where build/publish-pypi are skipped). `always()` + the inner
+    # condition pick the mode. See docker_image_variants/readme.md → Triggers.
     if: >-
       always() && (
         github.event_name == 'workflow_dispatch'
@@ -140,18 +136,13 @@ jobs:
           else
             CHANNEL="stable"
           fi
+          # Arch policy (why stable is multi-arch and pre-release amd64-only):
+          # docker_image_variants/readme.md → Architecture policy.
           if [[ "$CHANNEL" == "stable" ]]; then
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest"
-            # Stable channel is consumer-facing (main branch images,
-            # downstream charm releases, external users) and must work
-            # on arm64 too.
             PLATFORMS="linux/amd64,linux/arm64"
           else
             TAGS="$REGISTRY:$VERSION,$REGISTRY:latest-$CHANNEL"
-            # Pre-release channels (beta/rc/alpha) are consumed only by
-            # our own dev-cluster CD which runs on amd64 nodes. Skipping
-            # the arm64 build saves ~8–10 min per release (QEMU emulation
-            # is the slow step) and matches the documented arch policy.
             PLATFORMS="linux/amd64"
           fi
           {
@@ -164,13 +155,9 @@ jobs:
           echo "Tags: $TAGS"
           echo "Platforms: $PLATFORMS"
 
-      # Build context always has a ``dist/`` directory. On the tag-push
-      # path we populate it with the wheel that ``build`` already uploaded
-      # as an artifact — no PyPI round-trip, no CDN race. On the
-      # workflow_dispatch path the ``build`` job was skipped (different
-      # ``if`` gate) so no artifact exists; the Dockerfile falls back to
-      # ``pip install cogflow==$VERSION`` from PyPI and the wait step
-      # below handles any lingering propagation.
+      # tag-push fills dist/ from the build artifact; workflow_dispatch leaves
+      # it empty and the Dockerfile installs from PyPI. See readme.md →
+      # Build strategy: wheel artifact vs PyPI.
       - name: Prepare wheel directory in build context
         run: mkdir -p docker_image_variants/latest/dist
 
@@ -181,13 +168,9 @@ jobs:
           name: cogflow-${{ needs.build.outputs.version }}
           path: ./docker_image_variants/latest/dist/
 
-      # Tag-push doesn't hit PyPI during the main image build — the wheel
-      # comes from the artifact downloaded above — so this wait is only
-      # needed on workflow_dispatch, where we rebuild the image for a
-      # version installed from PyPI. Dispatch targets stable/long-published
-      # versions, so propagation is usually a non-issue, but keep the poll
-      # as a safety net in case someone triggers it seconds after upload.
-      # (Runs on the runner's system python3 — stdlib only, no setup-python.)
+      # Only workflow_dispatch installs the main image from PyPI, so only it
+      # needs this wait (see readme.md → Build strategy). Runs on the runner's
+      # system python3 — stdlib only, no setup-python.
       - name: Wait for PyPI simple index (dispatch-only)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -219,11 +202,9 @@ jobs:
           sys.exit(1)
           PY
 
+      # Only needed for non-native archs (arm64); driven off the same platforms
+      # output so QEMU and build lists can't drift. See readme.md → Arch policy.
       - name: Set up QEMU
-        # Only needed when the platform list includes a non-native arch
-        # (runners are amd64, so arm64 is what actually needs emulation).
-        # Drive `with.platforms` from the same step so the QEMU and build
-        # platform lists can't drift if we later add/remove archs.
         if: contains(steps.tags.outputs.platforms, 'arm64')
         uses: docker/setup-qemu-action@v3
         with:
@@ -242,14 +223,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./docker_image_variants/latest
+          # Explicit even for amd64-only builds (v6 manifest-index quirk).
+          # See readme.md → Architecture policy.
           platforms: ${{ steps.tags.outputs.platforms }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             COGFLOW_VERSION=${{ github.event.inputs.version || needs.build.outputs.version }}
-          # Buildx GitHub-Actions cache: layer reuse across runs when
-          # only requirements.txt / cogflow version changes. `mode=max`
-          # includes intermediate layers so later runs benefit too.
+          # Per-image cache scope (full vs lite); see readme.md → Build cache.
           cache-from: type=gha,scope=latest
           cache-to: type=gha,mode=max,scope=latest
 
@@ -259,11 +240,9 @@ jobs:
           docker run --rm "${{ steps.tags.outputs.version_tag }}" \
             python3 -c "import cogflow, kfp; print('cogflow', cogflow.__version__, 'kfp', kfp.__version__)"
 
-      # On tag-push the main image installed from the wheel artifact, so
-      # this is the first PyPI round-trip of the run — cogflow_lite installs
-      # cogflow==$VERSION straight from PyPI. Wait longer than the dispatch
-      # path (18 × 20s ≈ 6 min) because the wheel was published seconds ago
-      # by publish-pypi and still needs to propagate to the simple index.
+      # cogflow_lite installs cogflow from PyPI, so on tag-push wait for the
+      # just-published wheel to reach the simple index before building lite
+      # (18 × 20s ≈ 6 min). See readme.md → Build strategy.
       - name: Wait for PyPI simple index (tag-push, for cogflow_lite)
         if: github.event_name == 'push'
         env:
@@ -295,12 +274,9 @@ jobs:
           sys.exit(1)
           PY
 
-      # cogflow_lite is built after the main image is already pushed and
-      # smoke-tested. A failure here (PyPI timeout, arm64 build) therefore
-      # leaves the main image published but lite un-pushed — re-run the job
-      # once the cause is resolved to reconcile. Platforms track the main
-      # image: amd64 for pre-release channels (dev-cluster CD is amd64) and
-      # amd64+arm64 for stable, so lite always runs on the dev cluster.
+      # Built after the main image is pushed; a failure here leaves lite
+      # un-pushed (re-run the job to reconcile). Platforms track the main
+      # image. See readme.md → Release ordering caveat / Architecture policy.
       - name: Build and push cogflow_lite image
         uses: docker/build-push-action@v6
         with:

--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -10,7 +10,7 @@ import sys
 
 from ._lazy import _LazyLoader
 
-__version__ = "3.0.0b8"
+__version__ = "3.0.0b9"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/__init__.py
+++ b/cogflow/__init__.py
@@ -10,7 +10,7 @@ import sys
 
 from ._lazy import _LazyLoader
 
-__version__ = "3.0.0b9"
+__version__ = "3.0.0b10"
 
 # Submodules that should be lazily imported when accessed
 _LAZY_SUBMODULES = [

--- a/cogflow/core/pipelines/orchestration.py
+++ b/cogflow/core/pipelines/orchestration.py
@@ -35,10 +35,41 @@ logger = get_logger(__name__)
 # ================================================================
 
 
+# KFP v1 rejects semantically-identical type names (e.g. ``str`` vs ``String``)
+# between cogflow-defined components and user-registered components — a false
+# positive that adds no safety and blocks otherwise-valid pipelines. Disable the
+# check, matching the non-enforcing default frameworks like ZenML ship with.
+#
+# ``kfp.TYPE_CHECK = False`` alone is not enough: ``Compiler.compile`` saves and
+# restores that flag around each compile, forcing ``type_check=True`` back on. So
+# the only reliable switch is to force every ``Compiler.compile`` to skip the
+# check. Applied lazily (when KFP is first loaded) and only once.
+_KFP_TYPE_CHECK_DISABLED = False
+
+
+def _disable_kfp_type_check():
+    """Force KFP's ``Compiler.compile`` to skip type checking (idempotent)."""
+    global _KFP_TYPE_CHECK_DISABLED
+    if _KFP_TYPE_CHECK_DISABLED:
+        return
+    from kfp import compiler
+
+    _original_compile = compiler.Compiler.compile
+
+    def _compile_without_type_check(self, *args, **kwargs):
+        kwargs["type_check"] = False
+        return _original_compile(self, *args, **kwargs)
+
+    compiler.Compiler.compile = _compile_without_type_check
+    _KFP_TYPE_CHECK_DISABLED = True
+
+
 def _load_kfp():
     """Lazy import full KFP; returns (kfp, dsl, ContainerOp)."""
     import kfp
     from kfp import dsl
+
+    _disable_kfp_type_check()
 
     return kfp, dsl
 

--- a/docker_image_variants/readme.md
+++ b/docker_image_variants/readme.md
@@ -54,3 +54,82 @@ docker push hiroregistry/cogflow:1.11.14-lite
 docker push hiroregistry/cogflow:1.11.14-fl
 docker push hiroregistry/cogflow:1.11.14-tensor
 docker push hiroregistry/cogflow:1.11.14-torch
+
+---
+
+## 🚀 Release CI/CD & architecture policy
+
+The `Build and Release` workflow (`.github/workflows/release.yml`) builds and
+publishes the `cogflow` (full) and `cogflow_lite` images in the `docker-publish`
+job. The policy decisions encoded there are documented here so they stay
+discoverable — the workflow comments only point back to this section.
+
+### Triggers
+
+The `docker-publish` job runs in two modes:
+
+- **Tag push (`v*`)** — the `build` and `publish-pypi` jobs run first; the job
+  gates on `publish-pypi` succeeding.
+- **`workflow_dispatch`** — a manual rebuild of a version already on PyPI.
+  `build`/`publish-pypi` are skipped (their `if` requires a push event), so the
+  job uses `always()` plus an inner condition to still run and pick the mode.
+
+### Channel & tags
+
+The channel is derived from the version suffix:
+
+| Version suffix | Channel | Moving tag       |
+|----------------|---------|------------------|
+| `*b*`          | beta    | `latest-beta`    |
+| `*rc*`         | rc      | `latest-rc`      |
+| `*a*`          | alpha   | `latest-alpha`   |
+| (none)         | stable  | `latest`         |
+
+Only **stable** moves the plain `latest` tag; pre-release channels move their
+own `latest-<channel>` tag so a beta never overwrites `latest`.
+
+### Architecture policy
+
+| Channel     | Platforms                 | Why |
+|-------------|---------------------------|-----|
+| stable      | `linux/amd64,linux/arm64` | Consumer-facing (main-branch images, downstream charm releases, external users) — must work on arm64. |
+| pre-release | `linux/amd64`             | Consumed only by our own dev-cluster CD, which runs on amd64 nodes. Skipping arm64 saves ~8–10 min per release (QEMU emulation is the slow step). |
+
+`platforms` is passed **explicitly even for amd64-only builds**: otherwise
+`docker/build-push-action@v6` wraps the output in a manifest index that
+downstream `docker pull --platform linux/arm64` consumers reject outright. QEMU
+is only set up when the platform list contains a non-native arch (arm64), and it
+reads the same `platforms` output so the QEMU and build lists can't drift.
+
+`cogflow_lite` reuses this same platform policy. It has no compiled heavy deps
+(no shap/xgboost/torch), so its arm64 build is cheap, and matching the full
+image's platforms keeps it runnable both on the dev cluster (amd64) and for
+arm64 stable consumers.
+
+### Build strategy: wheel artifact vs PyPI
+
+- **Tag push:** the `build` job uploads the freshly built wheel as an artifact.
+  `docker-publish` downloads it into `docker_image_variants/latest/dist/` and the
+  `latest` Dockerfile installs from that local wheel — no PyPI round-trip, so the
+  image can't race CDN propagation of a just-uploaded version.
+- **`workflow_dispatch`:** no artifact exists (the `build` job was skipped), so
+  `dist/` is left empty and the Dockerfile falls back to
+  `pip install cogflow==$VERSION` from PyPI. A poll of the PyPI simple index runs
+  first as a safety net for propagation lag.
+- **`cogflow_lite`:** always installs `cogflow` from PyPI (its Dockerfile has no
+  wheel bind-mount). On tag-push it therefore needs its own simple-index wait
+  before building — the wheel was published seconds earlier by `publish-pypi`. On
+  `workflow_dispatch` the earlier dispatch wait already covers it.
+
+### Build cache
+
+Each image uses its own GitHub Actions cache scope (`scope=latest` for the full
+image, `scope=lite` for lite). They have different Dockerfiles, so sharing a
+scope would make them evict each other's layers.
+
+### Release ordering caveat
+
+`cogflow_lite` is built after the full image is already pushed and smoke-tested.
+A failure in the lite build (PyPI timeout, arm64 build error) therefore leaves
+the full image published but lite un-pushed. Re-run the `docker-publish` job once
+the cause is resolved to reconcile.


### PR DESCRIPTION

KFP v1's type checker compares type *names* and rejects `str` vs `String`, even though
they're the same text type. It fails at compile time, before anything runs.
## Fix
Disable KFP's `Compiler.compile` type check inside cogflow (when KFP is lazily loaded).
Type mismatches now log a warning instead of failing.
Change `__version__` to `3.0.0b10`.